### PR TITLE
Set file dialogs to not be native

### DIFF
--- a/src/projectM-qt/qplaylistfiledialog.hpp
+++ b/src/projectM-qt/qplaylistfiledialog.hpp
@@ -40,6 +40,8 @@
      inline QPlaylistFileDialog(QWidget * parent = 0): 
 		QFileDialog(parent, OPEN_PLAYLIST_OR_DIRECTORY_TITLE, QString()), m_directorySelectAllowed(true), m_fileSelectAllowed(true) {
 
+	     this->setOption(QFileDialog::DontUseNativeDialog);
+
 	     updateFileMode(selectedFiles());
 	     
 	     //connect(this, SIGNAL(filesSelected(const QStringList&)),

--- a/src/projectM-qt/qpresetfiledialog.hpp
+++ b/src/projectM-qt/qpresetfiledialog.hpp
@@ -41,6 +41,8 @@
      QPresetFileDialog(QWidget * parent = 0): 
 		QFileDialog(parent, "Add preset files", QString(), "Presets (*.prjm *.milk *.so)" ) {
 
+		this->setOption(QFileDialog::DontUseNativeDialog);
+
 		this->setFileMode(QFileDialog::ExistingFiles);
 	}
 	


### PR DESCRIPTION
This is a simple change to set the DontUseNativeDialog option on the QFileDialog used for the playlist and preset file selection dialogs. See #165.