### PR TITLE
Alternate milkdrop preset format

### DIFF
--- a/src/libprojectM/MilkdropPresetFactory/IdlePreset.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/IdlePreset.cpp
@@ -201,9 +201,12 @@ return out.str();
 std::unique_ptr<Preset> IdlePresets::allocate(const std::string & name, PresetOutputs & presetOutputs)
 {
 
-  if (name == IDLE_PRESET_NAME) {
-  	std::istringstream in(presetText());
-  	return std::unique_ptr<Preset>(new MilkdropPreset(in, IDLE_PRESET_NAME, presetOutputs));
+  if (name == IDLE_PRESET_NAME)
+  {
+  	  std::istringstream in(presetText());
+  	  auto *preset = new MilkdropPreset(IDLE_PRESET_NAME, presetOutputs);
+  	  preset->initialize(in);
+      return std::unique_ptr<Preset>(preset);
   }
   else
     return std::unique_ptr<Preset>();

--- a/src/libprojectM/MilkdropPresetFactory/Makefile.am
+++ b/src/libprojectM/MilkdropPresetFactory/Makefile.am
@@ -12,7 +12,8 @@ CValue.hpp                InitCond.hpp              PerFrameEqn.hpp\
 CustomShape.hpp           InitCondUtils.hpp         PerPixelEqn.hpp\
 CustomWave.hpp            MilkdropPreset.hpp        PerPointEqn.hpp\
 Eval.hpp                  MilkdropPresetFactory.hpp PresetFrameIO.hpp\
-Expr.hpp                  Param.hpp
+Expr.hpp                  Param.hpp\
+SaltWaterTaffyPreset.hpp SaltWaterTaffyPreset.cpp
 
 
 libMilkdropPresetFactory_la_CPPFLAGS = ${my_CFLAGS} \

--- a/src/libprojectM/MilkdropPresetFactory/MilkdropPreset.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/MilkdropPreset.cpp
@@ -42,15 +42,16 @@
 #include "PresetFrameIO.hpp"
 
 #include "PresetFactoryManager.hpp"
+#include "SaltWaterTaffyPreset.hpp"
 
 
-MilkdropPreset::MilkdropPreset(std::istream & in, const std::string & presetName,  PresetOutputs & presetOutputs):
+MilkdropPreset::MilkdropPreset(const std::string & presetName,  PresetOutputs & presetOutputs):
 	Preset(presetName),
     	builtinParams(_presetInputs, presetOutputs),
     	_presetOutputs(presetOutputs)
 {
-  initialize(in);
-
+  // NOTE: don't call initialize here, because subclass vtable is not set up yet
+  // initialize(in);
 }
 
 MilkdropPreset::MilkdropPreset(const std::string & absoluteFilePath, const std::string & presetName, PresetOutputs & presetOutputs):
@@ -60,10 +61,10 @@ MilkdropPreset::MilkdropPreset(const std::string & absoluteFilePath, const std::
     _absoluteFilePath(absoluteFilePath),
     _presetOutputs(presetOutputs)
 {
-
-  initialize(absoluteFilePath);
-
+  // NOTE: don't call initialize here, because subclass vtable is not set up yet
+  // initialize(absoluteFilePath);
 }
+
 MilkdropPreset::~MilkdropPreset()
 {
 

--- a/src/libprojectM/MilkdropPresetFactory/MilkdropPreset.hpp
+++ b/src/libprojectM/MilkdropPresetFactory/MilkdropPreset.hpp
@@ -70,7 +70,10 @@ public:
   /// \param MilkdropPresetName a descriptive name for the MilkdropPreset. Usually just the file name
   /// \param MilkdropPresetInputs a reference to read only projectM engine variables
   /// \param MilkdropPresetOutputs initialized and filled with data parsed from a MilkdropPreset
-  MilkdropPreset(std::istream & in, const std::string & milkdropPresetName, PresetOutputs & presetOutputs);
+  MilkdropPreset(const std::string & milkdropPresetName, PresetOutputs & presetOutputs);
+
+  void initialize(const std::string & pathname);
+  void initialize(std::istream & in);
 
   ~MilkdropPreset();
 
@@ -152,9 +155,6 @@ private:
   // The absolute path of the MilkdropPreset
   std::string _absolutePath;
 
-  void initialize(const std::string & pathname);
-  void initialize(std::istream & in);
-
   int loadPresetFile(const std::string & pathname);
 
   void loadBuiltinParamsUnspecInitConds();
@@ -169,11 +169,12 @@ private:
   void evalPerPixelEqns();
   void evalPerFrameEquations();
   void initialize_PerPixelMeshes();
-  int readIn(std::istream & fs);
-
+protected:
+  virtual int readIn(std::istream & fs);
+private:
   void preloadInitialize();
   void postloadInitialize();
-  
+
   PresetOutputs & _presetOutputs;
 
 template <class CustomObject>

--- a/src/libprojectM/MilkdropPresetFactory/MilkdropPresetFactory.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/MilkdropPresetFactory.cpp
@@ -12,6 +12,7 @@
 //
 #include "MilkdropPresetFactory.hpp"
 #include "MilkdropPreset.hpp"
+#include "SaltWaterTaffyPreset.hpp"
 #include "BuiltinFuncs.hpp"
 #include "Eval.hpp"
 #include "IdlePreset.hpp"
@@ -220,8 +221,20 @@ std::unique_ptr<Preset> MilkdropPresetFactory::allocate(const std::string & url,
 	resetPresetOutputs(presetOutputs);
 
 	std::string path;
-	if (PresetFactory::protocol(url, path) == PresetFactory::IDLE_PRESET_PROTOCOL) {
-		return IdlePresets::allocate(path, *presetOutputs);
-	} else
-		return std::unique_ptr<Preset>(new MilkdropPreset(url, name, *presetOutputs));
+	if (PresetFactory::protocol(url, path) == PresetFactory::IDLE_PRESET_PROTOCOL)
+    {
+        return IdlePresets::allocate(path, *presetOutputs);
+    }
+	else if (url.substr(url.length()-5)==".salt")
+    {
+        auto *preset = new SaltWaterTaffyPreset(url, name, *presetOutputs);
+        preset->initialize(url);
+        return std::unique_ptr<Preset>(preset);
+    }
+	else
+    {
+        auto *preset = new MilkdropPreset(url, name, *presetOutputs);
+	    preset->initialize(url);
+		return std::unique_ptr<Preset>(preset);
+    }
 }

--- a/src/libprojectM/MilkdropPresetFactory/MilkdropPresetFactory.hpp
+++ b/src/libprojectM/MilkdropPresetFactory/MilkdropPresetFactory.hpp
@@ -29,7 +29,7 @@ public:
  std::unique_ptr<Preset> allocate(const std::string & url, const std::string & name = std::string(),
 	const std::string & author = std::string());
 
- std::string supportedExtensions() const { return "milk prjm"; }
+ std::string supportedExtensions() const { return "milk prjm salt milk.salt"; }
 
 private:
     static PresetOutputs* createPresetOutputs(int gx, int gy);

--- a/src/libprojectM/MilkdropPresetFactory/Parser.hpp
+++ b/src/libprojectM/MilkdropPresetFactory/Parser.hpp
@@ -29,7 +29,7 @@
 #ifndef _PARSER_H
 #define _PARSER_H
 //#define PARSE_DEBUG 2
-#define PARSE_DEBUG 0
+#define PARSE_DEBUG 1
 
 #include <stdio.h>
 

--- a/src/libprojectM/MilkdropPresetFactory/Parser.hpp
+++ b/src/libprojectM/MilkdropPresetFactory/Parser.hpp
@@ -29,7 +29,7 @@
 #ifndef _PARSER_H
 #define _PARSER_H
 //#define PARSE_DEBUG 2
-#define PARSE_DEBUG 1
+#define PARSE_DEBUG 0
 
 #include <stdio.h>
 

--- a/src/libprojectM/MilkdropPresetFactory/SaltWaterTaffyPreset.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/SaltWaterTaffyPreset.cpp
@@ -1,0 +1,352 @@
+//
+// Created by matthew on 12/22/18.
+//
+
+#include "SaltWaterTaffyPreset.hpp"
+#include "Parser.hpp"
+#include "fatal.h"
+#include <stack>
+
+
+int convert(std::istream & fs, std::ostream & os);
+int parse_object(const char *prefix_init, const char *prefix_eqns, std::istream & fs, std::ostream & os);
+int parse_equations(const char *prefix, std::istream & fs, std::ostream & os);
+int parse_shader(const char *prefix, std::istream & fs, std::ostream & os);
+int parse_object_line(const std::string &line, std::string &type, std::string &name, std::string &comment);
+int parse_assignment_line(const std::string &line, std::string &name, std::string &value, std::string &comment);
+
+
+
+SaltWaterTaffyPreset::SaltWaterTaffyPreset(const std::string & absoluteFilePath, const std::string & presetName, PresetOutputs & presetOutputs):
+    MilkdropPreset(absoluteFilePath, presetName, presetOutputs)
+{
+
+}
+
+
+int SaltWaterTaffyPreset::readIn(std::istream & fs)
+{
+    // I could actually write a new parser, and that would probably give better error messages
+    // but for a start just translate to .milk format in memory
+    std::ostringstream os;
+    int ret = convert( fs, os );
+    if (ret != PROJECTM_SUCCESS)
+        return ret;
+    std::string converted = os.str();
+std::cerr << converted << std::endl;
+    std::istringstream is(converted);
+    return MilkdropPreset::readIn(is);
+}
+
+
+bool starts_with(const std::string & a, const std::string & b)
+{
+    return a.compare(0, b.length(), b) == 0;
+}
+bool ends_with(const std::string & a, const std::string & b)
+{
+    return a.compare(a.length()-b.length(), a.length(), b) == 0;
+}
+void trim(std::string & s)
+{
+    size_t start = s.find_first_not_of(' ');
+    if (start == std::string::npos)
+    {
+        s.clear();
+        return;
+    }
+    size_t end = s.find_last_not_of(' ');
+    s.erase(end+1);
+    s.erase(0,start);
+}
+bool getline(std::istream & fs, std::string & line)
+{
+    line.clear();
+    if (!fs || fs.eof())
+        return false;
+
+    while (true)
+    {
+        char c = fs.get();
+        if (c == EOF)
+            return !line.empty();
+        if (c == '\n')
+            return true;
+        line.append(1,c);
+    }
+}
+
+
+// try to keep lines # matching between source and target
+
+int convert(std::istream & fs, std::ostream & os)
+{
+    // read looking for top level objects: preset, wave, shape
+    std::string line;
+    int wavecount=0, shapecount=0;
+    char prefix_init_buffer[30];
+    char prefix_eqns_buffer[30];
+
+    while (getline(fs,line))
+    {
+        trim(line);
+
+        if (starts_with(line, "//") || line.empty())
+        {
+            os << line << std::endl;
+        }
+        else if (starts_with(line, "preset ") || starts_with(line, "wave ") || starts_with(line, "shape "))
+        {
+            std::string type, name, comment;
+            int ret = parse_object_line(line, type, name, comment);
+            if (ret != PROJECTM_SUCCESS)
+                return ret;
+
+            if (type == "preset")
+            {
+                os << "[" << (name.empty()?"preset0":name) << "]" << std::endl;;
+                parse_object("", "", fs, os);
+            }
+            else if (type == "wave")
+            {
+                os << std::endl;
+                sprintf(prefix_init_buffer, "wavecode_%d_", wavecount);
+                sprintf(prefix_eqns_buffer, "wave_%d_", wavecount);
+                wavecount++;
+                parse_object(prefix_init_buffer, prefix_eqns_buffer, fs, os);
+            }
+            else // type == "shape"
+            {
+                os << std::endl;
+                sprintf(prefix_init_buffer, "shapecode_%d_", shapecount);
+                sprintf(prefix_eqns_buffer, "shape_%d_", shapecount);
+                shapecount++;
+                parse_object(prefix_init_buffer,prefix_eqns_buffer, fs, os);
+            }
+        }
+        else
+        {
+            // we have a non-blank line that doesn't seem to start an object...
+            if (PARSE_DEBUG) printf("parse taffy: expected start of object 'preset', 'shape', or 'wave': %s\n", line.c_str());
+            return PROJECTM_PARSE_ERROR;
+        }
+    }
+    return PROJECTM_SUCCESS;
+}
+
+
+// not including the shader program there are really only two line types
+//
+// {preset|wave|shape} 'name' {
+// key=value
+
+
+int parse_object_line(const std::string & line, std::string & type, std::string & name, std::string & comment)
+{
+    type.empty(); name.empty(); comment.empty();
+    size_t start = 0;
+    size_t end = line.length();
+
+    size_t c = line.find("//");
+    if (c != std::string::npos)
+    {
+        comment = line.substr(c);
+        end = c;
+    }
+    if (line[end-1] != '{')
+    {
+        if (PARSE_DEBUG) printf("parse taffy: expected line to end with '{': %s\n", line.c_str());
+        return PROJECTM_PARSE_ERROR;
+    }
+    start = line.find(' ');
+    type = line.substr(0, start);
+
+    start = line.find_first_not_of(" ", start);
+    end =  line.find_last_not_of(' ', end-2)+1;
+    if (end-start > 3 && line[start]=='\'' && line[end-1]=='\'')
+    {
+        start++;
+        end--;
+    }
+    if (end > start)
+        name = line.substr(start,end-start);
+    return PROJECTM_SUCCESS;
+}
+
+
+int parse_assignment_line(const std::string &line, std::string &name, std::string &value, std::string &comment)
+{
+    name.empty(); value.empty(); comment.empty();
+
+    size_t c = line.find("//");
+    if (c != std::string::npos)
+    {
+        comment = line.substr(c);
+    }
+    size_t eq = line.find('=');
+    if (eq == std::string::npos || eq > c)
+    {
+        name = line.substr(0,c);
+        trim(name);
+        if (name.empty())
+            return PROJECTM_SUCCESS;
+        if (PARSE_DEBUG) printf("parse taffy: expected line to containe '=': %s\n", line.c_str());
+        return PROJECTM_PARSE_ERROR;
+    }
+    name = line.substr(0,eq);
+    trim(name);
+    value = line.substr(eq+1);
+    trim(value);
+    return PROJECTM_SUCCESS;
+}
+
+
+
+// parse init conditions, looking for function blocks, until '}
+int parse_object(const char *prefix_init, const char *prefix_eqn, std::istream & fs, std::ostream & os)
+{
+    std::string line;
+    std::string name, value, comment;
+    char prefix_buffer[30];
+
+    while (getline(fs,line))
+    {
+        trim(line);
+        if (line.empty())
+        {
+            os << std::endl;
+            continue;
+        }
+        else if (line == "}")
+        {
+            os << std::endl;
+            return PROJECTM_SUCCESS;
+        }
+
+        int ret = parse_assignment_line(line, name, value, comment);
+        if (ret != PROJECTM_SUCCESS)
+            return ret;
+
+        if (value == "{")
+        {
+            if (name != "per_frame_init" && name != "per_frame" &&  name != "per_point" && name != "per_pixel")
+            {
+                if (PARSE_DEBUG) printf("parse taffy: block name should be one of frame_init, per_frame, per_point, per_frame, per_pixel: %s\n", line.c_str());
+                return PROJECTM_PARSE_ERROR;
+            }
+
+            if (!strlen(prefix_init) && (name == "per_frame" || name == "per_frame_init" || name == "per_pixel"))
+                sprintf(prefix_buffer, "%s%s_", prefix_eqn, name.c_str());
+            else
+                sprintf(prefix_buffer, "%s%s", prefix_eqn, name.c_str());
+
+            os << std::endl;
+            ret = parse_equations(prefix_buffer, fs, os);
+            if (ret != PROJECTM_SUCCESS)
+                return ret;
+        }
+        else if (value == "\"\"\"")
+        {
+            std::string shader="comp";
+            std::string lang="hlsl";
+            if (name != "comp_hlsl" && name != "comp_glsl_330" && name != "warp_hlsl" && name != "warp_glsl_330")
+            {
+                if (PARSE_DEBUG) printf("parse taffy: shader name should be one of comp_hlsl, comp_glsl_330, warp, or warp_glsl_330: %s\n", line.c_str());
+                return PROJECTM_PARSE_ERROR;
+            }
+            if (name == "comp_glsl_330" || name == "warp_glsl_330")
+                lang = "glsl_330";
+            if (starts_with(name, "warp"))
+                shader = "warp";
+            os << shader << "_lang=" << lang << name << std::endl;
+            sprintf(prefix_buffer, "%s_", shader.c_str());
+            ret = parse_shader(prefix_buffer, fs, os);
+            if (ret != PROJECTM_SUCCESS)
+                return ret;
+        }
+        else
+        {
+            os << prefix_init << line << std::endl;
+        }
+    }
+    if (PARSE_DEBUG) printf("parse taffy: found EOF expected '}'\n");
+    return PROJECTM_PARSE_ERROR;
+}
+
+
+int parse_equations(const char *prefix, std::istream & fs, std::ostream & os)
+{
+    std::string line;
+    int line_no=0;
+
+    bool continue_line = false;
+    std::string newlines;
+
+    while (getline(fs,line))
+    {
+        trim(line);
+        if (starts_with(line, "//") || line.empty())
+        {
+            os << std::endl;
+            continue;
+        }
+        else if (line == "}")
+        {
+            os << std::endl;
+            return PROJECTM_SUCCESS;
+        }
+        else if (continue_line)
+        {
+            os << " " << line;
+            // collect a new line to keep things lined up
+            newlines.append("\n");
+        }
+        else
+        {
+            ++line_no;
+            os << prefix << line_no << (line_no <= 9 ? " = ":"= ") << line;
+            newlines = "";
+        }
+        if (ends_with(line, ";"))
+        {
+            os << std::endl;
+            os << newlines;
+            newlines = "";
+            continue_line = false;
+        }
+        else
+        {
+            continue_line = true;
+        }
+    }
+    if (PARSE_DEBUG) printf("parse taffy: found EOF expected '}'\n");
+    return PROJECTM_PARSE_ERROR;
+}
+
+
+int parse_shader(const char *prefix, std::istream & fs, std::ostream & os)
+{
+    int count=0;
+    std::string line;
+    while (getline(fs,line))
+    {
+        std::string trimmed = line;
+        trim(trimmed);
+        if (trimmed.empty())
+        {
+            os << std::endl;
+            continue;
+        }
+        else if (trimmed == "\"\"\"")
+        {
+            os << std::endl;
+            return PROJECTM_SUCCESS;
+        }
+        else
+        {
+            os << prefix << (++count) << "=`" << line << std::endl;
+        }
+    }
+    if (PARSE_DEBUG) printf("parse taffy: found EOF expected \"\"\"\n");
+    return PROJECTM_PARSE_ERROR;
+}

--- a/src/libprojectM/MilkdropPresetFactory/SaltWaterTaffyPreset.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/SaltWaterTaffyPreset.cpp
@@ -5,7 +5,7 @@
 #include "SaltWaterTaffyPreset.hpp"
 #include "Parser.hpp"
 #include "fatal.h"
-#include <stack>
+#include <cstring>
 
 
 int convert(std::istream & fs, std::ostream & os);

--- a/src/libprojectM/MilkdropPresetFactory/SaltWaterTaffyPreset.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/SaltWaterTaffyPreset.cpp
@@ -33,7 +33,9 @@ int SaltWaterTaffyPreset::readIn(std::istream & fs)
     if (ret != PROJECTM_SUCCESS)
         return ret;
     std::string converted = os.str();
-std::cerr << converted << std::endl;
+#if PARSE_DEBUG==2
+    std::cerr << converted << std::endl;
+#endif
     std::istringstream is(converted);
     return MilkdropPreset::readIn(is);
 }
@@ -258,7 +260,8 @@ int parse_object(const char *prefix_init, const char *prefix_eqn, std::istream &
                 lang = "glsl_330";
             if (starts_with(name, "warp"))
                 shader = "warp";
-            os << shader << "_lang=" << lang << name << std::endl;
+            // TODO enable this with the glsl branch
+            // os << shader << "_lang=" << lang << name << std::endl;
             sprintf(prefix_buffer, "%s_", shader.c_str());
             ret = parse_shader(prefix_buffer, fs, os);
             if (ret != PROJECTM_SUCCESS)

--- a/src/libprojectM/MilkdropPresetFactory/SaltWaterTaffyPreset.hpp
+++ b/src/libprojectM/MilkdropPresetFactory/SaltWaterTaffyPreset.hpp
@@ -1,0 +1,22 @@
+//
+// Created by matthew on 12/22/18.
+//
+
+#ifndef PROJECTM_GLSL_TAFFYPRESET_H
+#define PROJECTM_GLSL_TAFFYPRESET_H
+
+#include "MilkdropPreset.hpp"
+#include <iostream>
+#include <sstream>
+
+class SaltWaterTaffyPreset : public MilkdropPreset
+{
+public:
+    SaltWaterTaffyPreset(const std::string & absoluteFilePath, const std::string & presetName, PresetOutputs & presetOutputs);
+
+protected:
+    virtual int readIn(std::istream & fs) override;
+};
+
+
+#endif //PROJECTM_GLSL_TAFFYPRESET_H

--- a/src/libprojectM/Renderer/ShaderEngine.cpp
+++ b/src/libprojectM/Renderer/ShaderEngine.cpp
@@ -777,6 +777,7 @@ GLuint ShaderEngine::compilePresetShader(const PresentShaderType shaderType, Sha
             out3.close();
 #endif
     }
+    std::cerr.flush();
 
     return ret;
 }

--- a/taffy.py
+++ b/taffy.py
@@ -1,0 +1,445 @@
+#! /usr/bin/python3
+import sys
+import re
+
+STRING_RW = 'float rw'
+FLOAT_RW = 'float rw'
+FLOAT_R = 'float r'
+INT_RW = 'int rw'
+INT_R = 'int r'
+BOOL_RW = 'bool rw'
+BOOL_R = 'bool r'
+NUM_Q_VARIABLES = 64
+
+preset_vars = {}
+matrix_vars = {}
+shape_vars = {}
+# TODO point_vars
+wave_vars = {}
+
+def init_variable_definitions():
+    for s in ["frating", "fwavescale", "gamma", "fGammaAdj", "echo_zoom", "fVideoEchoZoom", "echo_alpha", "fvideoechoalpha",
+              "wave_a", "fwavealpha",
+              "fwavesmoothing", "fmodwavealphastart", "fmodwavealphaend", "fWarpAnimSpeed", "fWarpScale", "fshader",
+              "decay", "fdecay",
+              "b1n", "b2n", "b3n", "b1x", "b2x", "b3x", "b1ed", "wave_r", "wave_g", "wave_b", "wave_x", "wave_y",
+              "wave_mystery", "fWaveParam",
+              "ob_size", "ob_r", "ob_g", "ob_b", "ob_a",
+              "ib_size", "ib_r", "ib_g", "ib_b", "ib_a",
+              "mv_r", "mv_g", "mv_b", "mv_x", "nmotionvectorsx", "mv_y", "nmotionvectorsy", "mv_l", "mv_dx", "mv_dy",
+              "mv_a"]:
+        preset_vars[s.lower()] = FLOAT_RW
+    for s in ["echo_orient", "nVideoEchoOrientation", "wave_mode", "nwavemode"]:
+        preset_vars[s.lower()] = INT_RW
+    for s in ["wave_additive", "bAdditiveWaves", "bmodwavealphabyvolume", "wave_brighten", "bMaximizeWaveColor", "wrap",
+              "btexwrap",
+              "darken_center", "bdarkencenter", "bredbluestereo", "brighten", "bbrighten", "darken", "bdarken", "solarize",
+              "bsolarize",
+              "invert", "binvert", "bmotionvectorson", "wave_dots", "bwavedots", "wave_thick", "bwavethick"]:
+        preset_vars[s.lower()] = BOOL_RW
+
+    # read-only
+    for s in ["time", "bass", "mid", "treb", "bass_att", "mid_att", "treb_att", "progress"]:
+        preset_vars[s] = FLOAT_R
+    preset_vars['frame'] = INT_R
+    preset_vars['fps'] = INT_R
+    preset_vars['meshx'] = INT_R
+    preset_vars['meshy'] = INT_R
+
+    # matrix variables
+    for s in ["warp", "zoom", "rot", "zoomexp", "fzoomexponent", "cx", "cy", "dx", "dy", "sx", "sy"]:
+        preset_vars[s] = FLOAT_RW
+        matrix_vars[s] = FLOAT_RW
+    for s in ["x", "y", "ang", "rad"]:
+        matrix_vars[s] = FLOAT_R
+
+    for i in range(0, NUM_Q_VARIABLES):
+        preset_vars['q' + str(i)] = FLOAT_RW
+        matrix_vars['q' + str(i)] = FLOAT_RW
+
+    # shape
+    for s in ["r", "g", "b", "a", "border_r", "border_g", "border_b", "border_a", "r2", "g2", "b2", "a2", "x", "y",
+              "thickoutline", "enabled", "sides", "additive", "textured", "rad", "ang", "tex_zoom", "tex_ang",
+              ]:
+        shape_vars[s] = FLOAT_RW
+    for i in range(0, 8):
+        shape_vars['t' + str(i)] = FLOAT_RW
+    for i in range(0, NUM_Q_VARIABLES):
+        shape_vars['q' + str(i)] = FLOAT_RW
+    shape_vars['imageurl'] = STRING_RW
+    # TODO shape_points
+
+
+    # wave
+    for s in ["r", "g", "b", "a", "x", "y", "smoothing", "scaling"]:
+        wave_vars[s] = FLOAT_RW
+    for s in ["enabled", "bspectrum", "bdrawthick", "busedots", "badditive"]:
+        wave_vars[s] = BOOL_RW
+    for s in ["sep", "samples"]:
+        wave_vars[s] = INT_RW
+    for i in range(0, 8):
+        wave_vars['t' + str(i)] = FLOAT_RW
+    for i in range(0, NUM_Q_VARIABLES):
+        wave_vars['q' + str(i)] = FLOAT_RW
+
+
+    # TODO wave_points
+    # int [sample int_r
+    # float value1 float_r
+    # float value2 float_r
+
+
+class Shape:
+    def __init__(self, name):
+        self.name = str(name)
+        self.frame_eqns = []
+        self.point_eqns = []
+        self.variables = []
+        self.comments = []
+
+
+class Preset:
+    def __init__(self):
+        self.name = ''
+        self.variables = []
+        self.frame_init_eqns = []
+        self.frame_eqns = []
+        self.pixel_eqns = []
+        self.waves = []
+        self.shapes = []
+        self.comp_lang = 'hlsl'
+        self.comp = []
+        self.warp_lang = 'hlsl'
+        self.warp = []
+        self.comments = []
+
+    def get_shape(self, i):
+        i = int(i)
+        while len(self.shapes) <= int(i):
+            self.shapes.append(Shape(len(self.shapes)))
+        return self.shapes[i]
+
+    def get_wave(self, i):
+        i = int(i)
+        while len(self.waves) <= int(i):
+            self.waves.append(Shape(len(self.waves)))
+        return self.waves[i]
+
+
+# 'parse' right hand side of expression, allow substition of identifiers
+def scan_expr(expr, ident_callback):
+    last = 0
+    ret = []
+    for m in re.finditer(r'[\w$]+(\s*\()?', expr):
+        ret.append(expr[last:m.start(0)])
+        last = m.end(0)
+        if (m.group(0).endswith('(')):
+            ret.append(m.group(0))
+            continue
+        ret.append(ident_callback(m.group(0)))
+    ret.append(expr[last:])
+    return ''.join(ret)
+
+
+##
+## MILKDROP
+##
+
+
+def parse_milk(lines):
+    preset = Preset()
+    for line in lines:
+        m = re.match(r'shape_(\d+)_per_(point|frame)(\d+)\s*=', line)
+        if m:
+            eqn = line[(len(m.group(0))):].strip()
+            shape = preset.get_shape(m.group(1))
+            if 'frame' == m.group(2):
+                shape.frame_eqns.append(eqn)
+            if 'point' == m.group(2):
+                shape.point_eqns.append(eqn)
+            continue
+        m = re.match(r'shapecode_(\d+)_(\w+)\s*=', line)
+        if m:
+            rhs = line[(len(m.group(0))):].strip()
+            shape = preset.get_shape(m.group(1))
+            shape.variables.append(m.group(2) + '=' + rhs)
+            continue
+        m = re.match(r'wave_(\d+)_per_(point|frame)(\d+)\s*=', line)
+        if m:
+            eqn = line[(len(m.group(0))):].strip()
+            wave = preset.get_wave(m.group(1))
+            if 'frame' == m.group(2):
+                wave.frame_eqns.append(eqn)
+            if 'point' == m.group(2):
+                wave.point_eqns.append(eqn)
+            continue
+        m = re.match(r'wavecode_(\d+)_(\w+)\s*=', line)
+        if m:
+            rhs = line[(len(m.group(0))):].strip()
+            wave = preset.get_wave(m.group(1))
+            wave.variables.append(m.group(2) + '=' + rhs)
+            continue
+        m = re.match(r'per_(frame_init|frame|pixel)_(\d+)\s*=', line)
+        if m:
+            eqn = line[(len(m.group(0))):].strip()
+            if 'frame_init' == m.group(1):
+                preset.frame_init_eqns.append(eqn)
+            elif 'frame' == m.group(1):
+                preset.frame_eqns.append(eqn)
+            elif 'pixel' == m.group(1):
+                preset.pixel_eqns.append(eqn)
+            continue
+        m = re.match(r'(comp|warp)_(\d+)\s*=', line)
+        if m:
+            code = line[(len(m.group(0))):]
+            if code.startswith('`'):
+                code = code[1:]
+            if 'comp' == m.group(1):
+                preset.comp.append(code)
+            else:
+                preset.warp.append(code)
+            continue
+
+        m = re.match(r'\[(\w+)\]', line)
+        if m:
+            if m.group(1) != 'preset00':
+                preset.name = m.group(1)
+            continue
+
+        m = re.match(r'(\w+)\s*=', line)
+        if m:
+            if 'comp_lang' == m.group(1).strip():
+                preset.comp_lang = line.substr(len(m.group(1))).strip()
+            if 'warp_lang' == m.group(1).strip():
+                preset.warp_lang = line.substr(len(m.group(1))).strip()
+            preset.variables.append(line.strip())
+        continue
+
+    return preset
+
+
+def dump_shape_milk(output, type, index, shape, scope=None, scope_vars=None):
+    prefix = type + "code_" + str(index) + "_"
+    for v in shape.variables:
+        output.write(prefix + v + "\n")
+    prefix = type + "_" + str(index) + "_per_frame"
+    for i in range(0, len(shape.frame_eqns)):
+        eqn = shape.frame_eqns[i]
+        output.write(prefix + str(i + 1) + '=' + eqn + "\n")
+    prefix = type + "_" + str(index) + "_per_point"
+    for i in range(0, len(shape.point_eqns)):
+        eqn = shape.point_eqns[i]
+        output.write(prefix + str(i + 1) + '=' + eqn + "\n")
+
+
+def dump_milk(output, preset, var_prefix=None):
+    output.write("[" + (preset.name||"preset00") + "]\n")
+    for variable in preset.variables:
+        output.write(variable + "\n")
+    for i in range(0, len(preset.frame_init_eqns)):
+        eqn = preset.frame_init_eqns[i]
+        output.write("per_frame_init_" + str(i + 1) + "=" + eqn + "\n")
+    for i in range(0, len(preset.frame_eqns)):
+        eqn = preset.frame_eqns[i]
+        output.write("per_frame_" + str(i + 1) + "=" + eqn + "\n")
+    for i in range(0, len(preset.pixel_eqns)):
+        eqn = preset.pixel_eqns[i]
+        output.write("per_pixel_" + str(i + 1) + "=" + eqn + "\n")
+
+    for i in range(0, len(preset.shapes)):
+        dump_shape_milk(output, "shape", i, preset.shapes[i])
+
+    for i in range(0, len(preset.waves)):
+        dump_shape_milk(output, "wave", i, preset.waves[i])
+
+    for i in range(0, len(preset.comp)):
+        output.write("comp_" + str(i + 1) + '=`' + preset.comp[i])
+    for i in range(0, len(preset.warp)):
+        output.write("warp_" + str(i + 1) + '=`' + preset.warp[i])
+
+    return
+
+
+##
+## TAFFY
+##
+
+
+BEGIN = '{'
+END= '}'
+OBJECT='var'
+FUNCTION='%s = {'
+SHADER_BEGIN='%s_%s = """'
+SHADER_END='"""'
+LINE_COMMENT = '//'
+
+
+USE_SCOPE = True
+VERBOSE = True
+
+
+def format_eqn(assignments, eqn, scope=None, scope_vars=None, outer_scope=None, outer_vars=None, var_prefix=None):
+    # TODO parse RHS of equations
+    eqn = eqn.strip()
+    if not eqn:
+        return ""
+    if eqn.startswith("//"):
+        return LINE_COMMENT + eqn[2:]
+    if -1 == eqn.find('='):
+        return eqn
+    if not scope_vars:
+        return eqn
+
+    var = eqn[0:eqn.find('=')].strip()
+    expr = eqn[eqn.find('=') + 1:]
+
+    def rename_user_var(ident):
+        return (var_prefix + ident) if ident in assignments and assignments[ident] == 'var' else ident
+
+    if var_prefix:
+        expr = scan_expr(expr, rename_user_var)
+
+    if var.lower() in scope_vars:
+        if assignments is not None:
+            assignments[var] = scope
+        if VERBOSE and (scope_vars[var.lower()] == FLOAT_R or scope_vars[var.lower()] == INT_R or scope_vars[
+            var.lower()] == BOOL_R):
+            return var + " = " + expr + "    # assigning to READ-ONLY variable?"
+        else:
+            return var + " = " + expr
+    elif assignments is not None and not var in assignments:
+        assignments[var] = 'var'
+
+    if var_prefix:
+        var = rename_user_var(var)
+    return var + " = " + expr
+
+
+def dump_eqns(output, eqns, scope=None, scope_vars=None, outer_scope=None, outer_vars=None, var_prefix=None):
+    if VERBOSE:
+        assignments = {}
+        for eqn in eqns:
+            format_eqn(assignments, eqn, scope, scope_vars, outer_scope, outer_vars)
+        user_variables = []
+        for k, v in assignments.items():
+            if v == 'var':
+                user_variables.append(k)
+        if len(user_variables):
+            output.write('    ' + LINE_COMMENT + ' user variables: ' + ','.join(user_variables) + '\n')
+    assignments = {}
+    for eqn in eqns:
+        line = format_eqn(assignments, eqn, scope, scope_vars, outer_scope, outer_vars, var_prefix=var_prefix)
+        output.write('    ' + line + "\n")
+
+
+def format_var(var, scope=None, scope_vars=None):
+    return var
+
+
+def dump_shape(output, type, shape, scope=None, scope_vars=None, var_prefix=None):
+    output.write("\n" + type + " '" + shape.name + "' " + BEGIN + "\n")
+
+    for v in shape.variables:
+        output.write("  " + format_var(v, scope, scope_vars) + "\n")
+
+    if (len(shape.frame_eqns)):
+        output.write("\n  " + (FUNCTION % "per_frame") + "\n")
+        assignments = {}
+        for eqn in shape.frame_eqns:
+            output.write("    " + format_eqn(assignments, eqn, "shape", scope_vars) + "\n")
+        output.write("  " + END + "\n")
+    if (len(shape.point_eqns)):
+        output.write("\n  " + (FUNCTION % "per_point") + "\n")
+        dump_eqns(output, shape.point_eqns, scope, scope_vars, var_prefix=var_prefix)
+        output.write("  " + END + "\n")
+    output.write(END + "\n")
+
+
+def dump_taffy(output, preset, var_prefix=None):
+
+    if preset.name:
+        output.write("preset '" + preset.name + "' " + BEGIN + "\n")
+    else:
+        output.write("preset " + BEGIN + "\n")
+
+    for variable in preset.variables:
+        if variable.startswith("comp_lang") or variable.startswith("warp_lang"):
+            continue
+        output.write("  " + format_var(variable, "preset", preset_vars) + "\n")
+
+    if len(preset.frame_init_eqns):
+        output.write("\n  " + (FUNCTION % "per_frame_init") + "\n")
+        assignments = {}
+        for eqn in preset.frame_init_eqns:
+            output.write("    " + format_eqn(assignments, eqn, "frame") + "\n")
+        output.write("  " + END + "\n")
+
+    if len(preset.frame_eqns):
+        output.write("\n  " + (FUNCTION % "per_frame") + "\n")
+        dump_eqns(output, preset.frame_eqns, "frame", preset_vars, var_prefix=var_prefix)
+        output.write("  " + END + "\n")
+
+    if len(preset.pixel_eqns):
+        output.write("\n  " + (FUNCTION % "per_pixel") + "\n")
+        dump_eqns(output, preset.pixel_eqns, "pixel", matrix_vars, "frame", preset_vars, var_prefix=var_prefix)
+        output.write("  " + END + "\n")
+
+    if preset.comp:
+        output.write('\n  ' + (SHADER_BEGIN % ('comp', preset.comp_lang)) + '\n')
+        for s in preset.comp:
+            output.write("    " + s)
+        output.write(SHADER_END + '\n')
+
+    if preset.warp:
+        output.write('\n  ' + (SHADER_BEGIN % ('warp', preset.warp_lang)) + '\n')
+        for s in preset.warp:
+            output.write("    " + s)
+        output.write(SHADER_END + '\n')
+
+    output.write(END + "\n\n")
+
+    for shape in preset.shapes:
+        dump_shape(output, "shape", shape, "shape", shape_vars)
+
+    for wave in preset.waves:
+        dump_shape(output, "wave", wave, "wave", wave_vars)
+
+
+init_variable_definitions()
+
+if __name__ == "__main__":
+    input_file = None
+    input = sys.stdin
+    output_file = None
+    output = sys.stdout
+    parse = parse_milk
+    dump = dump_taffy
+    for arg in sys.argv[1:]:
+        if arg == '--taffy':
+            pass
+        elif arg == '--milk':
+            # parse = parse_taffy
+            dump = dump_milk
+        elif not input_file:
+            input_file = arg
+        elif not output_file:
+            output_file = arg
+        else:
+            raise Exception("too many arguments")
+    if input_file and input_file != "-":
+        input = open(input_file, 'r')
+        if input_file.endswith('.salt'):
+            raise Exception("parse_saltwatertaffy is NYI")
+    if output_file and output_file != "-":
+        output = open(output_file, 'w')
+        if output_file.endswith('.milk'):
+            dump = dump_milk
+
+    try:
+        preset = parse(input)
+        if not preset.name or preset.name == 'preset00':
+            if input_file != '-':
+                preset.name = input_file
+        dump(output, preset, var_prefix='')
+    except UnicodeDecodeError as ex:
+        sys.stdout.write("error parsing file: " + input_file + "\n")


### PR DESCRIPTION
An easier to parse file format for milkdrop presets.  Obviously, not backward compatible (but convertable).  My goal was to be more readable/editable but could be mechanically translated to the current format.   Below is an example of first proposal  (abridged for length).

```
preset 'AdamFx 2 Geiss -Somewhat Distort Me 3_1' {
  MILKDROP_PRESET_VERSION=201
  PSVERSION=2
  PSVERSION_WARP=2
  PSVERSION_COMP=2
  fRating=4.000000
  fGammaAdj=1.000
  fDecay=1.000
  fVideoEchoZoom=2.000
  fVideoEchoAlpha=0.000
  nVideoEchoOrientation=0
  nWaveMode=1
  bAdditiveWaves=0
  bWaveDots=0
  bWaveThick=0
  bModWaveAlphaByVolume=1
  bMaximizeWaveColor=1
  bTexWrap=1
  bDarkenCenter=0
  bRedBlueStereo=0
  bBrighten=0
  bDarken=0
  bSolarize=0
  bInvert=0
  fWaveAlpha=8.200
  fWaveScale=1.013
  fWaveSmoothing=0.900
  fWaveParam=-0.280
  fModWaveAlphaStart=1.050
  fModWaveAlphaEnd=1.650
  fWarpAnimSpeed=1.000
  fWarpScale=2.853
  fZoomExponent=3.60000
  fShader=0.000
  zoom=1.02500
  rot=-0.02000
  cx=0.500
  cy=0.500
  dx=0.00000
  dy=0.00000
  warp=0.30900
  sx=1.00000
  sy=1.00000
  wave_r=0.700
  wave_g=0.650
  wave_b=0.700
  wave_x=0.500
  wave_y=0.500
  ob_size=0.010
  ob_r=0.000
  ob_g=0.000
  ob_b=0.000
  ob_a=0.500
  ib_size=0.010
  ib_r=0.250
  ib_g=0.250
  ib_b=0.250
  ib_a=0.500
  nMotionVectorsX=31.200
  nMotionVectorsY=2.280
  mv_dx=0.000
  mv_dy=0.000
  mv_l=2.500
  mv_r=1.000
  mv_g=1.000
  mv_b=0.800
  mv_a=0.000
  b1n=0.000
  b2n=0.000
  b3n=0.000
  b1x=1.000
  b2x=1.000
  b3x=1.000
  b1ed=0.250

  per_frame = {
    wave_r =  wave_r + 0.200*( 0.60*sin(0.933*time) + 0.40*sin(1.045*time) );
    wave_g =  wave_g + 0.200*( 0.60*sin(0.900*time) + 0.40*sin(0.956*time) );
    wave_b =  wave_b + 0.200*( 0.60*sin(0.910*time) + 0.40*sin(0.920*time) );
    zoom =  zoom + 0.023*( 0.60*sin(0.339*time) + 0.40*sin(0.276*time) );
    rot =  rot + 0.030*( 0.60*sin(0.381*time) + 0.40*sin(0.579*time) );
  }

  per_pixel = {
    zoom = zoom+0.03*sin((x*2-1)*4+time*1.63)+0.03*sin((y*2-1)*3+time*1.37)-0.1*sin(rad*0.1+time*1.6);
  }

  comp_hlsl = """
    shader_body
    {
        ret = tex2D(sampler_main, uv).xyz;    
    }
"""

  warp_hlsl = """
    shader_body
    {
        // sample previous frame
        ret = tex2D( sampler_main, uv ).xyz;
    
        // take the difference between the crisp and blurred images,
        // then add it back into the image.  Creates spots and stripes over time.
        ret += (ret - GetBlur2(uv))*0.3;
        ret *= 0.9;
    
       // add noise:
       float2 dither_uv = uv_orig*texsize.xy*texsize_noise_lq.zw * 0.4 + rand_frame.xy;
       ret += (tex2D(sampler_noise_lq, dither_uv).xyz-0.5)/256.0 
                   * 122 * saturate((treb_att-1)+0.4);
    
       // desaturate over time, to keep the globs white
       ret = lerp(ret, lum(ret), 0.2);
    }
"""
}

shape '0' {
  enabled=0
  sides=4
  additive=0
  thickOutline=0
  textured=0
  num_inst=1
  x=0.500
  y=0.500
  rad=0.10000
  ang=0.00000
  tex_ang=0.00000
  tex_zoom=1.00000
  r=1.000
  g=0.000
  b=0.000
  a=1.000
  r2=0.000
  g2=1.000
  b2=0.000
  a2=0.000
  border_r=1.000
  border_g=1.000
  border_b=1.000
  border_a=0.100
}
// ... SHAPES DELETED

wave '0' {
  enabled=0
  samples=512
  sep=0
  bSpectrum=0
  bUseDots=0
  bDrawThick=0
  bAdditive=0
  scaling=1.00000
  smoothing=0.50000
  r=1.000
  g=1.000
  b=1.000
  a=1.000
}
// ... WAVES DELETED
```