### PR TITLE
Add double-click for fullscreen, right click for menu to projectm-qt

### DIFF
--- a/src/projectM-qt/qprojectm_mainwindow.cpp
+++ b/src/projectM-qt/qprojectm_mainwindow.cpp
@@ -118,6 +118,7 @@ activePresetIndex(new Nullable<long>), playlistItemCounter(0), m_QPresetEditorDi
 	m_QProjectMWidget->makeCurrent();
 	m_QProjectMWidget->setFocus();
 	setCentralWidget ( m_QProjectMWidget );
+	m_QProjectMWidget->installEventFilter(this);
 
 	m_timer->start ( 0 );
 
@@ -1315,3 +1316,16 @@ void QProjectM_MainWindow::handleFailedPresetSwitch(const bool isHardCut, const 
 
 }
 
+bool QProjectM_MainWindow::eventFilter(QObject *obj, QEvent *event)
+{
+	    if (event->type() == QEvent::MouseButtonDblClick && ((QMouseEvent*)event)->button() == Qt::LeftButton) {
+			    this->setWindowState ( this->windowState() ^ Qt::WindowFullScreen );
+			    return true;
+		} else if (event->type() == QEvent::MouseButtonPress && ((QMouseEvent*)event)->button() == Qt::RightButton) {
+			    setMenuVisible(!_menuVisible);
+				refreshHeaders();
+				return true;
+		} else {
+			    return false;
+		}
+}

--- a/src/projectM-qt/qprojectm_mainwindow.hpp
+++ b/src/projectM-qt/qprojectm_mainwindow.hpp
@@ -101,6 +101,7 @@ class QProjectM_MainWindow:public QMainWindow
       void keyReleaseEvent ( QKeyEvent * e );
       QProjectM * qprojectM();
       void refreshPlaylist();
+	  bool eventFilter(QObject *obj, QEvent *event);
 
       QProjectMWidget * qprojectMWidget() { return m_QProjectMWidget; }
 


### PR DESCRIPTION
This is a feature I always thought was missing from projectm-qt/pulseaudio/jack. Pretty straightforward:

Double left click on the visualisation to enter/leave fullscreen mode (same as pressing F key). Right click to show/hide them menu (same as M key).

Important so that the main features and functionality of the GUI are available using the mouse only, saving me reaching for the keyboard on the coffee table. Fullscreen and menu are much more discoverable with this as well -- which was a problem for new users I believe.