### PR TITLE
Increase soversion to 2.2.0

### DIFF
--- a/src/libprojectM/Makefile.am
+++ b/src/libprojectM/Makefile.am
@@ -14,7 +14,7 @@ AM_CPPFLAGS = \
 lib_LTLIBRARIES = libprojectM.la  # public, possibly-shared library
 
 # link flags
-libprojectM_la_LDFLAGS = $(CG_LDFLAGS) -no-undefined -version-info 4:0:2
+libprojectM_la_LDFLAGS = $(CG_LDFLAGS) -no-undefined -version-info 4:1:1
 
 # link libRenderer, MilkdropPresetFactory, NativePresetFactory, and libprojectM sources
 libprojectM_la_LIBADD = \

--- a/src/libprojectM/Makefile.am
+++ b/src/libprojectM/Makefile.am
@@ -14,7 +14,7 @@ AM_CPPFLAGS = \
 lib_LTLIBRARIES = libprojectM.la  # public, possibly-shared library
 
 # link flags
-libprojectM_la_LDFLAGS = $(CG_LDFLAGS) -no-undefined -version-info 2:0:0
+libprojectM_la_LDFLAGS = $(CG_LDFLAGS) -no-undefined -version-info 4:0:2
 
 # link libRenderer, MilkdropPresetFactory, NativePresetFactory, and libprojectM sources
 libprojectM_la_LIBADD = \


### PR DESCRIPTION
Right now 2.0.0 is even older than the original libprojectM before the refactoring.
