### PR TITLE
Allocate PerlinNoise dynamically / Fix thread detach after join

### DIFF
--- a/src/libprojectM/Renderer/TextureManager.cpp
+++ b/src/libprojectM/Renderer/TextureManager.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <vector>
+#include <memory>
 
 #include "projectM-opengl.h"
 
@@ -84,12 +85,12 @@ TextureManager::TextureManager(const std::string _presetsURL, const int texsizeX
         blurTextures.push_back(textureBlur);
     }
 
-    PerlinNoise noise;
+    std::unique_ptr<PerlinNoise> noise(new PerlinNoise());
 
     GLuint noise_texture_lq_lite;
     glGenTextures(1, &noise_texture_lq_lite);
     glBindTexture(GL_TEXTURE_2D, noise_texture_lq_lite);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 32, 32, 0, GL_RGB, GL_FLOAT, noise.noise_lq_lite);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 32, 32, 0, GL_RGB, GL_FLOAT, noise->noise_lq_lite);
     Texture * textureNoise_lq_lite = new Texture("noise_lq_lite", noise_texture_lq_lite, GL_TEXTURE_2D, 32, 32, false);
     textureNoise_lq_lite->getSampler(GL_REPEAT, GL_LINEAR);
     textures["noise_lq_lite"] = textureNoise_lq_lite;
@@ -97,7 +98,7 @@ TextureManager::TextureManager(const std::string _presetsURL, const int texsizeX
     GLuint noise_texture_lq;
     glGenTextures(1, &noise_texture_lq);
     glBindTexture(GL_TEXTURE_2D, noise_texture_lq);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 256, 0, GL_RGB, GL_FLOAT, noise.noise_lq);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 256, 0, GL_RGB, GL_FLOAT, noise->noise_lq);
     Texture * textureNoise_lq = new Texture("noise_lq", noise_texture_lq, GL_TEXTURE_2D, 256, 256, false);
     textureNoise_lq->getSampler(GL_REPEAT, GL_LINEAR);
     textures["noise_lq"] = textureNoise_lq;
@@ -105,7 +106,7 @@ TextureManager::TextureManager(const std::string _presetsURL, const int texsizeX
     GLuint noise_texture_mq;
     glGenTextures(1, &noise_texture_mq);
     glBindTexture(GL_TEXTURE_2D, noise_texture_mq);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 256, 0, GL_RGB, GL_FLOAT, noise.noise_mq);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 256, 0, GL_RGB, GL_FLOAT, noise->noise_mq);
     Texture * textureNoise_mq = new Texture("noise_mq", noise_texture_mq, GL_TEXTURE_2D, 256, 256, false);
     textureNoise_mq->getSampler(GL_REPEAT, GL_LINEAR);
     textures["noise_mq"] = textureNoise_mq;
@@ -113,7 +114,7 @@ TextureManager::TextureManager(const std::string _presetsURL, const int texsizeX
     GLuint noise_texture_hq;
     glGenTextures(1, &noise_texture_hq);
     glBindTexture(GL_TEXTURE_2D, noise_texture_hq);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 256, 0, GL_RGB, GL_FLOAT, noise.noise_hq);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 256, 0, GL_RGB, GL_FLOAT, noise->noise_hq);
     Texture * textureNoise_hq = new Texture("noise_hq", noise_texture_hq, GL_TEXTURE_2D, 256, 256, false);
     textureNoise_hq->getSampler(GL_REPEAT, GL_LINEAR);
     textures["noise_hq"] = textureNoise_hq;
@@ -121,7 +122,7 @@ TextureManager::TextureManager(const std::string _presetsURL, const int texsizeX
     GLuint noise_texture_lq_vol;
     glGenTextures( 1, &noise_texture_lq_vol );
     glBindTexture( GL_TEXTURE_3D, noise_texture_lq_vol );
-    glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA, 32 ,32 ,32 ,0 ,GL_RGB ,GL_FLOAT ,noise.noise_lq_vol);
+    glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA, 32 ,32 ,32 ,0 ,GL_RGB ,GL_FLOAT ,noise->noise_lq_vol);
     Texture * textureNoise_lq_vol = new Texture("noisevol_lq", noise_texture_lq_vol, GL_TEXTURE_3D, 32, 32, false);
     textureNoise_lq_vol->getSampler(GL_REPEAT, GL_LINEAR);
     textures["noisevol_lq"] = textureNoise_lq_vol;
@@ -129,7 +130,7 @@ TextureManager::TextureManager(const std::string _presetsURL, const int texsizeX
     GLuint noise_texture_hq_vol;
     glGenTextures( 1, &noise_texture_hq_vol );
     glBindTexture( GL_TEXTURE_3D, noise_texture_hq_vol );
-    glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA, 32, 32, 32, 0, GL_RGB, GL_FLOAT, noise.noise_hq_vol);
+    glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA, 32, 32, 32, 0, GL_RGB, GL_FLOAT, noise->noise_hq_vol);
     Texture * textureNoise_hq_vol = new Texture("noisevol_hq", noise_texture_hq_vol, GL_TEXTURE_3D, 32, 32, false);
     textureNoise_hq_vol->getSampler(GL_REPEAT, GL_LINEAR);
     textures["noisevol_hq"] = textureNoise_hq_vol;

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -76,8 +76,6 @@ projectM::~projectM()
     worker_sync.finish_up();
     printf("e");
     pthread_join(thread, &status);
-    printf("a");
-    pthread_detach(thread);
     printf("n");
     #ifdef SYNC_PRESET_SWITCHES
     pthread_mutex_destroy( &preset_mutex );


### PR DESCRIPTION
1.) There are some devices around (AFTV 2017 for example) which have limited stack size.
PerlinNoise is huge in size and leads to stack overflow -> crash if used in kodi.

2.) if pthread_join is called the thread is in some implementations in a not joinable mode and cannot be detached. Because there is no need to detach a thread after join, the detach was removed.