### PR TITLE
Preset outputs bug

### DIFF
--- a/src/libprojectM/MilkdropPresetFactory/IdlePreset.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/IdlePreset.cpp
@@ -198,12 +198,12 @@ return out.str();
 
 }
 
-std::unique_ptr<Preset> IdlePresets::allocate(const std::string & name, PresetOutputs & presetOutputs)
+std::unique_ptr<Preset> IdlePresets::allocate(MilkdropPresetFactory *factory, const std::string & name, PresetOutputs & presetOutputs)
 {
 
   if (name == IDLE_PRESET_NAME) {
   	std::istringstream in(presetText());
-  	return std::unique_ptr<Preset>(new MilkdropPreset(in, IDLE_PRESET_NAME, presetOutputs));
+  	return std::unique_ptr<Preset>(new MilkdropPreset(factory, in, IDLE_PRESET_NAME, presetOutputs));
   }
   else
     return std::unique_ptr<Preset>();

--- a/src/libprojectM/MilkdropPresetFactory/IdlePreset.hpp
+++ b/src/libprojectM/MilkdropPresetFactory/IdlePreset.hpp
@@ -3,8 +3,10 @@
 #include <memory>
 #include <string>
 
+class MilkdropPresetFactory;
 class PresetOutputs;
 class Preset;
+
 /// A preset that does not depend on the file system to be loaded. This allows projectM to render
 /// something (ie. self indulgent project advertising) even when no valid preset directory is found.
 class IdlePresets {
@@ -12,7 +14,7 @@ class IdlePresets {
   public:
 	/// Allocate a new idle preset instance
 	/// \returns a newly allocated auto pointer of an idle preset instance
-	static std::unique_ptr<Preset> allocate(const std::string & path, PresetOutputs & outputs);
+	static std::unique_ptr<Preset> allocate(MilkdropPresetFactory *factory, const std::string & path, PresetOutputs & outputs);
   private:
 	static std::string presetText();
 	static const std::string IDLE_PRESET_NAME;

--- a/src/libprojectM/MilkdropPresetFactory/MilkdropPreset.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/MilkdropPreset.cpp
@@ -42,28 +42,32 @@
 #include "PresetFrameIO.hpp"
 
 #include "PresetFactoryManager.hpp"
+#include "MilkdropPresetFactory.hpp"
 
 
-MilkdropPreset::MilkdropPreset(std::istream & in, const std::string & presetName,  PresetOutputs & presetOutputs):
+MilkdropPreset::MilkdropPreset(MilkdropPresetFactory *factory, std::istream & in, const std::string & presetName,  PresetOutputs & presetOutputs):
 	Preset(presetName),
-    	builtinParams(_presetInputs, presetOutputs),
-    	_presetOutputs(presetOutputs)
+    builtinParams(_presetInputs, presetOutputs),
+    _factory(factory),
+    _presetOutputs(presetOutputs)
 {
   initialize(in);
-
 }
 
-MilkdropPreset::MilkdropPreset(const std::string & absoluteFilePath, const std::string & presetName, PresetOutputs & presetOutputs):
+
+MilkdropPreset::MilkdropPreset(MilkdropPresetFactory *factory, const std::string & absoluteFilePath, const std::string & presetName, PresetOutputs & presetOutputs):
 	Preset(presetName),
     builtinParams(_presetInputs, presetOutputs),
     _filename(parseFilename(absoluteFilePath)),
     _absoluteFilePath(absoluteFilePath),
+    _factory(factory),
     _presetOutputs(presetOutputs)
 {
 
   initialize(absoluteFilePath);
-
 }
+
+
 MilkdropPreset::~MilkdropPreset()
 {
 
@@ -94,6 +98,9 @@ MilkdropPreset::~MilkdropPreset()
   }
   customWaves.clear();
   customShapes.clear();
+
+  if (nullptr != _factory)
+      _factory->releasePreset(this);
 }
 
 /* Adds a per pixel equation according to its string name. This

--- a/src/libprojectM/MilkdropPresetFactory/MilkdropPreset.hpp
+++ b/src/libprojectM/MilkdropPresetFactory/MilkdropPreset.hpp
@@ -47,6 +47,7 @@
 #include "InitCond.hpp"
 #include "Preset.hpp"
 
+class MilkdropPresetFactory;
 class CustomWave;
 class CustomShape;
 class InitCond;
@@ -63,14 +64,14 @@ public:
   /// \param MilkdropPresetName a descriptive name for the MilkdropPreset. Usually just the file name
   /// \param MilkdropPresetInputs a reference to read only projectM engine variables
   /// \param MilkdropPresetOutputs initialized and filled with data parsed from a MilkdropPreset
-  MilkdropPreset(const std::string & absoluteFilePath, const std::string & milkdropPresetName, PresetOutputs & presetOutputs);
+  MilkdropPreset(MilkdropPresetFactory *factory, const std::string & absoluteFilePath, const std::string & milkdropPresetName, PresetOutputs & presetOutputs);
 
   ///  Load a MilkdropPreset from an input stream with input and output buffers specified.
   /// \param in an already initialized input stream to read the MilkdropPreset file from
   /// \param MilkdropPresetName a descriptive name for the MilkdropPreset. Usually just the file name
   /// \param MilkdropPresetInputs a reference to read only projectM engine variables
   /// \param MilkdropPresetOutputs initialized and filled with data parsed from a MilkdropPreset
-  MilkdropPreset(std::istream & in, const std::string & milkdropPresetName, PresetOutputs & presetOutputs);
+  MilkdropPreset(MilkdropPresetFactory *factory, std::istream & in, const std::string & milkdropPresetName, PresetOutputs & presetOutputs);
 
   ~MilkdropPreset();
 
@@ -173,11 +174,14 @@ private:
 
   void preloadInitialize();
   void postloadInitialize();
-  
+
+  MilkdropPresetFactory *_factory;
   PresetOutputs & _presetOutputs;
 
 template <class CustomObject>
 void transfer_q_variables(std::vector<CustomObject*> & customObjects);
+
+friend class MilkdropPresetFactory;
 };
 
 

--- a/src/libprojectM/MilkdropPresetFactory/MilkdropPresetFactory.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/MilkdropPresetFactory.cpp
@@ -17,7 +17,7 @@
 #include "IdlePreset.hpp"
 #include "PresetFrameIO.hpp"
 
-MilkdropPresetFactory::MilkdropPresetFactory(int gx_, int gy_): gx(gx_), gy(gy_), _presetOutputs(nullptr), _presetOutputs2(nullptr)
+MilkdropPresetFactory::MilkdropPresetFactory(int gx_, int gy_): gx(gx_), gy(gy_), _presetOutputsCache(nullptr)
 {
 	/* Initializes the builtin function database */
 	BuiltinFuncs::init_builtin_func_db();
@@ -33,10 +33,8 @@ MilkdropPresetFactory::~MilkdropPresetFactory() {
 //	std::cerr << "[~MilkdropPresetFactory] destroy builtin func" << std::endl;
 	BuiltinFuncs::destroy_builtin_func_db();
 //	std::cerr << "[~MilkdropPresetFactory] delete preset out puts" << std::endl;
-	delete(_presetOutputs);
-        delete(_presetOutputs2);
+	delete(_presetOutputsCache);
 //	std::cerr << "[~MilkdropPresetFactory] done" << std::endl;
-
 }
 
 /* Reinitializes the engine variables to a default (conservative and sane) value */
@@ -144,10 +142,8 @@ void resetPresetOutputs(PresetOutputs * presetOutputs)
 void MilkdropPresetFactory::reset()
 {
 
-    if (_presetOutputs)
-        resetPresetOutputs(_presetOutputs);
-    if (_presetOutputs2)
-        resetPresetOutputs(_presetOutputs2);
+    if (_presetOutputsCache)
+        resetPresetOutputs(_presetOutputsCache);
 }
 
 PresetOutputs* MilkdropPresetFactory::createPresetOutputs(int gx, int gy)
@@ -215,15 +211,10 @@ std::unique_ptr<Preset> MilkdropPresetFactory::allocate(const std::string & url,
 
     PresetOutputs *presetOutputs;
     // use cached PresetOutputs if there is one, otherwise allocate
-    if (_presetOutputs)
+    if (_presetOutputsCache)
     {
-        presetOutputs = _presetOutputs;
-        _presetOutputs = nullptr;
-    }
-    else if (_presetOutputs2)
-    {
-        presetOutputs = _presetOutputs2;
-        _presetOutputs2 = nullptr;
+        presetOutputs = _presetOutputsCache;
+        _presetOutputsCache = nullptr;
     }
     else
     {
@@ -244,10 +235,8 @@ void MilkdropPresetFactory::releasePreset(Preset *preset_)
 {
     MilkdropPreset *preset = (MilkdropPreset *)preset_;
     // return PresetOutputs to the cache
-    if (nullptr == _presetOutputs)
-        _presetOutputs = &preset->_presetOutputs;
-    else if (nullptr == _presetOutputs2)
-        _presetOutputs2 = &preset->_presetOutputs;
+    if (nullptr == _presetOutputsCache)
+        _presetOutputsCache = &preset->_presetOutputs;
     else
         delete &preset->_presetOutputs;
 }

--- a/src/libprojectM/MilkdropPresetFactory/MilkdropPresetFactory.hpp
+++ b/src/libprojectM/MilkdropPresetFactory/MilkdropPresetFactory.hpp
@@ -39,8 +39,7 @@ private:
 	void reset();
 	int gx;
 	int gy;
-	PresetOutputs * _presetOutputs;
-    PresetOutputs * _presetOutputs2;
+	PresetOutputs * _presetOutputsCache;
 	//PresetInputs _presetInputs;
 };
 

--- a/src/libprojectM/MilkdropPresetFactory/MilkdropPresetFactory.hpp
+++ b/src/libprojectM/MilkdropPresetFactory/MilkdropPresetFactory.hpp
@@ -31,12 +31,16 @@ public:
 
  std::string supportedExtensions() const { return "milk prjm"; }
 
+ // called by ~MilkdropPreset
+  void releasePreset(Preset *preset);
+
 private:
     static PresetOutputs* createPresetOutputs(int gx, int gy);
 	void reset();
+	int gx;
+	int gy;
 	PresetOutputs * _presetOutputs;
     PresetOutputs * _presetOutputs2;
-    bool _usePresetOutputs;
 	//PresetInputs _presetInputs;
 };
 

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -736,12 +736,6 @@ static void *thread_callback(void *prjm) {
     void projectM::switchPreset(const bool hardCut) {
 		std::string result;
 
-        // if we're already switching, promote the current m_activePreset2
-        // see note in switchPreset() about not having too many presets allocated at once
-        if (m_activePreset2 != nullptr)
-            m_activePreset.swap(m_activePreset2);
-        m_activePreset2 = nullptr;
-
 		if (!hardCut) {
 			result = switchPreset(m_activePreset2);
 		} else {
@@ -810,16 +804,7 @@ std::string projectM::switchPreset(std::unique_ptr<Preset> & targetPreset) {
 	pthread_mutex_lock(&preset_mutex);
 	#endif
 	try {
-	    // NOTE SUBTLE BUG!
-        // MilkdropPresetFactory acts as if there can only ever be two presets allocated at a time, and so only
-        // allocates two PresetOutputs objects.  However, this is not true.  If we are in the middle of a soft transition
-        // already, we can have three.  m_activePreset, m_activePreset2, and the one we are about to allocate()
-        // to avoid very strange missing objects (waves/shapes), make sure to free the targetPreset BEFORE calling allocate()
-        //   but wait there is more...
-        // Just because we make sure we never have two presets allocated at once, isn't enough.  We actually
-        // have make sure we release the first allocated preset (or both presets) to make sure we're alternating.
-        // Otherwise, the two allocated presets may be pointing at the same PresetOutputs object.
-        // CONSIDER actually allocating or ref-counting PresetOutputs, or allocating more of them or something.
+	    // nice to free preset resources, before allocation new preset
         targetPreset = nullptr;
         targetPreset = m_presetPos->allocate();
 	} catch (const PresetFactoryException & e) {


### PR DESCRIPTION
This is a more complete fix for PresetOutput allocation bug.  Uses allocate/release pattern so MilkdropPresetFactory doesn't guess which PresetOutput is available, keeps a one object cache to save time.  This removes assumptions about projectM behavior for MilkdropPresetFactory to behave correctly.