### PR TITLE
Fix automake cohabitation with qt

### DIFF
--- a/src/projectM-pulseaudio/Makefile.am
+++ b/src/projectM-pulseaudio/Makefile.am
@@ -33,11 +33,15 @@ AM_CFLAGS = ${my_CFLAGS} \
 bin_PROGRAMS = projectM-pulseaudio
 
 projectM_pulseaudio_SOURCES = \
-	$(projectM_pulseaudio_moc_sources) \
 	qprojectM-pulseaudio.cpp \
 	QPulseAudioDeviceChooser.cpp \
 	QPulseAudioDeviceModel.cpp \
-	QPulseAudioThread.cpp
+	QPulseAudioThread.cpp \
+	PulseDeviceChooserDialog.ui \
+	$(projectM_pulseaudio_qtheaders)
+
+nodist_projectM_pulseaudio_SOURCES = \
+	$(nodist_projectM_pulseaudio_moc_sources)
 
 projectM_pulseaudio_LDADD = \
 	${QT_LIBS} \
@@ -54,7 +58,7 @@ BUILT_SOURCES =               \
 
 CLEANFILES = \
 	${BUILT_SOURCES} \
-	${projectM_pulseaudio_moc_sources}
+	${nodist_projectM_pulseaudio_moc_sources}
 
 desktopdir = $(datadir)/applications
 dist_desktop_DATA = projectM-pulseaudio.desktop

--- a/src/projectM-qt/Makefile.am
+++ b/src/projectM-qt/Makefile.am
@@ -38,18 +38,25 @@ BUILT_SOURCES =               \
 noinst_LIBRARIES = libprojectM_qt.a
 
 libprojectM_qt_a_SOURCES = \
-	$(projectM_qt_moc_sources) \
 	qprojectm_mainwindow.cpp \
 	configfile.hpp configfile.cpp \
 	qplaylistfiledialog.cpp \
 	qplaylistmodel.cpp \
 	qprojectmconfigdialog.cpp \
 	qpresettextedit.cpp \
-	qpreseteditordialog.cpp
+	qpreseteditordialog.cpp \
+	qprojectm_mainwindow.ui \
+	qpreseteditordialog.ui \
+	qprojectmconfigdialog.ui \
+	$(projectM_qt_qtheaders) \
+	qxmlplaylisthandler.hpp \
+	nullable.hpp \
+	application.qrc \
+	images/*
 
 nodist_libprojectM_qt_a_SOURCES = \
 	application_qrc.cpp \
-	$(test_moc_sources)
+	$(nodist_projectM_qt_moc_sources)
 
 AM_CPPFLAGS = \
 	-include $(top_builddir)/config.h \
@@ -67,4 +74,4 @@ AM_CFLAGS = ${my_CFLAGS} \
 CLEANFILES = \
 	application_qrc.cpp \
 	${BUILT_SOURCES} \
-	${projectM_qt_moc_sources}
+	${nodist_projectM_qt_moc_sources}


### PR DESCRIPTION
Automake tweaking for Qt cohabitation

TODO: travis with Qt enabled build (a build matrix ?)
TODO: merge projectM-qt and projectM-pulseaudio into one folder ? (it could simplify Qt/pulseaudio building)