### PR TITLE
Added VR/Multiple screen support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Helix
 [![Silverjuke](https://github.com/projectM-visualizer/projectm/raw/master/web/silverjuke.png)](https://www.silverjuke.net)
 Silverjuke (FOSS Jukebox)
 
+[![Silent Radiance](https://silentradiance.com/demos/projectM_vr/projectm_vr.png)](https://silentradiance.com)
+Silent Radiance Distance Disco
+
 ***
 
 ## Screenshots
@@ -60,6 +63,7 @@ Silverjuke (FOSS Jukebox)
 
 ![Screenshot](https://github.com/projectM-visualizer/projectm/raw/master/src/projectM-iTunes/projectM%20screenshots/Screen%20Shot%202014-08-25%20at%2012.31.07%20AM.png)
 
+![Screenshot](https://silentradiance.com/demos/projectM_vr/projectm_vr.png)
 ***
 
 # Building from source

--- a/src/libprojectM/Renderer/Renderer.cpp
+++ b/src/libprojectM/Renderer/Renderer.cpp
@@ -298,17 +298,10 @@ void Renderer::Pass2(const Pipeline &pipeline, const PipelineContext &pipelineCo
     }
 }
 
-void Renderer::RenderFrame(const Pipeline &pipeline, const PipelineContext &pipelineContext)
+void Renderer::RenderFrame(const Pipeline &pipeline, 
+const PipelineContext &pipelineContext)
 {
-    shaderEngine.RenderBlurTextures(pipeline, pipelineContext);
-
-    SetupPass1(pipeline, pipelineContext);
-
-    Interpolation(pipeline, pipelineContext);
-
-    RenderItems(pipeline, pipelineContext);
-
-    FinishPass1();
+    RenderFrameOnlyPass1(pipeline,pipelineContext);
 
     Pass2(pipeline, pipelineContext);
 }
@@ -337,6 +330,10 @@ void Renderer::RenderFrameOnlyPass2(const Pipeline &pipeline, const PipelineCont
     vstartx = 0;
     vstarty = 0;
 }
+
+
+
+
 void Renderer::Interpolation(const Pipeline &pipeline, const PipelineContext &pipelineContext)
 {
     glActiveTexture(GL_TEXTURE0);

--- a/src/libprojectM/Renderer/Renderer.hpp
+++ b/src/libprojectM/Renderer/Renderer.hpp
@@ -71,6 +71,8 @@ public:
   ~Renderer();
 
   void RenderFrame(const Pipeline &pipeline, const PipelineContext &pipelineContext);
+  void RenderFrameOnlyPass1(const Pipeline &pipeline, const PipelineContext &pipelineContext);
+  void RenderFrameOnlyPass2(const Pipeline &pipeline, const PipelineContext &pipelineContext,int xoffset,int yoffset,int eye);
   void ResetTextures();
   void reset(int w, int h);
   GLuint initRenderToTexture();
@@ -102,7 +104,12 @@ private:
 
   float* p;
 
-
+  int vstartx; /* view start x position - normally 0, but could be different if doing a subset of the window - like
+                  for virtual reality */
+  int vstarty; /* view start y position - normally 0, but could be different if doing a subset of the window - like
+                  for virtual reality */
+	       /* these are currently set only for rendering to the screen, not to the textbuffer */
+		  
   int vw;
   int vh;
 

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -454,6 +454,228 @@ void projectM::renderFrame()
 
 }
 
+
+
+
+
+
+/* This alternate rendering is as possible:
+Pipeline pipeline;
+Pipeline *comboPipeline;
+comboPipeline = renderFrameOnlyPass1(&pipeline);
+
+for each eye:
+  renderFrameOnlyPass2(comboPipeline,xoffset,yoffset,eye);
+  
+Then
+renderFrameEndOnSeparatePasses(comboPipeline); 
+for the accounting and releasing the mutex
+*/
+
+
+Pipeline * projectM::renderFrameOnlyPass1(Pipeline *pPipeline) /*pPipeline is a pointer to a Pipeline for use in pass 2. returns the pointer if it was used, else returns NULL */
+{
+#ifdef SYNC_PRESET_SWITCHES
+    pthread_mutex_lock(&preset_mutex);
+#endif
+
+#ifdef DEBUG
+    char fname[1024];
+    FILE *f = NULL;
+    int index = 0;
+    int x, y;
+#endif
+
+    timeKeeper->UpdateTimers();
+/*
+    if (timeKeeper->IsSmoothing())
+    {
+        printf("Smoothing A:%f, B:%f, S:%f\n", timeKeeper->PresetProgressA(), timeKeeper->PresetProgressB(), timeKeeper->SmoothRatio());
+    }
+    else
+    {
+        printf("          A:%f\n", timeKeeper->PresetProgressA());
+    }*/
+
+    mspf= ( int ) ( 1000.0/ ( float ) settings().fps ); //milliseconds per frame
+
+    /// @bug who is responsible for updating this now?"
+    pipelineContext().time = timeKeeper->GetRunningTime();
+    pipelineContext().presetStartTime = timeKeeper->PresetTimeA();
+    pipelineContext().frame = timeKeeper->PresetFrameA();
+    pipelineContext().progress = timeKeeper->PresetProgressA();
+
+    beatDetect->detectFromSamples();
+
+    //m_activePreset->evaluateFrame();
+
+    //if the preset isn't locked and there are more presets
+    if ( renderer->noSwitch==false && !m_presetChooser->empty() )
+    {
+        //if preset is done and we're not already switching
+        if ( timeKeeper->PresetProgressA()>=1.0 && !timeKeeper->IsSmoothing())
+        {
+            if (settings().shuffleEnabled)
+                selectRandom(false);
+            else
+                selectNext(false);
+        }
+
+        else if ((beatDetect->vol-beatDetect->vol_old>beatDetect->beat_sensitivity ) &&
+                 timeKeeper->CanHardCut())
+        {
+            // printf("Hard Cut\n");
+            if (settings().shuffleEnabled)
+                selectRandom(true);
+            else
+                selectNext(true);
+        }
+    }
+
+
+    if ( timeKeeper->IsSmoothing() && timeKeeper->SmoothRatio() <= 1.0 && !m_presetChooser->empty() )
+    {
+        //	 printf("start thread\n");
+        assert ( m_activePreset2.get() );
+
+#ifdef USE_THREADS
+        worker_sync.wake_up_bg();
+#endif
+
+        m_activePreset->Render(*beatDetect, pipelineContext());
+
+#ifdef USE_THREADS
+        worker_sync.wait_for_bg_to_finish();
+#else
+        evaluateSecondPreset();
+#endif
+
+
+        pPipeline->setStaticPerPixel(settings().meshX, settings().meshY);
+
+        assert(_matcher);
+        PipelineMerger::mergePipelines( m_activePreset->pipeline(),
+                                        m_activePreset2->pipeline(), *pPipeline,
+                                        _matcher->matchResults(),
+                                        *_merger, timeKeeper->SmoothRatio());
+
+        renderer->RenderFrameOnlyPass1(*pPipeline, pipelineContext());
+
+
+        return pPipeline;
+
+    }
+    else
+    {
+
+
+        if ( timeKeeper->IsSmoothing() && timeKeeper->SmoothRatio() > 1.0 )
+        {
+            //printf("End Smooth\n");
+            m_activePreset = std::move(m_activePreset2);
+            timeKeeper->EndSmoothing();
+        }
+        //printf("Normal\n");
+
+        m_activePreset->Render(*beatDetect, pipelineContext());
+        renderer->RenderFrameOnlyPass1 (m_activePreset->pipeline(), pipelineContext());
+	return NULL; // indicating no transition
+
+    }
+
+    //	std::cout<< m_activePreset->absoluteFilePath()<<std::endl;
+    //	renderer->presetName = m_activePreset->absoluteFilePath();
+
+
+
+
+}
+
+
+
+
+
+/* eye is 0,or 1, or who knows?*/
+void projectM::renderFrameOnlyPass2(Pipeline *pPipeline,int xoffset,int yoffset,int eye) /*pPipeline can be null if we re not in transition */
+{
+/* eye is currently ignored */
+
+
+#ifdef DEBUG
+    char fname[1024];
+    FILE *f = NULL;
+    int index = 0;
+    int x, y;
+#endif
+
+    if (pPipeline) 
+//    if ( timeKeeper->IsSmoothing() && timeKeeper->SmoothRatio() <= 1.0 && !m_presetChooser->empty() )
+    {
+        //	 printf("start thread\n");
+        assert ( m_activePreset2.get() );
+
+
+        /* was other stuff */
+	
+        renderer->RenderFrameOnlyPass2(*pPipeline, pipelineContext(),xoffset,yoffset,eye);
+
+    }
+    else
+    {
+
+
+        renderer->RenderFrameOnlyPass2 (m_activePreset->pipeline(), pipelineContext(),xoffset,yoffset,eye);
+
+
+    }
+
+}
+
+
+
+
+void projectM::renderFrameEndOnSeparatePasses(Pipeline *pPipeline) {
+
+    if (pPipeline) {
+       // mergePipelines() sets masterAlpha for each RenderItem, reset it before we forget
+       for (RenderItem *drawable : pPipeline->drawables) {
+           drawable->masterAlpha = 1.0;
+       }
+    pPipeline->drawables.clear();
+    }
+  
+    count++;
+#ifndef WIN32
+    /** Frame-rate limiter */
+    /** Compute once per preset */
+    if ( this->count%100==0 )
+    {
+        this->renderer->realfps=100.0/ ( ( getTicks ( &timeKeeper->startTime )-this->fpsstart ) /1000 );
+        this->fpsstart=getTicks ( &timeKeeper->startTime );
+    }
+
+#ifndef UNLOCK_FPS
+    int timediff = getTicks ( &timeKeeper->startTime )-this->timestart;
+
+    if ( timediff < this->mspf )
+    {
+        // printf("%s:",this->mspf-timediff);
+        int sleepTime = ( unsigned int ) ( this->mspf-timediff ) * 1000;
+        //		DWRITE ( "usleep: %d\n", sleepTime );
+        if ( sleepTime > 0 && sleepTime < 100000 )
+        {
+            if ( usleep ( sleepTime ) != 0 ) {}}
+    }
+    this->timestart=getTicks ( &timeKeeper->startTime );
+#endif
+
+#endif /** !WIN32 */
+#ifdef SYNC_PRESET_SWITCHES
+    pthread_mutex_unlock(&preset_mutex);
+#endif
+return;
+}
+
 void projectM::projectM_reset()
 {
     this->mspf = 0;

--- a/src/libprojectM/projectM.hpp
+++ b/src/libprojectM/projectM.hpp
@@ -166,6 +166,9 @@ public:
   void projectM_resetTextures();
   void projectM_setTitle( std::string title );
   void renderFrame();
+  Pipeline * renderFrameOnlyPass1(Pipeline *pPipeline);
+  void renderFrameOnlyPass2(Pipeline *pPipeline,int xoffset,int yoffset,int eye);
+  void renderFrameEndOnSeparatePasses(Pipeline *pPipeline);
   unsigned initRenderToTexture();
   void key_handler( projectMEvent event,
 		    projectMKeycode keycode, projectMModifier modifier );


### PR DESCRIPTION
I broke the RenderFrame into three separate methods in order to allow pass2 to be rendered multiple times.  This is to satisfy the requirements of VR, but might have other uses as well.

Made Renderer also have separate methods, and made it possible to do pass2 in an offset on the screen (like for left eye and right eye).