### PR TITLE
Fix Milkdrop Preset parser to read floats always in C locale

### DIFF
--- a/src/libprojectM/MilkdropPresetFactory/Parser.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/Parser.cpp
@@ -24,6 +24,7 @@
 #include <string>
 #include <cstring>
 #include <iostream>
+#include <locale>
 #include <stdlib.h>
 
 #include "Common.hpp"
@@ -1287,26 +1288,17 @@ int Parser::parse_int(std::istream &  fs, int * int_ptr)
 int Parser::string_to_float(char * string, float * float_ptr)
 {
 
-  char ** error_ptr;
-
   if (*string == 0)
     return PROJECTM_PARSE_ERROR;
 
-  error_ptr = (char**)wipemalloc(sizeof(char**));
-
-  (*float_ptr) = strtod(string, error_ptr);
-
-  /* These imply a succesful parse of the string */
-  if ((**error_ptr == '\0') || (**error_ptr == '\r'))
-  {
-    free(error_ptr);
-    error_ptr = NULL;
+  std::istringstream iss(string);
+  iss.imbue(std::locale("C"));
+  iss >> (*float_ptr);
+  if (!iss.fail()) {
     return PROJECTM_SUCCESS;
   }
 
   (*float_ptr) = 0;
-  free(error_ptr);
-  error_ptr = NULL;
   return PROJECTM_PARSE_ERROR;
 }
 
@@ -1315,11 +1307,8 @@ int Parser::parse_float(std::istream &  fs, float * float_ptr)
 {
 
   char string[MAX_TOKEN_SIZE];
-  char ** error_ptr;
   token_t token;
   int sign;
-
-  error_ptr =(char**) wipemalloc(sizeof(char**));
 
   token = parseToken(fs, string);
 
@@ -1339,26 +1328,20 @@ int Parser::parse_float(std::istream &  fs, float * float_ptr)
 
   if (string[0] == 0)
   {
-    free(error_ptr);
-    error_ptr = NULL;
     return PROJECTM_PARSE_ERROR;
   }
 
-  (*float_ptr) = sign*strtod(string, error_ptr);
-
-  /* No conversion was performed */
-  if ((**error_ptr == '\0') || (**error_ptr == '\r'))
-  {
-    free(error_ptr);
-    error_ptr = NULL;
+  std::istringstream iss(string);
+  iss.imbue(std::locale("C"));
+  iss >> (*float_ptr);
+  if (!iss.fail()) {
+    (*float_ptr) *= sign;
     return PROJECTM_SUCCESS;
   }
 
   if (PARSE_DEBUG) printf("parse_float: float conversion failed for string \"%s\"\n", string);
 
   (*float_ptr) = 0;
-  free(error_ptr);
-  error_ptr = NULL;
   return PROJECTM_PARSE_ERROR;
 
 }

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -469,15 +469,11 @@ void projectM::projectM_reset()
 
     this->fpsstart = 0;
 
-    setlocale(LC_NUMERIC, "C");
-
     projectM_resetengine();
 }
 
 void projectM::projectM_init ( int gx, int gy, int fps, int texsize, int width, int height )
 {
-    setlocale(LC_NUMERIC, "C");
-
     /** Initialise start time */
     timeKeeper = new TimeKeeper(_settings.presetDuration,_settings.smoothPresetDuration, _settings.easterEgg);
 

--- a/src/projectM-jack/qprojectM-jack.cpp
+++ b/src/projectM-jack/qprojectM-jack.cpp
@@ -205,7 +205,6 @@ int main (int argc, char **argv) {
 
 	// Start a new application
 	ProjectMApplication app(argc, argv);
-	setlocale(LC_NUMERIC, "C");  // Fix
 
 	std::string config_file;
 	config_file = read_config();

--- a/src/projectM-pulseaudio/qprojectM-pulseaudio.cpp
+++ b/src/projectM-pulseaudio/qprojectM-pulseaudio.cpp
@@ -116,7 +116,6 @@ int main ( int argc, char*argv[] )
 
 	ProjectMApplication app ( argc, argv );
 
-	setlocale(LC_NUMERIC, "C");  // Fix
 	std::string config_file;
 	config_file = read_config();
 


### PR DESCRIPTION
Also remove calls of setlocale(LC_NUMERIC, "C"); in library,
which results in unexpected sideeffects in the rest of the process
where the library is used.
Same for the applications which also had this work-around added.

Work-arounds using setlocale had been added in
90aa2c8f381c7bf35496536acd015b84533cd596 & 196c374a74a158eacd806469311f2b701cbc3849