### PR TITLE
fix for issue 64

### DIFF
--- a/src/libprojectM/MilkdropPresetFactory/Expr.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/Expr.cpp
@@ -140,7 +140,7 @@ public:
 };
 /* TODO optimize FloatParameterExpr::eval() further.
 //  - flag "never matrix" parameters
-//  - always pass in 2d matrix. instead of using  (i, -1) for 1d matrix, we could just use (0, i) and avoid check
+//  - always pass in 2d matrix. instead of using (i, -1) for 1d matrix, we could just use (0, i) and avoid check
 //  - instead of using matrix_flag to give "copy on write" behavior, maybe pre-copy from engine_val to matrix[]
 */
 float FloatParameterExpr::eval ( int mesh_i, int mesh_j )
@@ -160,7 +160,9 @@ float FloatParameterExpr::eval ( int mesh_i, int mesh_j )
 			}
 			else
 			{
-				return ( ( ( float* ) term.param->matrix ) [mesh_i] );
+				// issue 64, make sure we're not reading a P_FLAG_PER_PIXEL matrix variable
+				if (!(term.param->flags & P_FLAG_PER_PIXEL))
+					return ( ( ( float* ) term.param->matrix ) [mesh_i] );
 			}
 		}
 		//assert(mesh_i >=0);

--- a/src/libprojectM/MilkdropPresetFactory/Param.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/Param.cpp
@@ -47,6 +47,7 @@ Param::Param( std::string _name, short int _type, short int _flags, void * _engi
         flags (_flags),
         matrix_flag (0),
         engine_val(_engine_val),
+        local_value(0.0),
         matrix (_matrix),
         default_init_val (_default_init_val),
         upper_bound (_upper_bound),
@@ -62,6 +63,7 @@ Param::Param(std::string _name) :
         type(P_TYPE_DOUBLE),
 	flags(P_FLAG_USERDEF),
         matrix_flag(0),
+        local_value(0.0),
         matrix(0)
         {
 


### PR DESCRIPTION
Rambling discussion of issue here:
  https://github.com/projectM-visualizer/projectm/issues/64

This pull request simply forces the "per point" equations to not read from any "per pixel" values, and always use the preset output values.