### PR TITLE
Install native presets libraries in libdir

### DIFF
--- a/src/NativePresets/Makefile.am
+++ b/src/NativePresets/Makefile.am
@@ -9,10 +9,8 @@ AM_CFLAGS = ${my_CFLAGS} \
 -ffunction-sections \
 -fdata-sections
 
-presetsdir = $(pkgdatadir)/presets
+presetsdir = $(libdir)/projectM
 
-# native presets are shared object files.
-# they should get installed to $presetsdir/
 presets_LTLIBRARIES = \
   libMstressJuppyDancer.la \
   libRLGFractalDrop7c.la \


### PR DESCRIPTION
As requested [here](https://github.com/projectM-visualizer/projectm/issues/95#issuecomment-413964324)
It seems to work fine on my computer but please check if this is okay because there was a comment saying 
```
# native presets are shared object files.
# they should get installed to $presetsdir/
```
Signed-off-by: Pierre-Yves <pyu@riseup.net>