### PR TITLE
Sort input file list

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,7 @@ pm_font__DATA = fonts/Vera.ttf fonts/VeraMono.ttf
 # find and install all preset files
 install-data-local:
 	test -z $(DESTDIR)$(pkgdatadir) || $(MKDIR_P) $(DESTDIR)$(pm_presets_dir)
-	find "$(PRESETSDIR)" -type f -exec $(INSTALL_DATA) {} $(DESTDIR)$(pm_presets_dir) \;
+	find "$(PRESETSDIR)" -type f -print0 | LC_ALL=C sort -z | xargs -0 '-I{}' $(INSTALL_DATA) '{}' $(DESTDIR)$(pm_presets_dir)
 
 # from https://stackoverflow.com/questions/30897170/ac-subst-does-not-expand-variable answer: https://stackoverflow.com/a/30960268
 # ptomato https://stackoverflow.com/users/172999/ptomato


### PR DESCRIPTION
so that projectM builds in a reproducible way
in spite of indeterministic filesystem readdir order.

See https://reproducible-builds.org/ for why this is good.

Without this patch, multiple .milk files varied between builds
in interesting ways:
```diff
--- "old//usr/share/projectM/presets/Geiss - All-Spark Polar.milk"
+++ "new//usr/share/projectM/presets/Geiss - All-Spark Polar.milk"
@@ -3,7 +3,7 @@
 PSVERSION_WARP=2^M
 PSVERSION_COMP=2^M
 [preset00]^M
-fRating=4.000000^M
+fRating=2.0^M
```

Maybe it is also a bug and either duplicate input .milk files should 

* be dropped or
* be synchronized or
* all of them should be installed into subdirs so no overwrites happen