### PR TITLE
Add GLES into automake build / fix android compile string

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -139,8 +139,10 @@ AC_PREFIX_DEFAULT([/usr/local])
 
 AC_PROG_MKDIR_P
 
-AX_CHECK_COMPILE_FLAG([-stdlib=libc++], [
+AS_IF([grep android <<< ${host}], [],
+  [AX_CHECK_COMPILE_FLAG([-stdlib=libc++], [
                         CXXFLAGS="$CXXFLAGS -stdlib=libc++"])
+])
 
 AX_CHECK_COMPILE_FLAG([-std=c++11], [
                         CXXFLAGS="$CXXFLAGS -std=c++11"])

--- a/m4/autoconf-archive/ax_check_gl.m4
+++ b/m4/autoconf-archive/ax_check_gl.m4
@@ -97,6 +97,8 @@ m4_define([_AX_CHECK_GL_PROGRAM],
 #   include <GL/gl.h>
 # elif defined(HAVE_OPENGL_GL_H)
 #   include <OpenGL/gl.h>
+# elif defined(HAVE_GLES_GL_H)
+#   include <GLES/gl.h>
 # else
 #   error no gl.h
 # endif
@@ -274,7 +276,7 @@ AC_DEFUN([AX_CHECK_GL],
 
  dnl this was cache
  _AX_CHECK_GL_SAVE_FLAGS([CFLAGS])
- AC_CHECK_HEADERS([GL/gl.h OpenGL/gl.h],
+ AC_CHECK_HEADERS([GL/gl.h OpenGL/gl.h GLES/gl.h],
    [ax_check_gl_have_headers="yes";break])
  _AX_CHECK_GL_RESTORE_FLAGS([CFLAGS])
 


### PR DESCRIPTION
This PR changes adds GLES detection in configure step.