### PR TITLE
Fix the config.inp generation with 2 steps in AC and Automake

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,3 +20,14 @@ pm_shaders__DATA = src/libprojectM/Renderer/blur.cg \
 install-data-local:
 	test -z $(pkgdatadir) || $(MKDIR_P) $(pm_presets_dir)
 	find "$(PRESETSDIR)" -type f -exec $(INSTALL_DATA) {} $(pm_presets_dir) \;
+
+# from https://stackoverflow.com/questions/30897170/ac-subst-does-not-expand-variable answer: https://stackoverflow.com/a/30960268
+# ptomato https://stackoverflow.com/users/172999/ptomato 
+
+src/libprojectM/config.inp: src/libprojectM/config.inp.in Makefile
+	$(AM_V_GEN)rm -f $@ $@.tmp && \
+	$(SED) -e "s,%datadir%,$(datadir),"g  $< >$@.tmp && \
+	chmod a-w $@.tmp && \
+	mv $@.tmp $@
+
+CLEANFILES += src/libprojectM/config.inp

--- a/configure.ac
+++ b/configure.ac
@@ -32,8 +32,14 @@ AC_CONFIG_FILES([
   src/libprojectM/MilkdropPresetFactory/Makefile
   src/projectM-sdl/Makefile
 ])
-dnl FIXME
-AC_CONFIG_FILES([src/libprojectM/config.inp], [sed -i -e"s/\${prefix}/$prefix/" src/libprojectM/config.inp])
+
+dnl from https://stackoverflow.com/questions/30897170/ac-subst-does-not-expand-variable answer: https://stackoverflow.com/a/30960268
+dnl ptomato https://stackoverflow.com/users/172999/ptomato 
+
+AC_SUBST([PACKAGE])
+AC_PROG_SED
+AC_CONFIG_FILES([src/libprojectM/config.inp.in])
+
 
 AC_PREFIX_DEFAULT([/usr/local])
 

--- a/src/libprojectM/config.inp.in.in
+++ b/src/libprojectM/config.inp.in.in
@@ -16,6 +16,6 @@ Easter Egg Parameter = 1
 Hard Cut Sensitivity = 10       # Lower to make hard cuts more frequent
 Aspect Correction = true	# Custom Shape Aspect Correction
 
-Preset Path = @datarootdir@/presets # preset location
+Preset Path = %datadir%/@PACKAGE@/presets # preset location
 Title Font = Vera.ttf
 Menu Font = VeraMono.ttf


### PR DESCRIPTION
Try to fix the config.inp file problem with both autoconf (configure and sed) and then a second build time stage with automake. config.inp.in becomes config.inp.in.in which configure builds as config.inp.in which automake uses to generate the actual config file.