### PR TITLE
autogen.sh: fix

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,6 +1,7 @@
-#!/bin/sh -e
+#!/usr/bin/env sh
 
 echo "Running autoreconf... make sure you have GNU autotools available on your system"
+set -e # Drop-out from execution if error occurs
 
 autoreconf --install
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env sh
 
-echo "Running autoreconf... make sure you have GNU autotools available on your system"
 set -e # Drop-out from execution if error occurs
+
+printf 'Running autoreconf...'
 
 autoreconf --install
 
-echo "You followed directions! Great work!\nNow run ./configure"
+printf '\nSuccess!\nNow please run: ./configure\n'


### PR DESCRIPTION
Brief:

upd output, make it portable

`echo` has different behaviour, keys and possibilities on different systems.
Example:
```
echo "Line1\nLine2"
```

Is probably parses `\n` in `macOS`, while Linux `echo` doe not, resulting
in verbatim output.

`printf` special character parsing is much more portable.

Also removed the thanks `You followed directions! Great work!`
to the person that just ran one command, which is a script that has one command
inside and thanks the person for that.


add more portable #!, provide -e key explicitly

This is minority, NixOS and some other distros do not have this `sh` path,
paradoxically `/usr/bin/env` path is more widespread.

Also documenting `set -e`
