### PR TITLE
Hardcode missing Qt5 libs (libQt5Gui and libQt5OpenGL) 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -183,6 +183,10 @@ AS_IF([test "$enable_qt" != "no"],
         # we have at least qt5 if $have_qt is true
         enable_qt=yes
         export QT_SELECT=qt5
+
+        # we depend on lQt5Gui and lQt5OpenGL
+        # https://github.com/projectM-visualizer/projectm/issues/271
+        LIBS="$LIBS -lQt5Gui -lQt5OpenGL"
     ],
     [AS_IF([test "$enable_qt" = "yes"],
         [AC_MSG_ERROR(["Qt5 not found"])],


### PR DESCRIPTION
To fix missing DSO linkage with Qt5 on Ubuntu 19.10

Should fix the error: 
```
/usr/bin/ld: ../projectM-qt/libprojectM_qt.a(qprojectm_mainwindow.o): undefined reference to symbol '_ZN5QIconC1Ev@@Qt_5'
/usr/bin/ld: /usr/lib/x86_64-linux-gnu/libQt5Gui.so: error adding symbols: DSO missing from command line
```

I don't know if there is a better way to solve this but hardcoding these needed libraries seems to fix the issue, at least for me, on ubuntu 19.10.

Should address #274 #283 #271 #280 