### PR TITLE
handle 2ch floating point PCM data

### DIFF
--- a/src/libprojectM/PCM.cpp
+++ b/src/libprojectM/PCM.cpp
@@ -143,17 +143,17 @@ void PCM::addPCMfloat_2ch(const float *PCMdata, int samples)
 {
     int i,j;
 
-    for(i=0;i<samples/2;i++)
+    for(i=0;i<samples;i+=2)
     {
         j=(i/2)+start;
         PCMd[0][j%maxsamples] = PCMdata[i];
         PCMd[1][j%maxsamples] = PCMdata[i+1];
     }
 
-    start+=samples;
+    start+=samples/2;
     start=start%maxsamples;
 
-    newsamples+=samples;
+    newsamples+=samples/2;
     if (newsamples>maxsamples)
         newsamples=maxsamples;
     numsamples = getPCMnew(pcmdataR,1,0,waveSmoothing,0,0);

--- a/src/libprojectM/PCM.cpp
+++ b/src/libprojectM/PCM.cpp
@@ -138,6 +138,31 @@ void PCM::addPCMfloat(const float *PCMdata, int samples)
     getPCM(vdataR,512,1,1,0,0);
 }
 
+
+void PCM::addPCMfloat_2ch(const float *PCMdata, int samples)
+{
+    int i,j;
+
+    for(i=0;i<samples;i+=2)
+    {
+        j=i+start;
+        PCMd[0][j%maxsamples] = PCMdata[i];
+        PCMd[1][j%maxsamples] = PCMdata[i+1];
+    }
+
+    start+=samples;
+    start=start%maxsamples;
+
+    newsamples+=samples;
+    if (newsamples>maxsamples)
+        newsamples=maxsamples;
+    numsamples = getPCMnew(pcmdataR,1,0,waveSmoothing,0,0);
+    getPCMnew(pcmdataL,0,0,waveSmoothing,0,1);
+    getPCM(vdataL,512,0,1,0,0);
+    getPCM(vdataR,512,1,1,0,0);
+}
+
+
 void PCM::addPCM16Data(const short* pcm_data, short samples)  {
    int i, j;
 

--- a/src/libprojectM/PCM.cpp
+++ b/src/libprojectM/PCM.cpp
@@ -143,9 +143,9 @@ void PCM::addPCMfloat_2ch(const float *PCMdata, int samples)
 {
     int i,j;
 
-    for(i=0;i<samples;i+=2)
+    for(i=0;i<samples/2;i++)
     {
-        j=i+start;
+        j=(i/2)+start;
         PCMd[0][j%maxsamples] = PCMdata[i];
         PCMd[1][j%maxsamples] = PCMdata[i+1];
     }

--- a/src/libprojectM/PCM.hpp
+++ b/src/libprojectM/PCM.hpp
@@ -59,6 +59,7 @@ public:
     PCM();
     ~PCM();
     void addPCMfloat(const float *PCMdata, int samples);
+    void addPCMfloat_2ch(const float *PCMdata, int samples);
     void addPCM16(short [2][512]);
     void addPCM16Data(const short* pcm_data, short samples);
     void addPCM8( unsigned char [2][1024]);

--- a/src/projectM-qt/qprojectm_mainwindow.cpp
+++ b/src/projectM-qt/qprojectm_mainwindow.cpp
@@ -242,7 +242,7 @@ projectM * QProjectM_MainWindow::GetProjectM()
 
 void QProjectM_MainWindow::addPCM(float * buffer, unsigned int bufferSize) {
 
-	qprojectM()->pcm()->addPCMfloat(buffer, bufferSize);
+	qprojectM()->pcm()->addPCMfloat_2ch(buffer, bufferSize);
 }
 
 void QProjectM_MainWindow::updatePlaylistSelection ( bool hardCut, unsigned int index )


### PR DESCRIPTION
pulseaudio app asks for PA_SAMPLE_FLOAT32LE but doesn't separate left and right channels, so in per_point equations value1==value2

	sample_spec.format = PA_SAMPLE_FLOAT32LE;
	sample_spec.rate = 44100;
	sample_spec.channels = 2;

see _Mig_304 - geiss remix 3.milk