### PR TITLE
Menu and FPS changes

### DIFF
--- a/msvc/MilkdropPresetFactory.vcxproj
+++ b/msvc/MilkdropPresetFactory.vcxproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{EF3369C9-E934-3F1E-996B-21518B57A809}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
     <Platform>x64</Platform>
     <ProjectName>MilkdropPresetFactory</ProjectName>

--- a/msvc/MstressJuppyDancer.vcxproj
+++ b/msvc/MstressJuppyDancer.vcxproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{55A71B6A-5C7E-30D5-8210-302A8D2080DB}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
     <Platform>x64</Platform>
     <ProjectName>MstressJuppyDancer</ProjectName>

--- a/msvc/NativePresetFactory.vcxproj
+++ b/msvc/NativePresetFactory.vcxproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{E2D4CEE6-B8CB-32AC-8977-52A48C8DA4E1}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
     <Platform>x64</Platform>
     <ProjectName>NativePresetFactory</ProjectName>

--- a/msvc/Renderer.vcxproj
+++ b/msvc/Renderer.vcxproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{07427FA1-1771-3A2D-9183-167A8345DEEB}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
     <Platform>x64</Platform>
     <ProjectName>Renderer</ProjectName>

--- a/msvc/RovastarDarkSecret.vcxproj
+++ b/msvc/RovastarDarkSecret.vcxproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{7A203034-A4D7-3A2B-9138-CB125F9B35E6}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
     <Platform>x64</Platform>
     <ProjectName>RovastarDarkSecret</ProjectName>

--- a/msvc/RovastarDriftingChaos.vcxproj
+++ b/msvc/RovastarDriftingChaos.vcxproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{6E418BC8-5407-3A37-96BD-5201D47DE753}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
     <Platform>x64</Platform>
     <ProjectName>RovastarDriftingChaos</ProjectName>

--- a/msvc/RovastarFractalSpiral.vcxproj
+++ b/msvc/RovastarFractalSpiral.vcxproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B7C4937F-A36D-3B6C-A8AC-CA99772AE5EC}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
     <Platform>x64</Platform>
     <ProjectName>RovastarFractalSpiral</ProjectName>

--- a/msvc/RovastarFractopiaFrantic.vcxproj
+++ b/msvc/RovastarFractopiaFrantic.vcxproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{27DDCE71-E33B-3521-92B5-9918356D78A1}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
     <Platform>x64</Platform>
     <ProjectName>RovastarFractopiaFrantic</ProjectName>

--- a/msvc/projectM-qt.vcxproj
+++ b/msvc/projectM-qt.vcxproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{9260C46C-6BC9-396F-9310-6BAAD56A7801}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
     <Platform>x64</Platform>
     <ProjectName>projectM-qt</ProjectName>

--- a/msvc/projectM.vcxproj
+++ b/msvc/projectM.vcxproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{DABC69A6-66C3-392C-8A62-EC989B0850A4}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
     <Platform>x64</Platform>
     <ProjectName>projectM</ProjectName>

--- a/msvc/projectMSDL.vcxproj
+++ b/msvc/projectMSDL.vcxproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{013DE011-EC24-3643-A8EE-F2609E7E4741}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
     <Platform>x64</Platform>
     <ProjectName>projectMSDL</ProjectName>

--- a/src/libprojectM/KeyHandler.cpp
+++ b/src/libprojectM/KeyHandler.cpp
@@ -123,7 +123,6 @@ void projectM::default_key_handler( projectMEvent event, projectMKeycode keycode
 		case PROJECTM_K_h:
  		  renderer->showhelp = !renderer->showhelp;
 	      renderer->showstats= false;
-	      renderer->showfps=false;
 	    case PROJECTM_K_F1:
 	      renderer->showhelp = !renderer->showhelp;
 	      renderer->showstats=false;
@@ -135,10 +134,15 @@ void projectM::default_key_handler( projectMEvent event, projectMKeycode keycode
 
 	    case PROJECTM_K_F5:
 		  renderer->showfps = !renderer->showfps;
-				if (renderer->showfps)
-				{
-					renderer->showpreset = false;
-				}
+			// Initialize counters and reset frame count.
+			renderer->lastTime = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
+			renderer->currentTime = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
+			renderer->totalframes = 0;
+			// Hide preset name from screen and replace it with FPS counter.
+			if (renderer->showfps)
+			{
+				renderer->showpreset = false;
+			}
 	      break;
 	    case PROJECTM_K_F4:
 		if (!renderer->showhelp)
@@ -146,10 +150,11 @@ void projectM::default_key_handler( projectMEvent event, projectMKeycode keycode
 	      break;
 	    case PROJECTM_K_F3: {
 	      renderer->showpreset = !renderer->showpreset;
-				if (renderer->showpreset)
-				{
-					renderer->showfps = false;
-				}
+			// Hide FPS from screen and replace it with preset name.
+			if (renderer->showpreset)
+			{
+				renderer->showfps = false;
+			}
 	      break;
 	     }
 	    case PROJECTM_K_F2:

--- a/src/libprojectM/Renderer/Renderer.cpp
+++ b/src/libprojectM/Renderer/Renderer.cpp
@@ -572,8 +572,7 @@ void Renderer::draw_help()
 {
 #ifdef USE_TEXT_MENU
 	// TODO: match winamp/milkdrop bindings
-	drawText("Help""\n"
-	         "-------------------------------""\n"
+	drawText("\n"
 	         "F1: This help menu""\n"
 	         "F3: Show preset name""\n"
 		     "F5: Show FPS""\n"
@@ -583,7 +582,7 @@ void Renderer::draw_help()
 	         "P: Previous preset""\n"
 	         "UP: Increase Beat Sensitivity""\n"
 	         "DOWN: Decrease Beat Sensitivity""\n"
-	         "CTRL-F: Fullscreen", 1, 20, 2.5);
+	         "CTRL-F: Fullscreen", 30, 20, 2.5);
 
 #endif /** USE_TEXT_MENU */
 }

--- a/src/libprojectM/Renderer/Renderer.cpp
+++ b/src/libprojectM/Renderer/Renderer.cpp
@@ -240,7 +240,7 @@ void Renderer::SetupPass1(const Pipeline& pipeline, const PipelineContext& pipel
 	/*
 	If FPS is displayed (by pressing F5 or by config):
 		- check if 250 milliseconds has passed (1/4 of a second)
-		- multiply the total rendered frames (totalframes) by four to get the approximate frames per second count.
+		- multiply the total rendered frames (totalframes) by the fraction of a second that passed to get the approximate frames per second count.
 		- reset the totalframes and timer (lastTime) so we don't trigger for another 250 milliseconds.
 	*/
 	if (this->showfps)
@@ -250,7 +250,7 @@ void Renderer::SetupPass1(const Pipeline& pipeline, const PipelineContext& pipel
 		double diff = ms.count();
 		if (diff >= 250)
 		{
-			this->realfps = totalframes * 4;
+			this->realfps = totalframes * (1000 / diff);
 			setFPS(realfps);
 			totalframes = 0;
 			this->lastTime = duration_cast<milliseconds>(system_clock::now().time_since_epoch());

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -656,6 +656,7 @@ int projectM::initPresetTools(int gx, int gy)
 //        std::cerr << "[projectM] Allocating idle preset..." << std::endl;
     m_activePreset = m_presetLoader->loadPreset
             ("idle://Geiss & Sperl - Feedback (projectM idle HDR mix).milk");
+	renderer->setPresetName("Geiss & Sperl - Feedback (projectM idle HDR mix)");
 
     renderer->SetPipeline(m_activePreset->pipeline());
 


### PR DESCRIPTION
Hopefully the commit messages are clear, but the summary is:
- more accurate FPS (resetting timers when the menu is first loaded and doing more exact math).
- removing the F1 help menu no longer removes the preset name from the screen.
- the F1 help menu is moved down and aligned with the preset name or FPS. Before you could have the help menu and preset name up at the same time and they go in the way of each other.
- the idle preset name is now set when you display it (before it displayed "None").
- changed the default Windows SDK version so all 10.* soany minor version of 10 should compile right away.