### PR TITLE
fix OSX install by use of preset subdirs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,8 @@ pm_font__DATA = fonts/Vera.ttf fonts/VeraMono.ttf
 # find and install all preset files
 install-data-local:
 if ENABLE_PRESET_SUBDIRS
-	find "$(PRESETSDIR)" -type f -exec install -Dm 755 "{}" "$(DESTDIR)/$(pm_data_dir)/{}" \;
+	find "$(PRESETSDIR)" -type d -exec $(MKDIR_P) "$(DESTDIR)/$(pm_data_dir)/{}" \;
+	find "$(PRESETSDIR)" -type f -exec $(INSTALL_DATA) "{}" "$(DESTDIR)/$(pm_data_dir)/{}" \;
 else
 	test -z $(DESTDIR)$(pkgdatadir) || $(MKDIR_P) $(DESTDIR)$(pm_presets_dir)
 	find "$(PRESETSDIR)" -type f -print0 | LC_ALL=C sort -z | xargs -0 '-I{}' $(INSTALL_DATA) '{}' $(DESTDIR)$(pm_presets_dir)


### PR DESCRIPTION
Before was a `install -D ...` used, but `-D` not supported on OSX.

With this change becomes it removed and on a separate call before, all
required directories created.