### PR TITLE
FIX: crash if preset directory is empty.

### DIFF
--- a/src/projectM-qt/qplaylistmodel.cpp
+++ b/src/projectM-qt/qplaylistmodel.cpp
@@ -318,11 +318,7 @@ int QPlaylistModel::rowCount ( const QModelIndex & parent ) const
 
 int QPlaylistModel::columnCount ( const QModelIndex & parent ) const
 {
-
-	if ( rowCount() > 0 )
-		return softCutRatingsEnabled() ? 3 : 2;
-	else
-		return 0;
+	return softCutRatingsEnabled() ? 3 : 2;
 }
 
 void QPlaylistModel::appendRow ( const QString & presetURL, const QString & presetName, int rating, int breedability )


### PR DESCRIPTION
The crash happens in QProjectM_MainWindow::refreshHeaders which is dependent of columns count.
Columns headers doesn't need to be hidden if preset folder is empty.

This could fix the issue described in #45 by @kenny-w1