### PR TITLE
SSE version of PresetOutputs::PerPixelMath

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,8 @@ AX_CHECK_GL
 
 AC_CHECK_LIB(c, dlopen, LIBDL="", AC_CHECK_LIB(dl, dlopen, LIBDL="-ldl"))
 
+AC_CHECK_FUNCS_ONCE([aligned_alloc posix_memalign])
+
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([
   Makefile

--- a/src/libprojectM/MilkdropPresetFactory/Param.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/Param.cpp
@@ -65,7 +65,7 @@ Param::Param(std::string _name) :
         matrix(0)
         {
 
-	engine_val = new float();
+	engine_val = (float *)&local_value;
 
 	default_init_val.float_val = DEFAULT_DOUBLE_IV;
         upper_bound.float_val = DEFAULT_DOUBLE_UB;
@@ -73,18 +73,10 @@ Param::Param(std::string _name) :
 
     /// @note may have fixed a recent bug. testing
     *((float*)engine_val) = default_init_val.float_val;
-
-   
-}
+ }
 
 /* Free's a parameter type */
 Param::~Param() {
-
-    // I hate this, but will let it be for now
-    if (flags & P_FLAG_USERDEF) {
-        delete((double*)engine_val);
-    }
-
     if (PARAM_DEBUG) printf("~Param: freeing \"%s\".\n", name.c_str());
 }
 

--- a/src/libprojectM/MilkdropPresetFactory/Param.hpp
+++ b/src/libprojectM/MilkdropPresetFactory/Param.hpp
@@ -58,6 +58,8 @@ class InitCond;
 class Param;
 class Preset;
 //#include <map>
+#include <immintrin.h>
+
 
 /* Parameter Type */
 class Param {
@@ -71,6 +73,9 @@ public:
     CValue default_init_val; /* a default initial condition value */
     CValue upper_bound; /* this parameter's upper bound */
     CValue lower_bound; /* this parameter's lower bound */
+
+    // for a local variable, engine_val can point here
+    float local_value;
 
     /// Create a new parameter
     Param(std::string name, short int type, short int flags,

--- a/src/libprojectM/MilkdropPresetFactory/PresetFrameIO.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/PresetFrameIO.cpp
@@ -9,9 +9,11 @@
 //#include <emmintrin.h> // X86 SSE2
 #include <immintrin.h>
 
+
 PresetInputs::PresetInputs() : PipelineContext()
 {
 }
+
 
 void PresetInputs::update(const BeatDetect & music, const PipelineContext & context) {
 
@@ -30,6 +32,7 @@ void PresetInputs::update(const BeatDetect & music, const PipelineContext & cont
     this->frame = context.frame;
     this->progress = context.progress;
 }
+
 
 void PresetInputs::Initialize ( int gx, int gy )
 {
@@ -102,13 +105,12 @@ void PresetInputs::Initialize ( int gx, int gy )
 			this->origtheta[x][y]=atan2 ( ( ( this->origy[x][y]-.5 ) *2 ), ( ( this->origx[x][y]-.5 ) *2 ) );
 		}
 	}
-
-
-
 }
+
 
 PresetOutputs::PresetOutputs() : Pipeline()
 {}
+
 
 PresetOutputs::~PresetOutputs()
 {
@@ -132,21 +134,21 @@ PresetOutputs::~PresetOutputs()
 		free(this->rad_mesh[x]);
 	}
 
-		free(this->rad_mesh);
-		free(this->sx_mesh);
-		free(this->sy_mesh);
-		free(this->dy_mesh);
-		free(this->dx_mesh);
-		free(this->cy_mesh);
-		free(this->cx_mesh);
-		free(this->warp_mesh);
-		free(this->zoom_mesh);
-		free(this->zoomexp_mesh);
-		free(this->rot_mesh);
-		free(this->orig_x);
-		free(this->orig_y);
-
+	free(this->rad_mesh);
+	free(this->sx_mesh);
+	free(this->sy_mesh);
+	free(this->dy_mesh);
+	free(this->dx_mesh);
+	free(this->cy_mesh);
+	free(this->cx_mesh);
+	free(this->warp_mesh);
+	free(this->zoom_mesh);
+	free(this->zoomexp_mesh);
+	free(this->rot_mesh);
+	free(this->orig_x);
+	free(this->orig_y);
 }
+
 
 void PresetOutputs::Render(const BeatDetect &music, const PipelineContext &context)
 {
@@ -158,18 +160,22 @@ void PresetOutputs::Render(const BeatDetect &music, const PipelineContext &conte
 
 	for (PresetOutputs::cshape_container::iterator pos = customShapes.begin();
 			pos != customShapes.end(); ++pos)
-			{
-				if( (*pos)->enabled==1)	drawables.push_back((*pos));
-			}
+	{
+		if ((*pos)->enabled==1)
+			drawables.push_back((*pos));
+	}
 
 	for (PresetOutputs::cwave_container::iterator pos = customWaves.begin();
 			pos != customWaves.end(); ++pos)
-			{
-				if( (*pos)->enabled==1)	drawables.push_back((*pos));
-			}
+	{
+		if ((*pos)->enabled==1)
+			drawables.push_back((*pos));
+	}
 
-    	drawables.push_back(&wave);
-	if(bDarkenCenter==1) drawables.push_back(&darkenCenter);
+	drawables.push_back(&wave);
+
+	if (bDarkenCenter==1)
+		drawables.push_back(&darkenCenter);
 	drawables.push_back(&border);
 
 	compositeDrawables.clear();
@@ -188,20 +194,17 @@ void PresetOutputs::Render(const BeatDetect &music, const PipelineContext &conte
 		compositeDrawables.push_back(&invert);
 }
 
+
 // N.B. The more optimization that can be done on this method, the better! This is called a lot and can probably be improved.
 void PresetOutputs::PerPixelMath_c(const PipelineContext &context)
 {
-
-	int x, y;
-	float fZoom2, fZoom2Inv;
-
-	for (x = 0; x < gx; x++)
+	for (int x = 0; x < gx; x++)
 	{
-		for (y = 0; y < gy; y++)
+		for (int y = 0; y < gy; y++)
 		{
-			fZoom2 = std::pow(this->zoom_mesh[x][y], std::pow(this->zoomexp_mesh[x][y],
+			const float fZoom2 = std::pow(this->zoom_mesh[x][y], std::pow(this->zoomexp_mesh[x][y],
 					rad_mesh[x][y] * 2.0f - 1.0f));
-			fZoom2Inv = 1.0f / fZoom2;
+			const float fZoom2Inv = 1.0f / fZoom2;
 			this->x_mesh[x][y] = this->orig_x[x][y] * 0.5f * fZoom2Inv + 0.5f;
 			this->x_mesh[x][y] = (this->x_mesh[x][y] - this->cx_mesh[x][y]) / this->sx_mesh[x][y] + this->cx_mesh[x][y];
 			this->y_mesh[x][y] = this->orig_y[x][y] * 0.5f * fZoom2Inv + 0.5f;
@@ -209,71 +212,35 @@ void PresetOutputs::PerPixelMath_c(const PipelineContext &context)
 		}
 	}
 
-	float fWarpTime = context.time * this->fWarpAnimSpeed;
-	float fWarpScaleInv = 1.0f / this->fWarpScale;
+	const float fWarpTime = context.time * this->fWarpAnimSpeed;
+	const float fWarpScaleInv = 1.0f / this->fWarpScale;
 	float f[4];
 	f[0] = 11.68f + 4.0f * cosf(fWarpTime * 1.413f + 10);
 	f[1] = 8.77f + 3.0f * cosf(fWarpTime * 1.113f + 7);
 	f[2] = 10.54f + 3.0f * cosf(fWarpTime * 1.233f + 3);
 	f[3] = 11.49f + 4.0f * cosf(fWarpTime * 0.933f + 5);
 
-	for (x = 0; x < gx; x++)
+	for (int x = 0; x < gx; x++)
 	{
-		for (y = 0; y < gy; y++)
+		for (int y = 0; y < gy; y++)
 		{
-#if 0
-			this->x_mesh[x][y] += this->warp_mesh[x][y] * 0.0035f * sinf(fWarpTime * 0.333f
-					+ fWarpScaleInv * (this->orig_x[x][y] * f[0] - this->orig_y[x][y] * f[3]));
-			this->y_mesh[x][y] += this->warp_mesh[x][y] * 0.0035f * cosf(fWarpTime * 0.375f
-					- fWarpScaleInv * (this->orig_x[x][y] * f[2] + this->orig_y[x][y] * f[1]));
-			this->x_mesh[x][y] += this->warp_mesh[x][y] * 0.0035f * cosf(fWarpTime * 0.753f
-					- fWarpScaleInv * (this->orig_x[x][y] * f[1] - this->orig_y[x][y] * f[2]));
-			this->y_mesh[x][y] += this->warp_mesh[x][y] * 0.0035f * sinf(fWarpTime * 0.825f
-					+ fWarpScaleInv * (this->orig_x[x][y] * f[0] + this->orig_y[x][y] * f[3]));
-#else
-			float orig_x = this->orig_x[x][y];
-			float orig_y = this->orig_y[x][y];
-			float warp_mesh = this->warp_mesh[x][y] * 0.0035f;
+			const float orig_x = this->orig_x[x][y];
+			const float orig_y = this->orig_y[x][y];
+			const float warp_mesh = this->warp_mesh[x][y] * 0.0035f;
 
-			this->x_mesh[x][y] += 
+			this->x_mesh[x][y] +=
 				(warp_mesh * sinf(fWarpTime * 0.333f + fWarpScaleInv * (orig_x * f[0] - orig_y * f[3]))) +
 				(warp_mesh * cosf(fWarpTime * 0.753f - fWarpScaleInv * (orig_x * f[1] - orig_y * f[2])));
 
-			this->y_mesh[x][y] += 
+			this->y_mesh[x][y] +=
 				(warp_mesh * cosf(fWarpTime * 0.375f - fWarpScaleInv * (orig_x * f[2] + orig_y * f[1]))) +
 				(warp_mesh * sinf(fWarpTime * 0.825f + fWarpScaleInv * (orig_x * f[0] + orig_y * f[3])));
-#endif
 		}
 	}
 
-#if 0
-	for (x = 0; x < gx; x++)
+	for (int x = 0; x < gx; x++)
 	{
-		for (y = 0; y < gy; y++)
-		{
-			float u2 = this->x_mesh[x][y] - this->cx_mesh[x][y];
-			float v2 = this->y_mesh[x][y] - this->cy_mesh[x][y];
-
-			float cos_rot = cosf(this->rot_mesh[x][y]);
-			float sin_rot = sinf(this->rot_mesh[x][y]);
-
-			this->x_mesh[x][y] = u2 * cos_rot - v2 * sin_rot + this->cx_mesh[x][y];
-			this->y_mesh[x][y] = u2 * sin_rot + v2 * cos_rot + this->cy_mesh[x][y];
-
-		}
-	}
-
-	for (x = 0; x < gx; x++)
-		for (y = 0; y < gy; y++)
-			this->x_mesh[x][y] -= this->dx_mesh[x][y];
-
-	for (x = 0; x < gx; x++)
-		for (y = 0; y < gy; y++)
-			this->y_mesh[x][y] -= this->dy_mesh[x][y];
-#else
-	for (x = 0; x < gx; x++)
-	{
-		for (y = 0; y < gy; y++)
+		for (int y = 0; y < gy; y++)
 		{
 			const float u2 = this->x_mesh[x][y] - this->cx_mesh[x][y];
 			const float v2 = this->y_mesh[x][y] - this->cy_mesh[x][y];
@@ -286,9 +253,7 @@ void PresetOutputs::PerPixelMath_c(const PipelineContext &context)
 			this->y_mesh[x][y] = u2 * sin_rot + v2 * cos_rot + this->cy_mesh[x][y] - this->dy_mesh[x][y];
 		}
 	}
-#endif
 }
-
 
 
 #ifdef __SSE2__
@@ -501,6 +466,7 @@ void PresetOutputs::PerPixelMath_sse(const PipelineContext &context)
 }
 #endif
 
+
 void PresetOutputs::PerPixelMath(const PipelineContext &context)
 {
 #ifdef __SSE2__
@@ -616,6 +582,7 @@ void PresetOutputs::Initialize ( int gx, int gy )
 		}
 }
 
+
 PresetInputs::~PresetInputs()
 {
 	for ( int x = 0; x < this->gx; x++ )
@@ -673,7 +640,6 @@ void PresetInputs::resetMesh()
 			theta_mesh[x][y]=this->origtheta[x][y];
 		}
 	}
-
 }
 
 

--- a/src/libprojectM/MilkdropPresetFactory/PresetFrameIO.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/PresetFrameIO.cpp
@@ -37,8 +37,8 @@ float **alloc_mesh(size_t gx, size_t gy)
 	// round gy up to multiple 4 (for possible SSE optimization) 
 	gy = (gy+3) & ~(size_t)3;
 
-	float **mesh = (float **)wipemalloc(gx * sizeof(float *));
-	float *m = (float *)wipemalloc(gx * gy * sizeof(float));
+	float **mesh = (float **)wipe_aligned_alloc(gx * sizeof(float *));
+	float *m = (float *)wipe_aligned_alloc(gx * gy * sizeof(float));
 	for ( int x = 0; x < gx; x++ )
 		mesh[x] = m + (gy * x);
 	return mesh;
@@ -46,8 +46,8 @@ float **alloc_mesh(size_t gx, size_t gy)
 
 float **free_mesh(float **mesh)
 {
-	free(mesh[0]);
-	free(mesh);
+	wipe_aligned_free(mesh[0]);
+	wipe_aligned_free(mesh);
 	return NULL;
 }
 
@@ -168,11 +168,8 @@ void PresetOutputs::Render(const BeatDetect &music, const PipelineContext &conte
 
 
 // N.B. The more optimization that can be done on this method, the better! This is called a lot and can probably be improved.
-// NOTE : Keep PerPixelMath_sse and PerPixelMath_c in sync
-
 void PresetOutputs::PerPixelMath_c(const PipelineContext &context)
 {
-
 	for (int x = 0; x < gx; x++)
 	{
 		for (int y = 0; y < gy; y++)
@@ -283,28 +280,6 @@ inline __m128 _mm_cosf(__m128 x)
 }
 
 
-/**
- * SSE instructions let us do the math on 4 floats in parallel.  You an see the main loop uses y += 4.  Each time through the loop,
- * we read operands in group of 4.  This looks like a mess, but just think of it as rewriting the infix expressions as a prefix expression
- * 
- * e.g.
- *   this->orig_x[x][y] * 0.5f * fZoom2Inv + 0.5f
- * becomes
- *			__m128 x_mesh = 
- *				_mm_add_ps(
- *					_mm_mul_ps(
- *						_mm_load_ps(&this->orig_x[x][y]), 
- *						_mm_mul_ps(fZoomInv,_mm_set_ps1(0.5f))),		// CONSIDER: common sub-expression
- *					_mm_set_ps1(0.5f));
- *
- * _mm_load_ps loads an SSE register from memory (4 floats at a time)
- * _mm_set_ps1 takes a constant 0.5 and loads it (replicated 4 times)
- *  * The other expressions are what they sound like:
- *    a + b --> _mm_add_ps(a, b)
- *    a * b --> _mm_mul_ps(a, b)
- */
-// NOTE : Keep PerPixelMath_sse and PerPixelMath_c in sync
-// NOTE : Even better would be to rewrite this as a compute shader
 void PresetOutputs::PerPixelMath_sse(const PipelineContext &context)
 {
 	for (int x = 0; x < gx; x++)

--- a/src/libprojectM/MilkdropPresetFactory/PresetFrameIO.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/PresetFrameIO.cpp
@@ -243,7 +243,7 @@ inline __m128 _mm_pow(__m128 x, __m128 y)
 	X[3] = __builtin_powf(X[3],Y[3]);
 	return _mm_load_ps(X);
 }
-inline __m128 _mm_sincosf(__m128 x, __m128 &sinx, __m128 &cosx)
+inline void _mm_sincosf(__m128 x, __m128 &sinx, __m128 &cosx)
 {
 	float X[4], S[4], C[4];
 	_mm_store_ps(X,x);

--- a/src/libprojectM/MilkdropPresetFactory/PresetFrameIO.hpp
+++ b/src/libprojectM/MilkdropPresetFactory/PresetFrameIO.hpp
@@ -138,6 +138,12 @@ public:
     float **orig_x;  //original mesh
     float **orig_y;
     float **rad_mesh;
+
+private:
+    void PerPixelMath_c( const PipelineContext &context);
+#ifdef __SSE2__
+    void PerPixelMath_sse( const PipelineContext &context);
+#endif
 };
 
 

--- a/src/libprojectM/Renderer/Pipeline.cpp
+++ b/src/libprojectM/Renderer/Pipeline.cpp
@@ -11,37 +11,26 @@ Pipeline::Pipeline() : staticPerPixel(false),gx(0),gy(0),blur1n(1), blur2n(1), b
 blur1x(1), blur2x(1), blur3x(1),
 blur1ed(1){}
 
+float **alloc_mesh(size_t gx, size_t gy);
+float **free_mesh(float **mesh);
+
 void Pipeline::setStaticPerPixel(int gx, int gy)
 {
-	 staticPerPixel = true;
-	 this->gx = gx;
-	 this->gy = gy;
+	staticPerPixel = true;
+	this->gx = gx;
+	this->gy = gy;
 
-		this->x_mesh= ( float ** ) wipemalloc ( gx * sizeof ( float * ) );
-		for ( int x = 0; x < gx; x++ )
-		{
-			this->x_mesh[x] = ( float * ) wipemalloc ( gy * sizeof ( float ) );
-		}
-		this->y_mesh= ( float ** ) wipemalloc ( gx * sizeof ( float * ) );
-		for ( int x = 0; x < gx; x++ )
-		{
-			this->y_mesh[x] = ( float * ) wipemalloc ( gy * sizeof ( float ) );
-		}
-
+	this->x_mesh = alloc_mesh(gx, gy);
+	this->y_mesh = alloc_mesh(gx, gy);
 }
 
 Pipeline::~Pipeline()
 {
-if (staticPerPixel)
-{
-	for ( int x = 0; x < this->gx; x++ )
+	if (staticPerPixel)
 	{
-		free(this->x_mesh[x]);
-		free(this->y_mesh[x]);
+		free_mesh(x_mesh);
+		free_mesh(y_mesh);
 	}
-	free(x_mesh);
-	free(y_mesh);
-}
 }
 
 //void Pipeline::Render(const BeatDetect &music, const PipelineContext &context){}

--- a/src/libprojectM/wipemalloc.cpp
+++ b/src/libprojectM/wipemalloc.cpp
@@ -27,7 +27,8 @@
 #include "wipemalloc.h"
 
  void *wipemalloc( size_t count ) {
-    void *mem = malloc( count );
+    count = (count + 15) & ~(size_t)15;
+    void *mem = aligned_alloc( 16, count );
     if ( mem != NULL ) {
         memset( mem, 0, count );
       } else {

--- a/src/libprojectM/wipemalloc.cpp
+++ b/src/libprojectM/wipemalloc.cpp
@@ -47,7 +47,7 @@
 
 void *wipe_aligned_alloc( size_t align, size_t size )
 {
-#if TARGET_OS_MAC
+#if __APPLE__
     // only support powers of 2 for align
     assert( (align & (align-1)) == 0 );
     void *allocated = malloc(size + align - 1 + sizeof(void*));
@@ -72,7 +72,7 @@ void *wipe_aligned_alloc( size_t align, size_t size )
 
 void wipe_aligned_free( void *p )
 {
-#if TARGET_OS_MAC
+#if __APPLE__
     if (p != NULL)
     {
         void *allocated = *((void**)((size_t)p - sizeof(void*)));

--- a/src/libprojectM/wipemalloc.cpp
+++ b/src/libprojectM/wipemalloc.cpp
@@ -27,59 +27,83 @@
 #include "wipemalloc.h"
 #include <assert.h>
 
- void *wipemalloc( size_t count )
- {
+
+void *wipemalloc( size_t count )
+{
     void *mem = malloc( count );
-    if ( mem != NULL ) {
+    if ( mem != NULL )
+    {
         memset( mem, 0, count );
-      } else {
+    }
+    else
+    {
         printf( "wipemalloc() failed to allocate %d bytes\n", (int)count );
-      }
+    }
     return mem;
- }
+}
+
 
 /** Safe memory deallocator */
- void wipefree( void *ptr ) {
-    if ( ptr != NULL ) {
+void wipefree( void *ptr )
+{
+    if ( ptr != NULL )
         free( ptr );
-      }
-  }
+}
+
 
 void *wipe_aligned_alloc( size_t align, size_t size )
 {
-#if __APPLE__
+    void *mem = NULL;
+
+#if HAVE_ALIGNED_ALLOC==1
+
+    mem = aligned_alloc( align, size );
+
+#elif HAVE_POSIX_MEMALIGN==1
+
+    if (posix_memalign(&mem, align, size))
+      mem = NULL;
+
+#else
+
     // only support powers of 2 for align
     assert( (align & (align-1)) == 0 );
+    assert( (size % align) == 0 );
     void *allocated = malloc(size + align - 1 + sizeof(void*));
-    if (allocated == NULL)
+    if (allocated)
     {
-        printf( "wipe_aligned_malloc() failed to allocate %d bytes\n", (int)size );
-        return NULL;
+        mem = (void*) (((size_t)allocated + sizeof(void*) + align -1) & ~(align-1));
+        ((void**)mem)[-1] = allocated;
     }
-    void *ret = (void*) (((size_t)allocated + sizeof(void*) + align -1) & ~(align-1));
-    *((void**)((size_t)ret - sizeof(void*))) = allocated;
-    return ret;
-#else
-    void *mem = aligned_alloc( align, size );
-    if ( mem != NULL ) {
-        memset( mem, 0, size );
-      } else {
-        printf( "wipe_aligned_alloc() failed to allocate %d bytes\n", (int)size );
-      }
-    return mem;
+
 #endif
+
+    if (mem)
+    {
+        memset( mem, 0, size );
+    }
+    else
+    {
+        printf( "wipe_aligned_alloc() failed to allocate %d bytes\n", (int)size );
+    }
+    return mem;
 }
+
 
 void wipe_aligned_free( void *p )
 {
-#if __APPLE__
-    if (p != NULL)
-    {
-        void *allocated = *((void**)((size_t)p - sizeof(void*)));
-        free(allocated);
-    }
-#else
+#if HAVE_ALIGNED_ALLOC==1 || HAVE_POSIX_MEMALIGN==1
+
     if (p != NULL)
         free(p);
+
+#else
+
+    if (p != NULL)
+    {
+        void *allocated = ((void**)p)[-1];
+        free(allocated);
+    }
+
 #endif
 }

--- a/src/libprojectM/wipemalloc.h
+++ b/src/libprojectM/wipemalloc.h
@@ -57,4 +57,8 @@
  void *wipemalloc( size_t count );
  void wipefree( void *ptr );
 
+/** wipe_aligned_malloc() must be matched with aligned_free() */
+ void *wipe_aligned_alloc( size_t align, size_t count);
+ inline void *wipe_aligned_alloc( size_t count ) { return wipe_aligned_alloc(16,count); }
+ void wipe_aligned_free( void *ptr );
 #endif /** !_WIPEMALLOC_H */

--- a/src/projectM-sdl/pmSDL.cpp
+++ b/src/projectM-sdl/pmSDL.cpp
@@ -96,13 +96,11 @@ int projectMSDL::openAudioInput() {
 void projectMSDL::beginAudioCapture() {
     // allocate a buffer to store PCM data for feeding in
     unsigned int maxSamples = audioChannelsCount * audioSampleCount;
-    pcmBuffer = (unsigned char *) malloc(maxSamples);
     SDL_PauseAudioDevice(audioDeviceID, false);
     pcm()->initPCM(2048);
 }
 
 void projectMSDL::endAudioCapture() {
-    free(pcmBuffer);
     SDL_PauseAudioDevice(audioDeviceID, true);
 }
 
@@ -235,4 +233,10 @@ void projectMSDL::init(SDL_Window *window, SDL_Renderer *renderer) {
     rend = renderer;
     selectRandom(true);
     projectM_resetGL(width, height);
+}
+
+
+std::string projectMSDL::getActivePresetName()
+{
+    return std::string("hey");
 }

--- a/src/projectM-sdl/pmSDL.hpp
+++ b/src/projectM-sdl/pmSDL.hpp
@@ -44,6 +44,7 @@ public:
     void renderFrame();
     void pollEvent();
     void maximize();
+    std::string getActivePresetName();
 
 private:
     SDL_Window *win;
@@ -59,11 +60,9 @@ private:
     unsigned short audioSampleCount;
     SDL_AudioFormat audioFormat;
     SDL_AudioDeviceID audioDeviceID;
-    unsigned char *pcmBuffer;  // pre-allocated buffer for audioInputCallback
 
     static void audioInputCallbackF32(void *userdata, unsigned char *stream, int len);
     static void audioInputCallbackS16(void *userdata, unsigned char *stream, int len);
-
 
     void addFakePCM();
     void keyHandler(SDL_Event *);


### PR DESCRIPTION
tested using 320x240, yin - 315 - Ocean of Light (yo im peakin yo Eo.S.-Phat).milk just about doubled FPS from 60ish to 110ish.

From google-pprof, doesn't entirely match up with my FPS observation, but does show CPU usage going down.

before
     881  48.6%  48.6%      881  48.6% __iscanonicall
     453  25.0%  73.7%     1225  67.6% PresetOutputs::PerPixelMath
after
     837  47.0%  47.0%      837  47.0% __iscanonicall
     131   7.4%  54.4%      965  54.2% PresetOutputs::PerPixelMath_sse