### PR TITLE
Fix non-SSE2 init_mesh variant, unbreak loop check for y

### DIFF
--- a/src/libprojectM/MilkdropPresetFactory/MilkdropPreset.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/MilkdropPreset.cpp
@@ -407,7 +407,7 @@ inline void init_mesh(float **mesh, const float value, const int gx, const int g
 inline void init_mesh(float **mesh, const float value, const int gx, const int gy)
 {
     for (x=0;x<gx;x++)
-        for(y=0;gy;y++)
+        for(y=0;y<gy;y++)
             mesh[x,y] = value;
 }
 #endif


### PR DESCRIPTION
Hi. Quick introduction: I am currently looking into making some QtQuick modules around libprojectM as a personal challenge to learn something new, given I have no clue about openGL :)
Initial goal of the experiment: create a projectM-based Plasma wallpaper plugin (can be shown both as normal background, but also on the lockscreen) as well as a projectM-based Plasma widget/applet, as external visualization of pulseaudio streams.
Nice-to-have follow-up goal: turn the created QtQuick module also useful for any QtQucik-based media players.
The Plasma side of things is no issue for me, have done some plugins before, as well as last week wrapped some Qt openGL tutorial examples into respective wallpaper & widget plugins for testing, so that in principle works :)

For now I am doing lots of try & error changes to all parts in the code to get started. Not sure if I will succeed in the time I gave myself.
Once I have become more familiar as far as I can get on my own, I then plan to come approaching you for help where needed to integrate the direct openGL API calls of libprojectM with what QQuickFramebufferObject expects to work together.

Looking at the recent commits I found this small glitch in the Perf cleanup (#151) commit, but only from reading the code, i.e. fix untested. So here my little "present" on the first-time contact :)