### PR TITLE
Makefile.am: Fix installation with DESTDIR set

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,8 +19,8 @@ pm_shaders__DATA = src/libprojectM/Renderer/blur.cg \
 
 # find and install all preset files
 install-data-local:
-	test -z $(pkgdatadir) || $(MKDIR_P) $(pm_presets_dir)
-	find "$(PRESETSDIR)" -type f -exec $(INSTALL_DATA) {} $(pm_presets_dir) \;
+	test -z $(DESTDIR)$(pkgdatadir) || $(MKDIR_P) $(DESTDIR)$(pm_presets_dir)
+	find "$(PRESETSDIR)" -type f -exec $(INSTALL_DATA) {} $(DESTDIR)$(pm_presets_dir) \;
 
 # from https://stackoverflow.com/questions/30897170/ac-subst-does-not-expand-variable answer: https://stackoverflow.com/a/30960268
 # ptomato https://stackoverflow.com/users/172999/ptomato


### PR DESCRIPTION
In OE/Yocto build the 'test -z'  part failed with error that /usr/share/projectM/presets could not be created. 

And now the fun story: This slipped through on my build machine at home (where I build projectm usually): There projectm is installed from packages and /usr/share/projectM/presets is already there so it did not fail... 