### PR TITLE
configure script to build libprojectM with NDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ projectM supports OpenGL ES 2 and 3 for embedded systems. Be sure to configure w
 * projectM is arch-independent, although there are some SSE2 enhancements for x86
 * [Notes on running on raspberry pi](https://github.com/projectM-visualizer/projectm/issues/115)
 
+### Build using NDK for Android
+Install Android Studio, launch SDK Manager and install NDK
+`./autogen.sh`
+`./configure-ndk`
+`make`
+Now you should be able to copy ./src/libprojectM/.libs/libprojectM.a
+into your android app and write JNI wrapper for it
 
 # Using the library
 At its core projectM is a library, [libprojectM](src/libprojectM). This library is responsible for parsing presets, analyzing audio PCM data with beat detection and FFT, applying the preset to the audio feature data and rendering the resulting output with openGL. It can render to an openGL context or a texture.

--- a/configure-ndk
+++ b/configure-ndk
@@ -16,5 +16,6 @@ export CC=$TOOLCHAIN/bin/armv7a-linux-androideabi19-clang
 export CXX=$TOOLCHAIN/bin/armv7a-linux-androideabi19-clang++
 export LIBS_NDK=$NDK/sources/third_party/vulkan/src/libs/
 export CPPFLAGS="-I$LIBS_NDK"
+export GL_LIBS="-lGLESv2"
 
-./configure --host arm-linux-androideabi --enable-gles --disable-shared --disable-sdl
+./configure --host arm-linux-androideabi --enable-gles --disable-sdl

--- a/configure-ndk
+++ b/configure-ndk
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ -z ${NDK+x} ]; then
+  export NDK=${HOME}/Android/Sdk/ndk-bundle;
+fi
+
+export HOST_TAG=linux-x86_64
+export TOOLCHAIN=$NDK/toolchains/llvm/prebuilt/$HOST_TAG
+export TARGET=arm-linux-androideabi
+export AR=$TOOLCHAIN/bin/$TARGET-ar
+export AS=$TOOLCHAIN/bin/$TARGET-as
+export LD=$TOOLCHAIN/bin/$TARGET-ld
+export RANLIB=$TOOLCHAIN/bin/$TARGET-ranlib
+export STRIP=$TOOLCHAIN/bin/$TARGET-strip
+export CC=$TOOLCHAIN/bin/armv7a-linux-androideabi19-clang
+export CXX=$TOOLCHAIN/bin/armv7a-linux-androideabi19-clang++
+export LIBS_NDK=$NDK/sources/third_party/vulkan/src/libs/
+export CPPFLAGS="-I$LIBS_NDK"
+
+./configure --host arm-linux-androideabi --enable-gles --disable-shared --disable-sdl


### PR DESCRIPTION
Allows to cross compile libprojectM library using
Android's toolchain for an arm target.
Tested on Ubuntu.