### PR TITLE
use updates synchronized with vertical retrace if adaptive vsync fails

### DIFF
--- a/src/projectM-sdl/projectM_SDL_main.cpp
+++ b/src/projectM-sdl/projectM_SDL_main.cpp
@@ -306,7 +306,11 @@ srand((int)(time(NULL)));
     SDL_SetWindowTitle(win, "projectM Visualizer");
     
     SDL_GL_MakeCurrent(win, glCtx);  // associate GL context with main window
-    SDL_GL_SetSwapInterval(-1); // Enable adaptive vsync
+    int avsync = SDL_GL_SetSwapInterval(-1); // try to enable adaptive vsync
+    if (avsync == -1) { // adaptive vsync not supported
+        SDL_GL_SetSwapInterval(1); // enable updates synchronized with vertical retrace
+    }
+
     
     projectMSDL *app;
     


### PR DESCRIPTION
got projectM-SDL compiled on a raspberry pi 4 using the SDL kmsdrm-backend instead of X - works but with lots of flicker after a short while. seems that you need vsync, but adaptive vsync is not supported (yet)

the SDL documentation for `SDL_GL_SetSwapInterval` suggests this
> If application requests adaptive vsync and the system does not support it, this function will fail and return -1. In such a case, you should probably retry the call with 1 for the interval. 

works nicely on the rpi4 now!