### PR TITLE
SDL changes

### DIFF
--- a/src/projectM-sdl/pmSDL.cpp
+++ b/src/projectM-sdl/pmSDL.cpp
@@ -1,154 +1,239 @@
 /**
-* projectM -- Milkdrop-esque visualisation SDK
-* Copyright (C)2003-2019 projectM Team
-*
-* This library is free software; you can redistribute it and/or
-* modify it under the terms of the GNU Lesser General Public
-* License as published by the Free Software Foundation; either
-* version 2.1 of the License, or (at your option) any later version.
-*
-* This library is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* Lesser General Public License for more details.
-*
-* You should have received a copy of the GNU Lesser General Public
-* License along with this library; if not, write to the Free Software
-* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-* See 'LICENSE.txt' included within this release
-*
-* projectM-sdl
-* This is an implementation of projectM using libSDL2
-*
-* pmSDL.cpp
-* Authors: Created by Mischa Spiegelmock on 2017-09-18.
-*
-*
-* experimental Stereoscopic SBS driver functionality by
-*	RobertPancoast77@gmail.com
-*/
+ * projectM -- Milkdrop-esque visualisation SDK
+ * Copyright (C)2003-2019 projectM Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * See 'LICENSE.txt' included within this release
+ *
+ * projectM-sdl
+ * This is an implementation of projectM using libSDL2
+ *
+ * pmSDL.cpp
+ * Authors: Created by Mischa Spiegelmock on 2017-09-18.
+ *
+ *
+ * experimental Stereoscopic SBS driver functionality by
+ *	RobertPancoast77@gmail.com
+ */
 
 #include "pmSDL.hpp"
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>
 #include "Renderer/ShaderEngine.hpp"
 
-
-void projectMSDL::audioInputCallbackF32(void *userdata, unsigned char *stream, int len) {
-    projectMSDL *app = (projectMSDL *) userdata;
-    //    printf("LEN: %i\n", len);
-    // stream is (i think) samples*channels floats (native byte order) of len BYTES
-    if (app->audioChannelsCount == 1)
-        app->pcm()->addPCMfloat((float *)stream, len/sizeof(float));
-    else if (app->audioChannelsCount == 2)
-        app->pcm()->addPCMfloat_2ch((float *)stream, len/sizeof(float));
-    else {
-        SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, "Multichannel audio not supported");
-        SDL_Quit();
-    }
+void projectMSDL::audioInputCallbackF32(void *userdata, unsigned char *stream, int len)
+{
+	projectMSDL *app = (projectMSDL *)userdata;
+	//    printf("LEN: %i\n", len);
+	// stream is (i think) samples*channels floats (native byte order) of len BYTES
+	if (app->audioChannelsCount == 1)
+		app->pcm()->addPCMfloat((float *)stream, len / sizeof(float));
+	else if (app->audioChannelsCount == 2)
+		app->pcm()->addPCMfloat_2ch((float *)stream, len / sizeof(float));
+	else
+	{
+		SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, "Multichannel audio not supported");
+		SDL_Quit();
+	}
 }
 
-void projectMSDL::audioInputCallbackS16(void *userdata, unsigned char *stream, int len) {
-    //    printf("LEN: %i\n", len);
-    projectMSDL *app = (projectMSDL *) userdata;
-    short pcm16[2][512];
+void projectMSDL::audioInputCallbackS16(void *userdata, unsigned char *stream, int len)
+{
+	//    printf("LEN: %i\n", len);
+	projectMSDL *app = (projectMSDL *)userdata;
+	short pcm16[2][512];
 
-    for (int i = 0; i < 512; i++) {
-        for (int j = 0; j < app->audioChannelsCount; j++) {
-            pcm16[j][i] = stream[i+j];
-        }
-    }
-    app->pcm()->addPCM16(pcm16);
+	for (int i = 0; i < 512; i++)
+	{
+		for (int j = 0; j < app->audioChannelsCount; j++)
+		{
+			pcm16[j][i] = stream[i + j];
+		}
+	}
+	app->pcm()->addPCM16(pcm16);
 }
 
-SDL_AudioDeviceID projectMSDL::selectAudioInput(int _count) {
-    // TODO: implement some sort of UI allowing the user to select which audio input device they would like to use
+SDL_AudioDeviceID projectMSDL::selectAudioInput(int _count)
+{
+	// TODO: implement some sort of UI allowing the user to select which audio input device they would
+	// like to use
 
+	// ask the user which capture device to use
+	// printf("Please select which audio input to use:\n");
+	printf("Detected devices:\n");
+	for (int i = 0; i < _count; i++)
+	{
+		printf("  %i: 🎤%s\n", i, SDL_GetAudioDeviceName(i, true));
+	}
 
-    // ask the user which capture device to use
-    // printf("Please select which audio input to use:\n");
-    printf("Detected devices:\n");
-    for (int i = 0; i < _count; i++) {
-        printf("  %i: 🎤%s\n", i, SDL_GetAudioDeviceName(i, true));
-    }
-
-    return 0;
+	return 0;
 }
 
-int projectMSDL::openAudioInput() {
-    // get audio driver name (static)
-    const char* driver_name = SDL_GetCurrentAudioDriver();
-    SDL_Log("Using audio driver: %s\n", driver_name);
+int projectMSDL::openAudioInput()
+{
+	// get audio driver name (static)
+	const char *driver_name = SDL_GetCurrentAudioDriver();
+	SDL_Log("Using audio driver: %s\n", driver_name);
 
-    // get audio input device
-    unsigned int i, count2 = SDL_GetNumAudioDevices(true);  // capture, please
-    if (count2 == 0) {
-        SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, "No audio capture devices found");
-        SDL_Quit();
-    }
-    for (i = 0; i < count2; i++) {
-        SDL_Log("Found audio capture device %d: %s", i, SDL_GetAudioDeviceName(i, true));
-    }
+	// get audio input device
+	unsigned int i, count2 = SDL_GetNumAudioDevices(true); // capture, please
+	if (count2 == 0)
+	{
+		SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, "No audio capture devices found");
+		SDL_Quit();
+	}
+	for (i = 0; i < count2; i++)
+	{
+		SDL_Log("Found audio capture device %d: %s", i, SDL_GetAudioDeviceName(i, true));
+	}
 
-    SDL_AudioDeviceID selectedAudioDevice = 0;  // device to open
-    if (count2 > 1) {
-        // need to choose which input device to use
-        selectedAudioDevice = selectAudioInput(count2);
-	if (selectedAudioDevice > count2) {
-            SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, "No audio input device specified.");
-            SDL_Quit();
-        }
-    }
+	SDL_AudioDeviceID selectedAudioDevice = 0; // device to open
+	if (count2 > 1)
+	{
+		// need to choose which input device to use
+		selectedAudioDevice = selectAudioInput(count2);
+		if (selectedAudioDevice > count2)
+		{
+			SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, "No audio input device specified.");
+			SDL_Quit();
+		}
+	}
 
-    // params for audio input
-    SDL_AudioSpec want, have;
+	// params for audio input
+	SDL_AudioSpec want, have;
 
-    // requested format
-    // https://wiki.libsdl.org/SDL_AudioSpec#Remarks
-    SDL_zero(want);
-    want.freq = 44100;
-    want.format = AUDIO_F32;  // float
-    want.channels = 2;
-    want.samples = PCM::maxsamples;
-    want.callback = projectMSDL::audioInputCallbackF32;
-    want.userdata = this;
+	// requested format
+	// https://wiki.libsdl.org/SDL_AudioSpec#Remarks
+	SDL_zero(want);
+	want.freq = 44100;
+	want.format = AUDIO_F32; // float
+	want.channels = 2;
+	want.samples = PCM::maxsamples;
+	want.callback = projectMSDL::audioInputCallbackF32;
+	want.userdata = this;
 
-    audioDeviceID = SDL_OpenAudioDevice(SDL_GetAudioDeviceName(selectedAudioDevice, true), true, &want, &have, 0);
+	audioDeviceID =
+		SDL_OpenAudioDevice(SDL_GetAudioDeviceName(selectedAudioDevice, true), true, &want, &have, 0);
 
-    if (audioDeviceID == 0) {
-        SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, "Failed to open audio capture device: %s", SDL_GetError());
-        SDL_Quit();
-    }
+	if (audioDeviceID == 0)
+	{
+		SDL_LogCritical(
+			SDL_LOG_CATEGORY_APPLICATION, "Failed to open audio capture device: %s", SDL_GetError());
+		SDL_Quit();
+	}
 
-    // read characteristics of opened capture device
-    SDL_Log("Opened audio capture device index=%i devId=%i: %s", selectedAudioDevice, audioDeviceID, SDL_GetAudioDeviceName(selectedAudioDevice, true));
-    SDL_Log("Samples: %i, frequency: %i, channels: %i, format: %i", have.samples, have.freq, have.channels, have.format);
-    audioChannelsCount = have.channels;
-    audioSampleRate = have.freq;
-    audioSampleCount = have.samples;
-    audioFormat = have.format;
-    audioInputDevice = audioDeviceID;
-    return 1;
+	// read characteristics of opened capture device
+	SDL_Log("Opened audio capture device index=%i devId=%i: %s", selectedAudioDevice, audioDeviceID,
+		SDL_GetAudioDeviceName(selectedAudioDevice, true));
+	SDL_Log("Samples: %i, frequency: %i, channels: %i, format: %i", have.samples, have.freq,
+		have.channels, have.format);
+	audioChannelsCount = have.channels;
+	audioSampleRate = have.freq;
+	audioSampleCount = have.samples;
+	audioFormat = have.format;
+	audioInputDevice = audioDeviceID;
+	return 1;
 }
 
-void projectMSDL::beginAudioCapture() {
-    // allocate a buffer to store PCM data for feeding in
-    SDL_PauseAudioDevice(audioDeviceID, false);
+void projectMSDL::beginAudioCapture()
+{
+	// allocate a buffer to store PCM data for feeding in
+	SDL_PauseAudioDevice(audioDeviceID, false);
 }
 
-void projectMSDL::endAudioCapture() {
-    SDL_PauseAudioDevice(audioDeviceID, true);
+void projectMSDL::endAudioCapture()
+{
+	SDL_PauseAudioDevice(audioDeviceID, true);
 }
 
-void projectMSDL::maximize() {
-    SDL_DisplayMode dm;
-    if (SDL_GetDesktopDisplayMode(0, &dm) != 0) {
-        SDL_Log("SDL_GetDesktopDisplayMode failed: %s", SDL_GetError());
-        return;
-    }
+void projectMSDL::maximize()
+{
+	SDL_DisplayMode dm;
+	if (SDL_GetDesktopDisplayMode(0, &dm) != 0)
+	{
+		SDL_Log("SDL_GetDesktopDisplayMode failed: %s", SDL_GetError());
+		return;
+	}
 
-    SDL_SetWindowSize(win, dm.w, dm.h);
-    resize(dm.w, dm.h);
+	SDL_SetWindowSize(win, dm.w, dm.h);
+	resize(dm.w, dm.h);
+}
+
+/* Moves projectM to the next monitor */
+void projectMSDL::stretchMonitors()
+{
+	int displayCount = SDL_GetNumVideoDisplays();
+	if (displayCount >= 2)
+	{
+		std::vector<SDL_Rect> displayBounds;
+		for (int i = 0; i < displayCount; i++)
+		{
+			displayBounds.push_back(SDL_Rect());
+			SDL_GetDisplayBounds(i, &displayBounds.back());
+		}
+
+		int furthestX = 0;
+		int furthestY = 0;
+		int widest = 0;
+		int highest = 0;
+		int spanX = 0;
+		int spanY = 0;
+		int spanWidth = 0;
+		int spanHeight = 0;
+
+		bool horizontal = true;
+		bool vertical = true;
+
+		for (int i = 0; i < displayCount; i++)
+		{
+			if (displayBounds[0].x != displayBounds[i].x) vertical = false;
+			if (displayBounds[0].y != displayBounds[i].y) horizontal = false;
+		}
+
+		if (!vertical && !horizontal)
+		{
+			// If multiple montors are not perfectly aligned it's a bit of work to get the correct x,y and
+			// dimensions But in my testing on Windows 10 even with the screen did not render correctly.
+			// @todo more testing and make it work.
+			SDL_Log(
+				"SDL currently only supports multiple monitors that are aligned evenly in a vertical or "
+				"horizontal position.");
+		}
+		else
+		{
+			for (int i = 0; i < displayCount; i++)
+			{
+				if (displayBounds[i].x < furthestX) spanX = displayBounds[i].x; // X furthest left device
+				if (displayBounds[i].y < furthestY) spanY = displayBounds[i].y; // Y highest device
+				if (displayBounds[i].h > highest) highest = displayBounds[i].h; // highest resolution Height
+				if (displayBounds[i].h > widest) widest = displayBounds[i].w;	// highest resolution Width
+				if (horizontal) // perfectly aligned horizonal monitors.
+				{
+					spanHeight = highest;
+					spanWidth = spanWidth + displayBounds[i].w;
+				}
+				else if (vertical) // perfectly aligned vertical monitors.
+				{
+					spanHeight = spanHeight + displayBounds[i].h;
+					spanWidth = widest;
+				}
+			}
+			SDL_SetWindowPosition(win, spanX, spanY);
+			SDL_SetWindowSize(win, spanWidth, spanHeight);
+		}
+	}
 }
 
 /* Moves projectM to the next monitor */
@@ -173,35 +258,42 @@ void projectMSDL::nextMonitor()
 	}
 }
 
-void projectMSDL::toggleFullScreen() {
-    maximize();
-    if (isFullScreen) {
-        SDL_SetWindowFullscreen(win, 0);
-        isFullScreen = false;
-        SDL_ShowCursor(true);
-    } else {
-        SDL_ShowCursor(false);
-        SDL_SetWindowFullscreen(win, SDL_WINDOW_FULLSCREEN);
-        isFullScreen = true;
-    }
+void projectMSDL::toggleFullScreen()
+{
+	maximize();
+	if (isFullScreen)
+	{
+		SDL_SetWindowFullscreen(win, 0);
+		isFullScreen = false;
+		SDL_ShowCursor(true);
+	}
+	else
+	{
+		SDL_ShowCursor(false);
+		SDL_SetWindowFullscreen(win, SDL_WINDOW_FULLSCREEN);
+		isFullScreen = true;
+	}
 }
 
-void projectMSDL::keyHandler(SDL_Event *sdl_evt) {
-    projectMEvent evt;
-    projectMKeycode key;
-    projectMModifier mod;
-    SDL_Keymod sdl_mod = (SDL_Keymod) sdl_evt->key.keysym.mod;
-    SDL_Keycode sdl_keycode = sdl_evt->key.keysym.sym;
+void projectMSDL::keyHandler(SDL_Event *sdl_evt)
+{
+	projectMEvent evt;
+	projectMKeycode key;
+	projectMModifier mod;
+	SDL_Keymod sdl_mod = (SDL_Keymod)sdl_evt->key.keysym.mod;
+	SDL_Keycode sdl_keycode = sdl_evt->key.keysym.sym;
 
 	// handle keyboard input (for our app first, then projectM)
-    switch (sdl_keycode) {
-        case SDLK_q:
-            if (sdl_mod & KMOD_LGUI || sdl_mod & KMOD_RGUI || sdl_mod & KMOD_LCTRL) {
-                // cmd/ctrl-q = quit
-                done = 1;
-                return;
-            }
-            break;
+	switch (sdl_keycode)
+	{
+		case SDLK_q:
+			if (sdl_mod & KMOD_LGUI || sdl_mod & KMOD_RGUI || sdl_mod & KMOD_LCTRL)
+			{
+				// cmd/ctrl-q = quit
+				done = 1;
+				return;
+			}
+			break;
 		case SDLK_m:
 			if (sdl_mod & KMOD_LGUI || sdl_mod & KMOD_RGUI || sdl_mod & KMOD_LCTRL)
 			{
@@ -212,269 +304,307 @@ void projectMSDL::keyHandler(SDL_Event *sdl_evt) {
 #endif
 				return; // handled
 			}
-        case SDLK_f:
-            if (sdl_mod & KMOD_LGUI || sdl_mod & KMOD_RGUI || sdl_mod & KMOD_LCTRL) {
-                // command-f: fullscreen
+		case SDLK_s:
+			if (sdl_mod & KMOD_LGUI || sdl_mod & KMOD_RGUI || sdl_mod & KMOD_LCTRL)
+			{
+				// command-s: [s]tretch monitors
+				// Stereo requires fullscreen
+#if !STEREOSCOPIC_SBS
+				stretchMonitors();
+#endif
+				return; // handled
+			}
+		case SDLK_f:
+			if (sdl_mod & KMOD_LGUI || sdl_mod & KMOD_RGUI || sdl_mod & KMOD_LCTRL)
+			{
+				// command-f: fullscreen
 				// Stereo requires fullscreen
 #if !STEREOSCOPIC_SBS
 				toggleFullScreen();
 #endif
-                return; // handled
-            }
-            break;
-					case SDLK_LEFT:
-						// selectPrevious(true);
-						break;
-					case SDLK_RIGHT:
-						// selectNext(true);
-						break;
-					case SDLK_UP:
-						break;
-					case SDLK_DOWN:
-						break;
+				return; // handled
+			}
+			break;
+		case SDLK_LEFT:
+			// selectPrevious(true);
+			break;
+		case SDLK_RIGHT:
+			// selectNext(true);
+			break;
+		case SDLK_UP: break;
+		case SDLK_DOWN: break;
 
-					case SDLK_F3:
-						break;
+		case SDLK_F3: break;
 
+		case SDLK_SPACE: setPresetLock(!isPresetLocked()); break;
+		case SDLK_F1:
+		case SDLK_ESCAPE:
 
-					case SDLK_SPACE:
-						setPresetLock(
-							!isPresetLocked()
-						);
-						break;
-					case SDLK_F1:
-					case SDLK_ESCAPE:
+			// exit(1);
+			// show help with other keys
+			sdl_keycode = SDLK_F1;
+			break;
+		case SDLK_DELETE:
+			/*
+			try {
+				if (selectedPresetIndex(index)) {
+					DeleteFile(
+						LPCSTR(
+							getPresetURL(index).c_str()
+						)
+					);
+				}
+			}
+			catch (const std::exception & e) {
+				printf("Delete failed");
+			}
+			*/
+			break;
+		case SDLK_RETURN:
+			/*
+			try {
+				if (selectedPresetIndex(index)) {
+					CopyFile(
+							LPCSTR(
+									app->getPresetURL(index).c_str()
+							),
+							LPCTSTR(L"C:\\"),
+							false
+					);
+				}
+			}
+			catch (const std::exception & e) {
+				printf("Delete failed");
+			}
+					*/
+			break;
+	}
 
-						// exit(1);
-						// show help with other keys
-						sdl_keycode = SDLK_F1;
-						break;
-					case SDLK_DELETE:
-						/*
-						try {
-							if (selectedPresetIndex(index)) {
-								DeleteFile(
-									LPCSTR(
-										getPresetURL(index).c_str()
-									)
-								);
-							}
-						}
-						catch (const std::exception & e) {
-							printf("Delete failed");
-						}
-						*/
-						break;
-					case SDLK_RETURN:
-						/*
-						try {
-							if (selectedPresetIndex(index)) {
-								CopyFile(
-										LPCSTR(
-												app->getPresetURL(index).c_str()
-										),
-										LPCTSTR(L"C:\\"),
-										false
-								);
-							}
-						}
-						catch (const std::exception & e) {
-							printf("Delete failed");
-						}
-								*/
-						break;
-    }
-
-    // translate into projectM codes and perform default projectM handler
-    evt = sdl2pmEvent(sdl_evt);
-    key = sdl2pmKeycode(sdl_keycode);
-    mod = sdl2pmModifier(sdl_mod);
-    key_handler(evt, key, mod);
+	// translate into projectM codes and perform default projectM handler
+	evt = sdl2pmEvent(sdl_evt);
+	key = sdl2pmKeycode(sdl_keycode);
+	mod = sdl2pmModifier(sdl_mod);
+	key_handler(evt, key, mod);
 }
 
-void projectMSDL::addFakePCM() {
-    int i;
-    short pcm_data[2][512];
-    /** Produce some fake PCM data to stuff into projectM */
-    for ( i = 0 ; i < 512 ; i++ ) {
-        if ( i % 2 == 0 ) {
-            pcm_data[0][i] = (float)( rand() / ( (float)RAND_MAX ) * (pow(2,14) ) );
-            pcm_data[1][i] = (float)( rand() / ( (float)RAND_MAX ) * (pow(2,14) ) );
-        } else {
-            pcm_data[0][i] = (float)( rand() / ( (float)RAND_MAX ) * (pow(2,14) ) );
-            pcm_data[1][i] = (float)( rand() / ( (float)RAND_MAX ) * (pow(2,14) ) );
-        }
-        if ( i % 2 == 1 ) {
-            pcm_data[0][i] = -pcm_data[0][i];
-            pcm_data[1][i] = -pcm_data[1][i];
-        }
-    }
+void projectMSDL::addFakePCM()
+{
+	int i;
+	short pcm_data[2][512];
+	/** Produce some fake PCM data to stuff into projectM */
+	for (i = 0; i < 512; i++)
+	{
+		if (i % 2 == 0)
+		{
+			pcm_data[0][i] = (float)(rand() / ((float)RAND_MAX) * (pow(2, 14)));
+			pcm_data[1][i] = (float)(rand() / ((float)RAND_MAX) * (pow(2, 14)));
+		}
+		else
+		{
+			pcm_data[0][i] = (float)(rand() / ((float)RAND_MAX) * (pow(2, 14)));
+			pcm_data[1][i] = (float)(rand() / ((float)RAND_MAX) * (pow(2, 14)));
+		}
+		if (i % 2 == 1)
+		{
+			pcm_data[0][i] = -pcm_data[0][i];
+			pcm_data[1][i] = -pcm_data[1][i];
+		}
+	}
 
-    /** Add the waveform data */
-    pcm()->addPCM16(pcm_data);
+	/** Add the waveform data */
+	pcm()->addPCM16(pcm_data);
 }
 
-void projectMSDL::resize(unsigned int width_, unsigned int height_) {
-    width = width_;
-    height = height_;
-    projectM_resetGL(width, height);
+void projectMSDL::resize(unsigned int width_, unsigned int height_)
+{
+	if (width_ != 0 && height_ != 0)
+	{
+		width = width_;
+		height = height_;
+		projectM_resetGL(width, height);
+	}
 }
 
-void projectMSDL::pollEvent() {
-    SDL_Event evt;
-
-    while (SDL_PollEvent(&evt))
-    {
-        switch (evt.type) {
-            case SDL_WINDOWEVENT:
-                switch (evt.window.event) {
-                    case SDL_WINDOWEVENT_RESIZED:
-                        resize(evt.window.data1, evt.window.data2);
-                        break;
-                }
-                break;
-            case SDL_KEYDOWN:
-                keyHandler(&evt);
-                break;
-            case SDL_QUIT:
-                done = true;
-                break;
-        }
-    }
+void projectMSDL::move(unsigned int x_, unsigned int y_)
+{
+	if (x_ != 0 && y_ != 0)
+	{
+		projectM_resetGL(x_, y_);
+	}
 }
 
-void projectMSDL::renderFrame() {
-    glClearColor( 0.0, 0.0, 0.0, 0.0 );
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+void projectMSDL::pollEvent()
+{
+	SDL_Event evt;
 
-    projectM::renderFrame();
-
-    if (renderToTexture) {
-        renderTexture();
-    }
-
-    SDL_GL_SwapWindow(win);
+	while (SDL_PollEvent(&evt))
+	{
+		switch (evt.type)
+		{
+			case SDL_WINDOWEVENT:
+				switch (evt.window.event)
+				{
+					case SDL_WINDOWEVENT_RESIZED: 
+						resize(evt.window.data1, evt.window.data2); 
+						break;
+					case SDL_WINDOWEVENT_SIZE_CHANGED: 
+						resize(evt.window.data1, evt.window.data2);
+						break;
+				}
+				break;
+			case SDL_KEYDOWN: keyHandler(&evt); break;
+			case SDL_QUIT: done = true; break;
+		}
+	}
 }
 
-projectMSDL::projectMSDL(Settings settings, int flags) : projectM(settings, flags) {
-    width = getWindowWidth();
-    height = getWindowHeight();
-    done = 0;
-    isFullScreen = false;
+void projectMSDL::renderFrame()
+{
+	glClearColor(0.0, 0.0, 0.0, 0.0);
+	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+	projectM::renderFrame();
+
+	if (renderToTexture)
+	{
+		renderTexture();
+	}
+
+	SDL_GL_SwapWindow(win);
 }
 
-projectMSDL::projectMSDL(std::string config_file, int flags) : projectM(config_file, flags) {
-    width = getWindowWidth();
-    height = getWindowHeight();
-    done = 0;
-    isFullScreen = false;
+projectMSDL::projectMSDL(Settings settings, int flags) : projectM(settings, flags)
+{
+	width = getWindowWidth();
+	height = getWindowHeight();
+	done = 0;
+	isFullScreen = false;
 }
 
-void projectMSDL::init(SDL_Window *window, SDL_GLContext *_glCtx, const bool _renderToTexture) {
-    win = window;
-    glCtx = _glCtx;
-    projectM_resetGL(width, height);
-
-    // are we rendering to a texture?
-    renderToTexture = _renderToTexture;
-    if (renderToTexture) {
-        programID = ShaderEngine::CompileShaderProgram(ShaderEngine::v2f_c4f_t2f_vert, ShaderEngine::v2f_c4f_t2f_frag, "v2f_c4f_t2f");
-        textureID = projectM::initRenderToTexture();
-
-        float points[16] = {
-            -0.8, -0.8,
-            0.0,    0.0,
-
-            -0.8, 0.8,
-            0.0,   1.0,
-
-            0.8, -0.8,
-            1.0,    0.0,
-
-            0.8, 0.8,
-            1.0,    1.0,
-        };
-
-        glGenBuffers(1, &m_vbo);
-        glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
-        glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 16, points, GL_DYNAMIC_DRAW);
-
-        glGenVertexArrays(1, &m_vao);
-        glBindVertexArray(m_vao);
-
-        glEnableVertexAttribArray(0);
-        glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(float)*4, (void*)0); // Positions
-
-        glDisableVertexAttribArray(1);
-
-        glEnableVertexAttribArray(2);
-        glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(float)*4, (void*)(sizeof(float)*2)); // Textures
-
-        glBindVertexArray(0);
-        glBindBuffer(GL_ARRAY_BUFFER, 0);
-    }
+projectMSDL::projectMSDL(std::string config_file, int flags) : projectM(config_file, flags)
+{
+	width = getWindowWidth();
+	height = getWindowHeight();
+	done = 0;
+	isFullScreen = false;
 }
 
+void projectMSDL::init(SDL_Window *window, SDL_GLContext *_glCtx, const bool _renderToTexture)
+{
+	win = window;
+	glCtx = _glCtx;
+	projectM_resetGL(width, height);
+
+	// are we rendering to a texture?
+	renderToTexture = _renderToTexture;
+	if (renderToTexture)
+	{
+		programID = ShaderEngine::CompileShaderProgram(
+			ShaderEngine::v2f_c4f_t2f_vert, ShaderEngine::v2f_c4f_t2f_frag, "v2f_c4f_t2f");
+		textureID = projectM::initRenderToTexture();
+
+		float points[16] = {
+			-0.8,
+			-0.8,
+			0.0,
+			0.0,
+
+			-0.8,
+			0.8,
+			0.0,
+			1.0,
+
+			0.8,
+			-0.8,
+			1.0,
+			0.0,
+
+			0.8,
+			0.8,
+			1.0,
+			1.0,
+		};
+
+		glGenBuffers(1, &m_vbo);
+		glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
+		glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 16, points, GL_DYNAMIC_DRAW);
+
+		glGenVertexArrays(1, &m_vao);
+		glBindVertexArray(m_vao);
+
+		glEnableVertexAttribArray(0);
+		glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(float) * 4, (void *)0); // Positions
+
+		glDisableVertexAttribArray(1);
+
+		glEnableVertexAttribArray(2);
+		glVertexAttribPointer(
+			2, 2, GL_FLOAT, GL_FALSE, sizeof(float) * 4, (void *)(sizeof(float) * 2)); // Textures
+
+		glBindVertexArray(0);
+		glBindBuffer(GL_ARRAY_BUFFER, 0);
+	}
+}
 
 std::string projectMSDL::getActivePresetName()
 {
-    unsigned int index = 0;
-    if (selectedPresetIndex(index)) {
-        return getPresetName(index);
-    }
-    return std::string();
+	unsigned int index = 0;
+	if (selectedPresetIndex(index))
+	{
+		return getPresetName(index);
+	}
+	return std::string();
 }
 
+void projectMSDL::renderTexture()
+{
+	static int frame = 0;
+	frame++;
 
-void projectMSDL::renderTexture() {
-    static int frame = 0;
-    frame++;
+	glClear(GL_COLOR_BUFFER_BIT);
+	glClear(GL_DEPTH_BUFFER_BIT);
 
-    glClear(GL_COLOR_BUFFER_BIT);
-    glClear(GL_DEPTH_BUFFER_BIT);
+	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+	glViewport(0, 0, getWindowWidth(), getWindowHeight());
 
-    glViewport(0, 0, getWindowWidth(), getWindowHeight());
+	glUseProgram(programID);
 
-    glUseProgram(programID);
+	glUniform1i(glGetUniformLocation(programID, "texture_sampler"), 0);
 
-    glUniform1i(glGetUniformLocation(programID, "texture_sampler"), 0);
+	glm::mat4 mat_proj = glm::frustum(-1.0f, 1.0f, -1.0f, 1.0f, 2.0f, 10.0f);
 
-    glm::mat4 mat_proj = glm::frustum(-1.0f, 1.0f, -1.0f, 1.0f, 2.0f, 10.0f);
+	glEnable(GL_DEPTH_TEST);
 
-    glEnable(GL_DEPTH_TEST);
+	glm::mat4 mat_model = glm::mat4(1.0f);
+	mat_model = glm::translate(
+		mat_model, glm::vec3(cos(frame * 0.023), cos(frame * 0.017), -5 + sin(frame * 0.022) * 2));
+	mat_model = glm::rotate(mat_model, glm::radians((float)sin(frame * 0.0043) * 360),
+		glm::vec3(sin(frame * 0.0017), sin(frame * 0.0032), 1));
 
-    glm::mat4 mat_model = glm::mat4(1.0f);
-    mat_model = glm::translate(mat_model, glm::vec3(cos(frame*0.023),
-                                                    cos(frame*0.017),
-                                                    -5+sin(frame*0.022)*2));
-    mat_model = glm::rotate(mat_model, glm::radians((float) sin(frame*0.0043)*360),
-                            glm::vec3(sin(frame*0.0017),
-                                      sin(frame *0.0032),
-                                      1));
+	glm::mat4 mat_transf = glm::mat4(1.0f);
+	mat_transf = mat_proj * mat_model;
 
-    glm::mat4 mat_transf = glm::mat4(1.0f);
-    mat_transf = mat_proj * mat_model;
+	glUniformMatrix4fv(glGetUniformLocation(programID, "vertex_transformation"), 1, GL_FALSE,
+		glm::value_ptr(mat_transf));
 
-    glUniformMatrix4fv(glGetUniformLocation(programID, "vertex_transformation"), 1, GL_FALSE, glm::value_ptr(mat_transf));
+	glActiveTexture(GL_TEXTURE0);
 
-    glActiveTexture(GL_TEXTURE0);
+	glBindTexture(GL_TEXTURE_2D, textureID);
 
-    glBindTexture(GL_TEXTURE_2D, textureID);
+	glVertexAttrib4f(1, 1.0, 1.0, 1.0, 1.0);
 
-    glVertexAttrib4f(1, 1.0, 1.0, 1.0, 1.0);
+	glBindVertexArray(m_vao);
 
-    glBindVertexArray(m_vao);
+	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
-    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+	glBindVertexArray(0);
 
-    glBindVertexArray(0);
-
-    glDisable(GL_DEPTH_TEST);
+	glDisable(GL_DEPTH_TEST);
 }
 
-void projectMSDL::presetSwitchedEvent(bool isHardCut, size_t index) const {
-    std::string presetName = getPresetName(index);
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Displaying preset: %s\n", presetName.c_str());
+void projectMSDL::presetSwitchedEvent(bool isHardCut, size_t index) const
+{
+	std::string presetName = getPresetName(index);
+	SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Displaying preset: %s\n", presetName.c_str());
 }

--- a/src/projectM-sdl/pmSDL.cpp
+++ b/src/projectM-sdl/pmSDL.cpp
@@ -1,239 +1,154 @@
 /**
- * projectM -- Milkdrop-esque visualisation SDK
- * Copyright (C)2003-2019 projectM Team
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- * See 'LICENSE.txt' included within this release
- *
- * projectM-sdl
- * This is an implementation of projectM using libSDL2
- *
- * pmSDL.cpp
- * Authors: Created by Mischa Spiegelmock on 2017-09-18.
- *
- *
- * experimental Stereoscopic SBS driver functionality by
- *	RobertPancoast77@gmail.com
- */
+* projectM -- Milkdrop-esque visualisation SDK
+* Copyright (C)2003-2019 projectM Team
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this library; if not, write to the Free Software
+* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+* See 'LICENSE.txt' included within this release
+*
+* projectM-sdl
+* This is an implementation of projectM using libSDL2
+*
+* pmSDL.cpp
+* Authors: Created by Mischa Spiegelmock on 2017-09-18.
+*
+*
+* experimental Stereoscopic SBS driver functionality by
+*	RobertPancoast77@gmail.com
+*/
 
 #include "pmSDL.hpp"
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>
 #include "Renderer/ShaderEngine.hpp"
 
-void projectMSDL::audioInputCallbackF32(void *userdata, unsigned char *stream, int len)
-{
-	projectMSDL *app = (projectMSDL *)userdata;
-	//    printf("LEN: %i\n", len);
-	// stream is (i think) samples*channels floats (native byte order) of len BYTES
-	if (app->audioChannelsCount == 1)
-		app->pcm()->addPCMfloat((float *)stream, len / sizeof(float));
-	else if (app->audioChannelsCount == 2)
-		app->pcm()->addPCMfloat_2ch((float *)stream, len / sizeof(float));
-	else
-	{
-		SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, "Multichannel audio not supported");
-		SDL_Quit();
-	}
+
+void projectMSDL::audioInputCallbackF32(void *userdata, unsigned char *stream, int len) {
+    projectMSDL *app = (projectMSDL *) userdata;
+    //    printf("LEN: %i\n", len);
+    // stream is (i think) samples*channels floats (native byte order) of len BYTES
+    if (app->audioChannelsCount == 1)
+        app->pcm()->addPCMfloat((float *)stream, len/sizeof(float));
+    else if (app->audioChannelsCount == 2)
+        app->pcm()->addPCMfloat_2ch((float *)stream, len/sizeof(float));
+    else {
+        SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, "Multichannel audio not supported");
+        SDL_Quit();
+    }
 }
 
-void projectMSDL::audioInputCallbackS16(void *userdata, unsigned char *stream, int len)
-{
-	//    printf("LEN: %i\n", len);
-	projectMSDL *app = (projectMSDL *)userdata;
-	short pcm16[2][512];
+void projectMSDL::audioInputCallbackS16(void *userdata, unsigned char *stream, int len) {
+    //    printf("LEN: %i\n", len);
+    projectMSDL *app = (projectMSDL *) userdata;
+    short pcm16[2][512];
 
-	for (int i = 0; i < 512; i++)
-	{
-		for (int j = 0; j < app->audioChannelsCount; j++)
-		{
-			pcm16[j][i] = stream[i + j];
-		}
-	}
-	app->pcm()->addPCM16(pcm16);
+    for (int i = 0; i < 512; i++) {
+        for (int j = 0; j < app->audioChannelsCount; j++) {
+            pcm16[j][i] = stream[i+j];
+        }
+    }
+    app->pcm()->addPCM16(pcm16);
 }
 
-SDL_AudioDeviceID projectMSDL::selectAudioInput(int _count)
-{
-	// TODO: implement some sort of UI allowing the user to select which audio input device they would
-	// like to use
+SDL_AudioDeviceID projectMSDL::selectAudioInput(int _count) {
+    // TODO: implement some sort of UI allowing the user to select which audio input device they would like to use
 
-	// ask the user which capture device to use
-	// printf("Please select which audio input to use:\n");
-	printf("Detected devices:\n");
-	for (int i = 0; i < _count; i++)
-	{
-		printf("  %i: 🎤%s\n", i, SDL_GetAudioDeviceName(i, true));
-	}
 
-	return 0;
+    // ask the user which capture device to use
+    // printf("Please select which audio input to use:\n");
+    printf("Detected devices:\n");
+    for (int i = 0; i < _count; i++) {
+        printf("  %i: 🎤%s\n", i, SDL_GetAudioDeviceName(i, true));
+    }
+
+    return 0;
 }
 
-int projectMSDL::openAudioInput()
-{
-	// get audio driver name (static)
-	const char *driver_name = SDL_GetCurrentAudioDriver();
-	SDL_Log("Using audio driver: %s\n", driver_name);
+int projectMSDL::openAudioInput() {
+    // get audio driver name (static)
+    const char* driver_name = SDL_GetCurrentAudioDriver();
+    SDL_Log("Using audio driver: %s\n", driver_name);
 
-	// get audio input device
-	unsigned int i, count2 = SDL_GetNumAudioDevices(true); // capture, please
-	if (count2 == 0)
-	{
-		SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, "No audio capture devices found");
-		SDL_Quit();
-	}
-	for (i = 0; i < count2; i++)
-	{
-		SDL_Log("Found audio capture device %d: %s", i, SDL_GetAudioDeviceName(i, true));
-	}
+    // get audio input device
+    unsigned int i, count2 = SDL_GetNumAudioDevices(true);  // capture, please
+    if (count2 == 0) {
+        SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, "No audio capture devices found");
+        SDL_Quit();
+    }
+    for (i = 0; i < count2; i++) {
+        SDL_Log("Found audio capture device %d: %s", i, SDL_GetAudioDeviceName(i, true));
+    }
 
-	SDL_AudioDeviceID selectedAudioDevice = 0; // device to open
-	if (count2 > 1)
-	{
-		// need to choose which input device to use
-		selectedAudioDevice = selectAudioInput(count2);
-		if (selectedAudioDevice > count2)
-		{
-			SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, "No audio input device specified.");
-			SDL_Quit();
-		}
-	}
+    SDL_AudioDeviceID selectedAudioDevice = 0;  // device to open
+    if (count2 > 1) {
+        // need to choose which input device to use
+        selectedAudioDevice = selectAudioInput(count2);
+	if (selectedAudioDevice > count2) {
+            SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, "No audio input device specified.");
+            SDL_Quit();
+        }
+    }
 
-	// params for audio input
-	SDL_AudioSpec want, have;
+    // params for audio input
+    SDL_AudioSpec want, have;
 
-	// requested format
-	// https://wiki.libsdl.org/SDL_AudioSpec#Remarks
-	SDL_zero(want);
-	want.freq = 44100;
-	want.format = AUDIO_F32; // float
-	want.channels = 2;
-	want.samples = PCM::maxsamples;
-	want.callback = projectMSDL::audioInputCallbackF32;
-	want.userdata = this;
+    // requested format
+    // https://wiki.libsdl.org/SDL_AudioSpec#Remarks
+    SDL_zero(want);
+    want.freq = 44100;
+    want.format = AUDIO_F32;  // float
+    want.channels = 2;
+    want.samples = PCM::maxsamples;
+    want.callback = projectMSDL::audioInputCallbackF32;
+    want.userdata = this;
 
-	audioDeviceID =
-		SDL_OpenAudioDevice(SDL_GetAudioDeviceName(selectedAudioDevice, true), true, &want, &have, 0);
+    audioDeviceID = SDL_OpenAudioDevice(SDL_GetAudioDeviceName(selectedAudioDevice, true), true, &want, &have, 0);
 
-	if (audioDeviceID == 0)
-	{
-		SDL_LogCritical(
-			SDL_LOG_CATEGORY_APPLICATION, "Failed to open audio capture device: %s", SDL_GetError());
-		SDL_Quit();
-	}
+    if (audioDeviceID == 0) {
+        SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, "Failed to open audio capture device: %s", SDL_GetError());
+        SDL_Quit();
+    }
 
-	// read characteristics of opened capture device
-	SDL_Log("Opened audio capture device index=%i devId=%i: %s", selectedAudioDevice, audioDeviceID,
-		SDL_GetAudioDeviceName(selectedAudioDevice, true));
-	SDL_Log("Samples: %i, frequency: %i, channels: %i, format: %i", have.samples, have.freq,
-		have.channels, have.format);
-	audioChannelsCount = have.channels;
-	audioSampleRate = have.freq;
-	audioSampleCount = have.samples;
-	audioFormat = have.format;
-	audioInputDevice = audioDeviceID;
-	return 1;
+    // read characteristics of opened capture device
+    SDL_Log("Opened audio capture device index=%i devId=%i: %s", selectedAudioDevice, audioDeviceID, SDL_GetAudioDeviceName(selectedAudioDevice, true));
+    SDL_Log("Samples: %i, frequency: %i, channels: %i, format: %i", have.samples, have.freq, have.channels, have.format);
+    audioChannelsCount = have.channels;
+    audioSampleRate = have.freq;
+    audioSampleCount = have.samples;
+    audioFormat = have.format;
+    audioInputDevice = audioDeviceID;
+    return 1;
 }
 
-void projectMSDL::beginAudioCapture()
-{
-	// allocate a buffer to store PCM data for feeding in
-	SDL_PauseAudioDevice(audioDeviceID, false);
+void projectMSDL::beginAudioCapture() {
+    // allocate a buffer to store PCM data for feeding in
+    SDL_PauseAudioDevice(audioDeviceID, false);
 }
 
-void projectMSDL::endAudioCapture()
-{
-	SDL_PauseAudioDevice(audioDeviceID, true);
+void projectMSDL::endAudioCapture() {
+    SDL_PauseAudioDevice(audioDeviceID, true);
 }
 
-void projectMSDL::maximize()
-{
-	SDL_DisplayMode dm;
-	if (SDL_GetDesktopDisplayMode(0, &dm) != 0)
-	{
-		SDL_Log("SDL_GetDesktopDisplayMode failed: %s", SDL_GetError());
-		return;
-	}
+void projectMSDL::maximize() {
+    SDL_DisplayMode dm;
+    if (SDL_GetDesktopDisplayMode(0, &dm) != 0) {
+        SDL_Log("SDL_GetDesktopDisplayMode failed: %s", SDL_GetError());
+        return;
+    }
 
-	SDL_SetWindowSize(win, dm.w, dm.h);
-	resize(dm.w, dm.h);
-}
-
-/* Moves projectM to the next monitor */
-void projectMSDL::stretchMonitors()
-{
-	int displayCount = SDL_GetNumVideoDisplays();
-	if (displayCount >= 2)
-	{
-		std::vector<SDL_Rect> displayBounds;
-		for (int i = 0; i < displayCount; i++)
-		{
-			displayBounds.push_back(SDL_Rect());
-			SDL_GetDisplayBounds(i, &displayBounds.back());
-		}
-
-		int furthestX = 0;
-		int furthestY = 0;
-		int widest = 0;
-		int highest = 0;
-		int spanX = 0;
-		int spanY = 0;
-		int spanWidth = 0;
-		int spanHeight = 0;
-
-		bool horizontal = true;
-		bool vertical = true;
-
-		for (int i = 0; i < displayCount; i++)
-		{
-			if (displayBounds[0].x != displayBounds[i].x) vertical = false;
-			if (displayBounds[0].y != displayBounds[i].y) horizontal = false;
-		}
-
-		if (!vertical && !horizontal)
-		{
-			// If multiple montors are not perfectly aligned it's a bit of work to get the correct x,y and
-			// dimensions But in my testing on Windows 10 even with the screen did not render correctly.
-			// @todo more testing and make it work.
-			SDL_Log(
-				"SDL currently only supports multiple monitors that are aligned evenly in a vertical or "
-				"horizontal position.");
-		}
-		else
-		{
-			for (int i = 0; i < displayCount; i++)
-			{
-				if (displayBounds[i].x < furthestX) spanX = displayBounds[i].x; // X furthest left device
-				if (displayBounds[i].y < furthestY) spanY = displayBounds[i].y; // Y highest device
-				if (displayBounds[i].h > highest) highest = displayBounds[i].h; // highest resolution Height
-				if (displayBounds[i].h > widest) widest = displayBounds[i].w;	// highest resolution Width
-				if (horizontal) // perfectly aligned horizonal monitors.
-				{
-					spanHeight = highest;
-					spanWidth = spanWidth + displayBounds[i].w;
-				}
-				else if (vertical) // perfectly aligned vertical monitors.
-				{
-					spanHeight = spanHeight + displayBounds[i].h;
-					spanWidth = widest;
-				}
-			}
-			SDL_SetWindowPosition(win, spanX, spanY);
-			SDL_SetWindowSize(win, spanWidth, spanHeight);
-		}
-	}
+    SDL_SetWindowSize(win, dm.w, dm.h);
+    resize(dm.w, dm.h);
 }
 
 /* Moves projectM to the next monitor */
@@ -258,42 +173,35 @@ void projectMSDL::nextMonitor()
 	}
 }
 
-void projectMSDL::toggleFullScreen()
-{
-	maximize();
-	if (isFullScreen)
-	{
-		SDL_SetWindowFullscreen(win, 0);
-		isFullScreen = false;
-		SDL_ShowCursor(true);
-	}
-	else
-	{
-		SDL_ShowCursor(false);
-		SDL_SetWindowFullscreen(win, SDL_WINDOW_FULLSCREEN);
-		isFullScreen = true;
-	}
+void projectMSDL::toggleFullScreen() {
+    maximize();
+    if (isFullScreen) {
+        SDL_SetWindowFullscreen(win, 0);
+        isFullScreen = false;
+        SDL_ShowCursor(true);
+    } else {
+        SDL_ShowCursor(false);
+        SDL_SetWindowFullscreen(win, SDL_WINDOW_FULLSCREEN);
+        isFullScreen = true;
+    }
 }
 
-void projectMSDL::keyHandler(SDL_Event *sdl_evt)
-{
-	projectMEvent evt;
-	projectMKeycode key;
-	projectMModifier mod;
-	SDL_Keymod sdl_mod = (SDL_Keymod)sdl_evt->key.keysym.mod;
-	SDL_Keycode sdl_keycode = sdl_evt->key.keysym.sym;
+void projectMSDL::keyHandler(SDL_Event *sdl_evt) {
+    projectMEvent evt;
+    projectMKeycode key;
+    projectMModifier mod;
+    SDL_Keymod sdl_mod = (SDL_Keymod) sdl_evt->key.keysym.mod;
+    SDL_Keycode sdl_keycode = sdl_evt->key.keysym.sym;
 
 	// handle keyboard input (for our app first, then projectM)
-	switch (sdl_keycode)
-	{
-		case SDLK_q:
-			if (sdl_mod & KMOD_LGUI || sdl_mod & KMOD_RGUI || sdl_mod & KMOD_LCTRL)
-			{
-				// cmd/ctrl-q = quit
-				done = 1;
-				return;
-			}
-			break;
+    switch (sdl_keycode) {
+        case SDLK_q:
+            if (sdl_mod & KMOD_LGUI || sdl_mod & KMOD_RGUI || sdl_mod & KMOD_LCTRL) {
+                // cmd/ctrl-q = quit
+                done = 1;
+                return;
+            }
+            break;
 		case SDLK_m:
 			if (sdl_mod & KMOD_LGUI || sdl_mod & KMOD_RGUI || sdl_mod & KMOD_LCTRL)
 			{
@@ -304,307 +212,269 @@ void projectMSDL::keyHandler(SDL_Event *sdl_evt)
 #endif
 				return; // handled
 			}
-		case SDLK_s:
-			if (sdl_mod & KMOD_LGUI || sdl_mod & KMOD_RGUI || sdl_mod & KMOD_LCTRL)
-			{
-				// command-s: [s]tretch monitors
-				// Stereo requires fullscreen
-#if !STEREOSCOPIC_SBS
-				stretchMonitors();
-#endif
-				return; // handled
-			}
-		case SDLK_f:
-			if (sdl_mod & KMOD_LGUI || sdl_mod & KMOD_RGUI || sdl_mod & KMOD_LCTRL)
-			{
-				// command-f: fullscreen
+        case SDLK_f:
+            if (sdl_mod & KMOD_LGUI || sdl_mod & KMOD_RGUI || sdl_mod & KMOD_LCTRL) {
+                // command-f: fullscreen
 				// Stereo requires fullscreen
 #if !STEREOSCOPIC_SBS
 				toggleFullScreen();
 #endif
-				return; // handled
-			}
-			break;
-		case SDLK_LEFT:
-			// selectPrevious(true);
-			break;
-		case SDLK_RIGHT:
-			// selectNext(true);
-			break;
-		case SDLK_UP: break;
-		case SDLK_DOWN: break;
-
-		case SDLK_F3: break;
-
-		case SDLK_SPACE: setPresetLock(!isPresetLocked()); break;
-		case SDLK_F1:
-		case SDLK_ESCAPE:
-
-			// exit(1);
-			// show help with other keys
-			sdl_keycode = SDLK_F1;
-			break;
-		case SDLK_DELETE:
-			/*
-			try {
-				if (selectedPresetIndex(index)) {
-					DeleteFile(
-						LPCSTR(
-							getPresetURL(index).c_str()
-						)
-					);
-				}
-			}
-			catch (const std::exception & e) {
-				printf("Delete failed");
-			}
-			*/
-			break;
-		case SDLK_RETURN:
-			/*
-			try {
-				if (selectedPresetIndex(index)) {
-					CopyFile(
-							LPCSTR(
-									app->getPresetURL(index).c_str()
-							),
-							LPCTSTR(L"C:\\"),
-							false
-					);
-				}
-			}
-			catch (const std::exception & e) {
-				printf("Delete failed");
-			}
-					*/
-			break;
-	}
-
-	// translate into projectM codes and perform default projectM handler
-	evt = sdl2pmEvent(sdl_evt);
-	key = sdl2pmKeycode(sdl_keycode);
-	mod = sdl2pmModifier(sdl_mod);
-	key_handler(evt, key, mod);
-}
-
-void projectMSDL::addFakePCM()
-{
-	int i;
-	short pcm_data[2][512];
-	/** Produce some fake PCM data to stuff into projectM */
-	for (i = 0; i < 512; i++)
-	{
-		if (i % 2 == 0)
-		{
-			pcm_data[0][i] = (float)(rand() / ((float)RAND_MAX) * (pow(2, 14)));
-			pcm_data[1][i] = (float)(rand() / ((float)RAND_MAX) * (pow(2, 14)));
-		}
-		else
-		{
-			pcm_data[0][i] = (float)(rand() / ((float)RAND_MAX) * (pow(2, 14)));
-			pcm_data[1][i] = (float)(rand() / ((float)RAND_MAX) * (pow(2, 14)));
-		}
-		if (i % 2 == 1)
-		{
-			pcm_data[0][i] = -pcm_data[0][i];
-			pcm_data[1][i] = -pcm_data[1][i];
-		}
-	}
-
-	/** Add the waveform data */
-	pcm()->addPCM16(pcm_data);
-}
-
-void projectMSDL::resize(unsigned int width_, unsigned int height_)
-{
-	if (width_ != 0 && height_ != 0)
-	{
-		width = width_;
-		height = height_;
-		projectM_resetGL(width, height);
-	}
-}
-
-void projectMSDL::move(unsigned int x_, unsigned int y_)
-{
-	if (x_ != 0 && y_ != 0)
-	{
-		projectM_resetGL(x_, y_);
-	}
-}
-
-void projectMSDL::pollEvent()
-{
-	SDL_Event evt;
-
-	while (SDL_PollEvent(&evt))
-	{
-		switch (evt.type)
-		{
-			case SDL_WINDOWEVENT:
-				switch (evt.window.event)
-				{
-					case SDL_WINDOWEVENT_RESIZED: 
-						resize(evt.window.data1, evt.window.data2); 
+                return; // handled
+            }
+            break;
+					case SDLK_LEFT:
+						// selectPrevious(true);
 						break;
-					case SDL_WINDOWEVENT_SIZE_CHANGED: 
-						resize(evt.window.data1, evt.window.data2);
+					case SDLK_RIGHT:
+						// selectNext(true);
 						break;
-				}
-				break;
-			case SDL_KEYDOWN: keyHandler(&evt); break;
-			case SDL_QUIT: done = true; break;
-		}
-	}
+					case SDLK_UP:
+						break;
+					case SDLK_DOWN:
+						break;
+
+					case SDLK_F3:
+						break;
+
+
+					case SDLK_SPACE:
+						setPresetLock(
+							!isPresetLocked()
+						);
+						break;
+					case SDLK_F1:
+					case SDLK_ESCAPE:
+
+						// exit(1);
+						// show help with other keys
+						sdl_keycode = SDLK_F1;
+						break;
+					case SDLK_DELETE:
+						/*
+						try {
+							if (selectedPresetIndex(index)) {
+								DeleteFile(
+									LPCSTR(
+										getPresetURL(index).c_str()
+									)
+								);
+							}
+						}
+						catch (const std::exception & e) {
+							printf("Delete failed");
+						}
+						*/
+						break;
+					case SDLK_RETURN:
+						/*
+						try {
+							if (selectedPresetIndex(index)) {
+								CopyFile(
+										LPCSTR(
+												app->getPresetURL(index).c_str()
+										),
+										LPCTSTR(L"C:\\"),
+										false
+								);
+							}
+						}
+						catch (const std::exception & e) {
+							printf("Delete failed");
+						}
+								*/
+						break;
+    }
+
+    // translate into projectM codes and perform default projectM handler
+    evt = sdl2pmEvent(sdl_evt);
+    key = sdl2pmKeycode(sdl_keycode);
+    mod = sdl2pmModifier(sdl_mod);
+    key_handler(evt, key, mod);
 }
 
-void projectMSDL::renderFrame()
-{
-	glClearColor(0.0, 0.0, 0.0, 0.0);
-	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+void projectMSDL::addFakePCM() {
+    int i;
+    short pcm_data[2][512];
+    /** Produce some fake PCM data to stuff into projectM */
+    for ( i = 0 ; i < 512 ; i++ ) {
+        if ( i % 2 == 0 ) {
+            pcm_data[0][i] = (float)( rand() / ( (float)RAND_MAX ) * (pow(2,14) ) );
+            pcm_data[1][i] = (float)( rand() / ( (float)RAND_MAX ) * (pow(2,14) ) );
+        } else {
+            pcm_data[0][i] = (float)( rand() / ( (float)RAND_MAX ) * (pow(2,14) ) );
+            pcm_data[1][i] = (float)( rand() / ( (float)RAND_MAX ) * (pow(2,14) ) );
+        }
+        if ( i % 2 == 1 ) {
+            pcm_data[0][i] = -pcm_data[0][i];
+            pcm_data[1][i] = -pcm_data[1][i];
+        }
+    }
 
-	projectM::renderFrame();
-
-	if (renderToTexture)
-	{
-		renderTexture();
-	}
-
-	SDL_GL_SwapWindow(win);
+    /** Add the waveform data */
+    pcm()->addPCM16(pcm_data);
 }
 
-projectMSDL::projectMSDL(Settings settings, int flags) : projectM(settings, flags)
-{
-	width = getWindowWidth();
-	height = getWindowHeight();
-	done = 0;
-	isFullScreen = false;
+void projectMSDL::resize(unsigned int width_, unsigned int height_) {
+    width = width_;
+    height = height_;
+    projectM_resetGL(width, height);
 }
 
-projectMSDL::projectMSDL(std::string config_file, int flags) : projectM(config_file, flags)
-{
-	width = getWindowWidth();
-	height = getWindowHeight();
-	done = 0;
-	isFullScreen = false;
+void projectMSDL::pollEvent() {
+    SDL_Event evt;
+
+    while (SDL_PollEvent(&evt))
+    {
+        switch (evt.type) {
+            case SDL_WINDOWEVENT:
+                switch (evt.window.event) {
+                    case SDL_WINDOWEVENT_RESIZED:
+                        resize(evt.window.data1, evt.window.data2);
+                        break;
+                }
+                break;
+            case SDL_KEYDOWN:
+                keyHandler(&evt);
+                break;
+            case SDL_QUIT:
+                done = true;
+                break;
+        }
+    }
 }
 
-void projectMSDL::init(SDL_Window *window, SDL_GLContext *_glCtx, const bool _renderToTexture)
-{
-	win = window;
-	glCtx = _glCtx;
-	projectM_resetGL(width, height);
+void projectMSDL::renderFrame() {
+    glClearColor( 0.0, 0.0, 0.0, 0.0 );
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-	// are we rendering to a texture?
-	renderToTexture = _renderToTexture;
-	if (renderToTexture)
-	{
-		programID = ShaderEngine::CompileShaderProgram(
-			ShaderEngine::v2f_c4f_t2f_vert, ShaderEngine::v2f_c4f_t2f_frag, "v2f_c4f_t2f");
-		textureID = projectM::initRenderToTexture();
+    projectM::renderFrame();
 
-		float points[16] = {
-			-0.8,
-			-0.8,
-			0.0,
-			0.0,
+    if (renderToTexture) {
+        renderTexture();
+    }
 
-			-0.8,
-			0.8,
-			0.0,
-			1.0,
-
-			0.8,
-			-0.8,
-			1.0,
-			0.0,
-
-			0.8,
-			0.8,
-			1.0,
-			1.0,
-		};
-
-		glGenBuffers(1, &m_vbo);
-		glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
-		glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 16, points, GL_DYNAMIC_DRAW);
-
-		glGenVertexArrays(1, &m_vao);
-		glBindVertexArray(m_vao);
-
-		glEnableVertexAttribArray(0);
-		glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(float) * 4, (void *)0); // Positions
-
-		glDisableVertexAttribArray(1);
-
-		glEnableVertexAttribArray(2);
-		glVertexAttribPointer(
-			2, 2, GL_FLOAT, GL_FALSE, sizeof(float) * 4, (void *)(sizeof(float) * 2)); // Textures
-
-		glBindVertexArray(0);
-		glBindBuffer(GL_ARRAY_BUFFER, 0);
-	}
+    SDL_GL_SwapWindow(win);
 }
+
+projectMSDL::projectMSDL(Settings settings, int flags) : projectM(settings, flags) {
+    width = getWindowWidth();
+    height = getWindowHeight();
+    done = 0;
+    isFullScreen = false;
+}
+
+projectMSDL::projectMSDL(std::string config_file, int flags) : projectM(config_file, flags) {
+    width = getWindowWidth();
+    height = getWindowHeight();
+    done = 0;
+    isFullScreen = false;
+}
+
+void projectMSDL::init(SDL_Window *window, SDL_GLContext *_glCtx, const bool _renderToTexture) {
+    win = window;
+    glCtx = _glCtx;
+    projectM_resetGL(width, height);
+
+    // are we rendering to a texture?
+    renderToTexture = _renderToTexture;
+    if (renderToTexture) {
+        programID = ShaderEngine::CompileShaderProgram(ShaderEngine::v2f_c4f_t2f_vert, ShaderEngine::v2f_c4f_t2f_frag, "v2f_c4f_t2f");
+        textureID = projectM::initRenderToTexture();
+
+        float points[16] = {
+            -0.8, -0.8,
+            0.0,    0.0,
+
+            -0.8, 0.8,
+            0.0,   1.0,
+
+            0.8, -0.8,
+            1.0,    0.0,
+
+            0.8, 0.8,
+            1.0,    1.0,
+        };
+
+        glGenBuffers(1, &m_vbo);
+        glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
+        glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 16, points, GL_DYNAMIC_DRAW);
+
+        glGenVertexArrays(1, &m_vao);
+        glBindVertexArray(m_vao);
+
+        glEnableVertexAttribArray(0);
+        glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(float)*4, (void*)0); // Positions
+
+        glDisableVertexAttribArray(1);
+
+        glEnableVertexAttribArray(2);
+        glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(float)*4, (void*)(sizeof(float)*2)); // Textures
+
+        glBindVertexArray(0);
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
+    }
+}
+
 
 std::string projectMSDL::getActivePresetName()
 {
-	unsigned int index = 0;
-	if (selectedPresetIndex(index))
-	{
-		return getPresetName(index);
-	}
-	return std::string();
+    unsigned int index = 0;
+    if (selectedPresetIndex(index)) {
+        return getPresetName(index);
+    }
+    return std::string();
 }
 
-void projectMSDL::renderTexture()
-{
-	static int frame = 0;
-	frame++;
 
-	glClear(GL_COLOR_BUFFER_BIT);
-	glClear(GL_DEPTH_BUFFER_BIT);
+void projectMSDL::renderTexture() {
+    static int frame = 0;
+    frame++;
 
-	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glClear(GL_DEPTH_BUFFER_BIT);
 
-	glViewport(0, 0, getWindowWidth(), getWindowHeight());
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-	glUseProgram(programID);
+    glViewport(0, 0, getWindowWidth(), getWindowHeight());
 
-	glUniform1i(glGetUniformLocation(programID, "texture_sampler"), 0);
+    glUseProgram(programID);
 
-	glm::mat4 mat_proj = glm::frustum(-1.0f, 1.0f, -1.0f, 1.0f, 2.0f, 10.0f);
+    glUniform1i(glGetUniformLocation(programID, "texture_sampler"), 0);
 
-	glEnable(GL_DEPTH_TEST);
+    glm::mat4 mat_proj = glm::frustum(-1.0f, 1.0f, -1.0f, 1.0f, 2.0f, 10.0f);
 
-	glm::mat4 mat_model = glm::mat4(1.0f);
-	mat_model = glm::translate(
-		mat_model, glm::vec3(cos(frame * 0.023), cos(frame * 0.017), -5 + sin(frame * 0.022) * 2));
-	mat_model = glm::rotate(mat_model, glm::radians((float)sin(frame * 0.0043) * 360),
-		glm::vec3(sin(frame * 0.0017), sin(frame * 0.0032), 1));
+    glEnable(GL_DEPTH_TEST);
 
-	glm::mat4 mat_transf = glm::mat4(1.0f);
-	mat_transf = mat_proj * mat_model;
+    glm::mat4 mat_model = glm::mat4(1.0f);
+    mat_model = glm::translate(mat_model, glm::vec3(cos(frame*0.023),
+                                                    cos(frame*0.017),
+                                                    -5+sin(frame*0.022)*2));
+    mat_model = glm::rotate(mat_model, glm::radians((float) sin(frame*0.0043)*360),
+                            glm::vec3(sin(frame*0.0017),
+                                      sin(frame *0.0032),
+                                      1));
 
-	glUniformMatrix4fv(glGetUniformLocation(programID, "vertex_transformation"), 1, GL_FALSE,
-		glm::value_ptr(mat_transf));
+    glm::mat4 mat_transf = glm::mat4(1.0f);
+    mat_transf = mat_proj * mat_model;
 
-	glActiveTexture(GL_TEXTURE0);
+    glUniformMatrix4fv(glGetUniformLocation(programID, "vertex_transformation"), 1, GL_FALSE, glm::value_ptr(mat_transf));
 
-	glBindTexture(GL_TEXTURE_2D, textureID);
+    glActiveTexture(GL_TEXTURE0);
 
-	glVertexAttrib4f(1, 1.0, 1.0, 1.0, 1.0);
+    glBindTexture(GL_TEXTURE_2D, textureID);
 
-	glBindVertexArray(m_vao);
+    glVertexAttrib4f(1, 1.0, 1.0, 1.0, 1.0);
 
-	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+    glBindVertexArray(m_vao);
 
-	glBindVertexArray(0);
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
-	glDisable(GL_DEPTH_TEST);
+    glBindVertexArray(0);
+
+    glDisable(GL_DEPTH_TEST);
 }
 
-void projectMSDL::presetSwitchedEvent(bool isHardCut, size_t index) const
-{
-	std::string presetName = getPresetName(index);
-	SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Displaying preset: %s\n", presetName.c_str());
+void projectMSDL::presetSwitchedEvent(bool isHardCut, size_t index) const {
+    std::string presetName = getPresetName(index);
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Displaying preset: %s\n", presetName.c_str());
 }

--- a/src/projectM-sdl/pmSDL.cpp
+++ b/src/projectM-sdl/pmSDL.cpp
@@ -151,6 +151,28 @@ void projectMSDL::maximize() {
     resize(dm.w, dm.h);
 }
 
+/* Moves projectM to the next monitor */
+void projectMSDL::nextMonitor()
+{
+	int displayCount = SDL_GetNumVideoDisplays();
+	int currentWindowIndex = SDL_GetWindowDisplayIndex(win);
+	if (displayCount >= 2)
+	{
+		std::vector<SDL_Rect> displayBounds;
+		int nextWindow = currentWindowIndex + 1;
+		if (nextWindow > displayCount) nextWindow = 0;
+
+		for (int i = 0; i < displayCount; i++)
+		{
+			displayBounds.push_back(SDL_Rect());
+			SDL_GetDisplayBounds(i, &displayBounds.back());
+		}
+		SDL_SetWindowPosition(win, displayBounds[nextWindow].x, displayBounds[nextWindow].y);
+		SDL_SetWindowSize(win, displayBounds[nextWindow].w, displayBounds[nextWindow].h);
+		maximize();
+	}
+}
+
 void projectMSDL::toggleFullScreen() {
     maximize();
     if (isFullScreen) {
@@ -180,8 +202,16 @@ void projectMSDL::keyHandler(SDL_Event *sdl_evt) {
                 return;
             }
             break;
-
-
+		case SDLK_m:
+			if (sdl_mod & KMOD_LGUI || sdl_mod & KMOD_RGUI || sdl_mod & KMOD_LCTRL)
+			{
+				// command-m: change [m]onitor
+				// Stereo requires fullscreen
+#if !STEREOSCOPIC_SBS
+				nextMonitor();
+#endif
+				return; // handled
+			}
         case SDLK_f:
             if (sdl_mod & KMOD_LGUI || sdl_mod & KMOD_RGUI || sdl_mod & KMOD_LCTRL) {
                 // command-f: fullscreen

--- a/src/projectM-sdl/pmSDL.cpp
+++ b/src/projectM-sdl/pmSDL.cpp
@@ -151,6 +151,71 @@ void projectMSDL::maximize() {
     resize(dm.w, dm.h);
 }
 
+/* Stretch projectM across multiple monitors */
+void projectMSDL::stretchMonitors()
+{
+	int displayCount = SDL_GetNumVideoDisplays();
+	if (displayCount >= 2)
+	{
+		std::vector<SDL_Rect> displayBounds;
+		for (int i = 0; i < displayCount; i++)
+		{
+			displayBounds.push_back(SDL_Rect());
+			SDL_GetDisplayBounds(i, &displayBounds.back());
+		}
+
+		int furthestX = 0;
+		int furthestY = 0;
+		int widest = 0;
+		int highest = 0;
+		int spanX = 0;
+		int spanY = 0;
+		int spanWidth = 0;
+		int spanHeight = 0;
+
+		bool horizontal = true;
+		bool vertical = true;
+
+		for (int i = 0; i < displayCount; i++)
+		{
+			if (displayBounds[0].x != displayBounds[i].x) vertical = false;
+			if (displayBounds[0].y != displayBounds[i].y) horizontal = false;
+		}
+
+		if (!vertical && !horizontal)
+		{
+			// If multiple montors are not perfectly aligned it's a bit of work to get the correct x,y and
+			// dimensions But in my testing on Windows 10 even with the screen did not render correctly.
+			// @todo more testing and make it work.
+			SDL_Log(
+				"SDL currently only supports multiple monitors that are aligned evenly in a vertical or "
+				"horizontal position.");
+		}
+		else
+		{
+			for (int i = 0; i < displayCount; i++)
+			{
+				if (displayBounds[i].x < furthestX) spanX = displayBounds[i].x; // X furthest left device
+				if (displayBounds[i].y < furthestY) spanY = displayBounds[i].y; // Y highest device
+				if (displayBounds[i].h > highest) highest = displayBounds[i].h; // highest resolution Height
+				if (displayBounds[i].h > widest) widest = displayBounds[i].w;		// highest resolution Width
+				if (horizontal) // perfectly aligned horizonal monitors.
+				{
+					spanHeight = highest;
+					spanWidth = spanWidth + displayBounds[i].w;
+				}
+				else if (vertical) // perfectly aligned vertical monitors.
+				{
+					spanHeight = spanHeight + displayBounds[i].h;
+					spanWidth = widest;
+				}
+			}
+			SDL_SetWindowPosition(win, spanX, spanY);
+			SDL_SetWindowSize(win, spanWidth, spanHeight);
+		}
+	}
+}
+
 /* Moves projectM to the next monitor */
 void projectMSDL::nextMonitor()
 {
@@ -202,6 +267,16 @@ void projectMSDL::keyHandler(SDL_Event *sdl_evt) {
                 return;
             }
             break;
+		case SDLK_s:
+			if (sdl_mod & KMOD_LGUI || sdl_mod & KMOD_RGUI || sdl_mod & KMOD_LCTRL)
+			{
+				// command-s: [s]tretch monitors
+				// Stereo requires fullscreen
+#if !STEREOSCOPIC_SBS
+				stretchMonitors();
+#endif
+				return; // handled
+			}
 		case SDLK_m:
 			if (sdl_mod & KMOD_LGUI || sdl_mod & KMOD_RGUI || sdl_mod & KMOD_LCTRL)
 			{
@@ -328,9 +403,12 @@ void projectMSDL::pollEvent() {
         switch (evt.type) {
             case SDL_WINDOWEVENT:
                 switch (evt.window.event) {
-                    case SDL_WINDOWEVENT_RESIZED:
-                        resize(evt.window.data1, evt.window.data2);
-                        break;
+					case SDL_WINDOWEVENT_RESIZED: 
+						resize(evt.window.data1, evt.window.data2); 
+						break;
+					case SDL_WINDOWEVENT_SIZE_CHANGED: 
+						resize(evt.window.data1, evt.window.data2);
+						break;
                 }
                 break;
             case SDL_KEYDOWN:

--- a/src/projectM-sdl/pmSDL.hpp
+++ b/src/projectM-sdl/pmSDL.hpp
@@ -95,6 +95,7 @@ public:
     int openAudioInput();
     void beginAudioCapture();
     void endAudioCapture();
+	void nextMonitor();
     void toggleFullScreen();
     void resize(unsigned int width, unsigned int height);
     void renderFrame();

--- a/src/projectM-sdl/pmSDL.hpp
+++ b/src/projectM-sdl/pmSDL.hpp
@@ -96,10 +96,8 @@ public:
     void beginAudioCapture();
     void endAudioCapture();
 	void nextMonitor();
-	void stretchMonitors();
     void toggleFullScreen();
     void resize(unsigned int width, unsigned int height);
-	void move(unsigned int x, unsigned int y);
     void renderFrame();
     void pollEvent();
     void maximize();

--- a/src/projectM-sdl/pmSDL.hpp
+++ b/src/projectM-sdl/pmSDL.hpp
@@ -96,8 +96,10 @@ public:
     void beginAudioCapture();
     void endAudioCapture();
 	void nextMonitor();
+	void stretchMonitors();
     void toggleFullScreen();
     void resize(unsigned int width, unsigned int height);
+	void move(unsigned int x, unsigned int y);
     void renderFrame();
     void pollEvent();
     void maximize();

--- a/src/projectM-sdl/pmSDL.hpp
+++ b/src/projectM-sdl/pmSDL.hpp
@@ -95,6 +95,7 @@ public:
     int openAudioInput();
     void beginAudioCapture();
     void endAudioCapture();
+	void stretchMonitors();
 	void nextMonitor();
     void toggleFullScreen();
     void resize(unsigned int width, unsigned int height);

--- a/src/projectM-sdl/projectM_SDL_main.cpp
+++ b/src/projectM-sdl/projectM_SDL_main.cpp
@@ -332,7 +332,7 @@ srand((int)(time(NULL)));
         projectM::Settings settings;
         settings.windowWidth = width;
         settings.windowHeight = height;
-        settings.meshX = 400;
+        settings.meshX = 128;
         settings.meshY = settings.meshX * heightWidthRatio;
         settings.fps   = 60;
         settings.smoothPresetDuration = 3; // seconds


### PR DESCRIPTION
**- Change default SDL meshx from 400 to 128**
This is to resolve low FPS https://github.com/projectM-visualizer/projectm/issues/304 
I am now getting 60fps on pretty much every preset using a second gen i7.

**- New feature CTRL+M will make projectM move to the next monitor.** 
This was added based on feedback / observations in Windows:
- you can't target the monitor of choice. It launches on your primary monitor by default and is difficult to change / move.
- you can't easily get multiple instances of projectM up if you want to display them on multiple monitors.

Demo:
![move](https://user-images.githubusercontent.com/59471060/72668279-9f1bbd00-3a3e-11ea-8654-97d56255b8ad.gif)

**- New feature CTRL+S will make projectM stretch across monitors.** 
This feature lets you stretch projectM across multiple monitors. It's not a complete implementation, as it replies on your monitors being completely vertical or horizontal without any offset. 
Next week I will work on a solution for complex setups like rows and columns of monitors, and different sized monitors that are at different offsets.

Demo:
![stretch](https://user-images.githubusercontent.com/59471060/72668280-a93dbb80-3a3e-11ea-987e-59845c9a5905.gif)

Notes:
- I did not add this key combinations for CTRL+S or CTRL+M to the on screen help menu yet as it will only function in SDL, and the menu is part of the library.
- Monitor switching/stretching is based on ID so it's not limited to dual monitors / triple monitors (but that's what it's tested with).