### PR TITLE
OpenGL ES 3.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ before_install:
 
 # TODO: test different combinations of flags, --enable-sdl, --enable-qt, etc
 script:
-  - ./configure --enable-sdl --enable-ftgl --prefix=$PWD/local && make -j8 && make install  # build from checkout
-  - make dist && tar -zxf projectM-*.tar.gz && cd projectM-* && ./configure --enable-sdl --enable-ftgl --prefix=$PWD/dist_install && make -j8 && make install  # build from dist
+  - ./configure --enable-sdl --prefix=$PWD/local && make -j8 && make install  # build from checkout
+  - make dist && tar -zxf projectM-*.tar.gz && cd projectM-* && ./configure --enable-sdl --prefix=$PWD/dist_install && make -j8 && make install  # build from dist
   - echo "PWD $PWD"
   - ls .
   - test -e src/projectM-sdl/projectMSDL

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ matrix:
             - libftgl-dev
             - libsdl2-dev
             - libdevil-dev
+            - libglm-dev
       env:
         - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
     # linux/gcc
@@ -51,6 +52,7 @@ matrix:
             - libftgl-dev
             - libsdl2-dev
             - libdevil-dev
+            - libglm-dev
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
 

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,7 @@ m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 LT_INIT
 
 AC_PROG_CXX
+AC_LANG(C++)
 
 AC_CONFIG_MACRO_DIRS([m4 m4/autoconf-archive])
 AX_CHECK_GL
@@ -65,7 +66,7 @@ AS_IF([test "x$enable_ftgl" = "xyes"], [
   AC_DEFINE([USE_FTGL], [1], [Define USE_FTGL])
 ])
 
-PKG_CHECK_MODULES(glm, [glm], [], [AC_MSG_ERROR([libglm is required.])])
+AC_CHECK_HEADER([glm/glm.hpp],, AC_MSG_ERROR(libglm is required.))
 
 AC_ARG_ENABLE([gles],
   AS_HELP_STRING([--enable-gles], [OpenGL ES support]),

--- a/src/libprojectM/projectM-opengl.h
+++ b/src/libprojectM/projectM-opengl.h
@@ -12,7 +12,6 @@
 #else /* linux/unix/other */
 # ifdef USE_GLES
 #  include <GLES3/gl3.h>
-#  include <GLES3/gl32.h>
 # else
 #  if !defined(GL_GLEXT_PROTOTYPES)
 #     define GL_GLEXT_PROTOTYPES

--- a/src/projectM-sdl/projectM_SDL_main.cpp
+++ b/src/projectM-sdl/projectM_SDL_main.cpp
@@ -11,6 +11,8 @@
 #define OGL_DEBUG	0
 
 #if OGL_DEBUG
+#include <GLES3/gl32.h>
+
 void DebugLog(GLenum source,
                GLenum type,
                GLuint id,


### PR DESCRIPTION
Modernization of openGL calls: now it is compliant to GL 3.2+ and GLES 3.0+ core profiles.

To check for correctness of this port, I've compared the behavior of each preset builtin variables for openGL 3.2 and openGL ES 3.0 profiles vs the previous rendering results. 
All openGL calls have been ported and are functional.

Not working (in priority order):
FBO: some tests needs to be completed to check for correctness
Cg: next step is the integration with @revmischa HLSL->GLSL translation
FTGL: no openGL ES support, is it worth it ? (alternative candidate: http://cdave1.github.io/ftgles/)
