### PR TITLE
new BeatDetect implementation

### DIFF
--- a/src/libprojectM/PCM.hpp
+++ b/src/libprojectM/PCM.hpp
@@ -31,6 +31,11 @@
 
 #include "dlldefs.h"
 
+
+// 1024 is more computationally intensive, but maybe better at detecting lower bass
+#define FFT_LENGTH 512
+
+
 class 
 #ifdef WIN32 
 DLLEXPORT 
@@ -52,8 +57,8 @@ public:
     float *pcmdataR;     //holder for most recent pcm data
 
     /** PCM data */
-    float vdataL[512];  //holders for FFT data (spectrum)
-    float vdataR[512];
+    float vdataL[FFT_LENGTH];  //holders for FFT data (spectrum)
+    float vdataR[FFT_LENGTH];
 
     static int maxsamples;
     PCM();

--- a/src/libprojectM/PCM.hpp
+++ b/src/libprojectM/PCM.hpp
@@ -33,7 +33,7 @@
 
 
 // 1024 is more computationally intensive, but maybe better at detecting lower bass
-#define FFT_LENGTH 512
+#define FFT_LENGTH 1024
 
 
 class 

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -114,8 +114,9 @@ void BeatDetect::getBeatVals( float samplerate, unsigned fft_length, float *vdat
     assert( 512==fft_length || 1024==fft_length );    // should be power of 2, expect >= 512
 
     // TODO: compute ranges based on samplerate
-    unsigned ranges512[4]  = {0, 3, 23, 200};
-    unsigned ranges1024[4] = {0, 5, 46, 400};
+    // roughly aiming or basee-mid cutoff of 220ish and mid-treb cutoff of 2000ish, if I did my math right
+    unsigned ranges512[4]  = {0, 3 /* 3*441000/512 = =258 */, 23 /* 23*441000/512 = =1981 */ , 200};
+    unsigned ranges1024[4] = {0, 5 /* 5*44100/1024 == 215 */, 46 /* 46*44100/1024 == 1981  */, 400};
     unsigned *ranges = fft_length==1024 ? ranges1024 : ranges512;
 
     bass_instant = 0;

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -36,31 +36,32 @@
 #include <cmath>
 #include "BeatDetect.hpp"
 
-BeatDetect::BeatDetect(PCM *_pcm) {
-  int x,y; 
 
-  this->pcm=_pcm;
+BeatDetect::BeatDetect(PCM *_pcm)
+{
+    this->pcm=_pcm;
 
-  this->vol_instant=0;
-  this->vol_history=0;
+    this->vol_instant=0;
+    this->vol_history=0;
+    for (unsigned y=0;y<80;y++)
+        this->vol_buffer[y]=0;
 
-  for (y=0;y<80;y++)
-    {
-      this->vol_buffer[y]=0;
-    }
+    this->beat_buffer_pos=0;
 
-  this->beat_buffer_pos=0;
+    this->bass_instant = 0;
+    this->bass_history = 0;
+    for (unsigned y=0;y<80;y++)
+        this->bass_buffer[y]=0;
 
-  for (x=0;x<32;x++) {
-      this->beat_instant[x]=0;
-      this->beat_history[x]=0;
-      this->beat_val[x]=1.0;
-      this->beat_att[x]=1.0;
-      this->beat_variance[x]=0;
-      for (y=0;y<80;y++) {
-	    this->beat_buffer[x][y]=0;
-	    }
-    }
+    this->mid_instant = 0;
+    this->mid_history = 0;
+    for (unsigned y=0;y<80;y++)
+        this->mid_buffer[y]=0;
+
+    this->treb_instant = 0;
+    this->treb_history = 0;
+    for (unsigned y=0;y<80;y++)
+        this->treb_buffer[y]=0;
 
     this->treb = 0;
     this->mid = 0;
@@ -72,119 +73,119 @@ BeatDetect::BeatDetect(PCM *_pcm) {
     this->bass_att = 0;
     this->vol_att = 0;
     this->vol = 0;
-  
-  
-  }
+}
 
-BeatDetect::~BeatDetect() 
+
+BeatDetect::~BeatDetect()
 {
 
 }
 
-void BeatDetect::reset() {
-  this->treb = 0;
-  this->mid = 0;
-  this->bass = 0;
-  this->treb_att = 0;
-  this->mid_att = 0;
-  this->bass_att = 0;
-  this->vol_att = 0;
-  }
 
-void BeatDetect::detectFromSamples() {
+void BeatDetect::reset()
+{
+    this->treb = 0;
+    this->mid = 0;
+    this->bass = 0;
+    this->treb_att = 0;
+    this->mid_att = 0;
+    this->bass_att = 0;
+    this->vol_att = 0;
+    this->vol_old = 0;
+    this->vol_instant=0;
+}
+
+
+void BeatDetect::detectFromSamples()
+{
     vol_old = vol;
-    bass=0;mid=0;treb=0;
+    bass=0;
+    mid=0;
+    treb=0;
+    vol=0;
 
-    getBeatVals(pcm->pcmdataL,pcm->pcmdataR);
-  }
+    // TODO: get sample rate from PCM?  Assume 44100
+    getBeatVals(44100.0f, FFT_LENGTH, pcm->pcmdataL, pcm->pcmdataR);
+}
 
-void BeatDetect::getBeatVals( float *vdataL,float *vdataR ) {
 
-  int linear=0;
-  int x,y;
-  float temp2=0;
+void BeatDetect::getBeatVals( float samplerate, unsigned fft_length, float *vdataL, float *vdataR )
+{
+    assert( 512==fft_length || 1024==fft_length );    // should be power of 2, expect >= 512
 
-  vol_instant=0;
-      for ( x=0;x<16;x++)
-	{
-	  
-	  beat_instant[x]=0;
-	  for ( y=linear*2;y<(linear+8+x)*2;y++)
-	    {
-	      beat_instant[x]+=((vdataL[y]*vdataL[y])+(vdataR[y]*vdataR[y]))*(1.0/(8+x)); 
-//	      printf( "beat_instant[%d]: %f %f %f\n", x, beat_instant[x], vdataL[y], vdataR[y] );
-	      vol_instant+=((vdataL[y]*vdataL[y])+(vdataR[y]*vdataR[y]))*(1.0/512.0);
+    // TODO: compute ranges based on samplerate
+    unsigned ranges512[4]  = {0, 3, 23, 200};
+    unsigned ranges1024[4] = {0, 5, 46, 400};
+    unsigned *ranges = fft_length==1024 ? ranges1024 : ranges512;
 
-	    }
-//printf("1");	  
-	  linear=y/2;
-	  beat_history[x]-=(beat_buffer[x][beat_buffer_pos])*.0125;
-	  beat_buffer[x][beat_buffer_pos]=beat_instant[x];
-	  beat_history[x]+=(beat_instant[x])*.0125;
-	  
-	  beat_val[x]=(beat_instant[x])/(beat_history[x]);
-	  
-	  beat_att[x]+=(beat_instant[x])/(beat_history[x]);
+    bass_instant = 0;
+    for (unsigned i=ranges[0]+1 ; i<=ranges[1] ; i++)
+    {
+        bass_instant += (vdataL[i*2]*vdataL[i*2]) + (vdataR[i*2]*vdataR[i*2]);
+    }
+    bass_instant *= 100.0/(ranges[1]-ranges[0]);
+    bass_history -= bass_buffer[beat_buffer_pos] *.0125;
+    bass_buffer[beat_buffer_pos] = bass_instant;
+    bass_history += bass_instant *.0125;
 
-//printf("2\n");
- 	  
-	}
-//printf("b\n");      
-      vol_history-=(vol_buffer[beat_buffer_pos])*.0125;
-      vol_buffer[beat_buffer_pos]=vol_instant;
-      vol_history+=(vol_instant)*.0125;
+    mid_instant = 0;
+    for (unsigned i=ranges[1]+1 ; i<=ranges[2] ; i++)
+    {
+        mid_instant += (vdataL[i*2]*vdataL[i*2]) + (vdataR[i*2]*vdataR[i*2]);
+    }
+    mid_instant *= 100.0/(ranges[2]-ranges[1]);
+    mid_history -= mid_buffer[beat_buffer_pos] *.0125;
+    mid_buffer[beat_buffer_pos] = mid_instant;
+    mid_history += mid_instant *.0125;
 
-      mid=0;
-      for(x=1;x<10;x++)
-	{
-	 mid+=(beat_instant[x]);
-	  temp2+=(beat_history[x]);
-	 
-	}
+    treb_instant = 0;
+    for (unsigned i=ranges[2]+1 ; i<=ranges[3] ; i++)
+    {
+        treb_instant += (vdataL[i*2]*vdataL[i*2]) + (vdataR[i*2]*vdataR[i*2]);
+    }
+    treb_instant *= 90.0/(ranges[3]-ranges[2]);
+    treb_history -= treb_buffer[beat_buffer_pos] *.0125;
+    treb_buffer[beat_buffer_pos] = treb_instant;
+    treb_history += treb_instant *.0125;
 
-	 mid=mid/(1.5*temp2);
-	 temp2=0;
-	 treb=0;
- 	  for(x=10;x<16;x++)
-	    { 
-	      treb+=(beat_instant[x]);
-	      temp2+=(beat_history[x]);
-	    }
-//printf("c\n");
-	  treb=treb/(1.5*temp2);
-//	  *vol=vol_instant/(1.5*vol_history);
-	  vol=vol_instant/(1.5*vol_history);
+    vol_instant  = (bass_instant + mid_instant + treb_instant) / 3.0f;
+    vol_history -= (vol_buffer[beat_buffer_pos])*.0125;
+    vol_buffer[beat_buffer_pos] = vol_instant;
+    vol_history += (vol_instant)*.0125;
 
-	  bass=(beat_instant[0])/(1.5*beat_history[0]);
+//    fprintf(stderr, "%6.3f %6.2f %6.3f\n", bass_history/vol_history, mid_history/vol_history, treb_history/vol_history);
+    bass = bass_instant / fmax(0.0001, bass_history + 0.5*vol_history);
+    mid  =  mid_instant / fmax(0.0001,  mid_history + 0.5*vol_history);
+    treb = treb_instant / fmax(0.0001, treb_history + 0.5*vol_history);
+    vol = vol_instant / fmax(0.0001, 1.5f * vol_history);
 
-	  
-	  if ( projectM_isnan( treb ) ) {
-	    treb = 0.0;
-	  }
-	  if ( projectM_isnan( mid ) ) {
-	    mid = 0.0;
-	  }
-	  if ( projectM_isnan( bass ) ) {
-	    bass = 0.0;
-	  }
-	  treb_att=.6 * treb_att + .4 * treb;
-	  mid_att=.6 * mid_att + .4 * mid;
-	  bass_att=.6 * bass_att + .4 * bass;
-      vol_att=.6 * vol_att + .4 * vol;
+    if ( projectM_isnan( treb ) ) {
+        treb = 0.0;
+    }
+    if ( projectM_isnan( mid ) ) {
+        mid = 0.0;
+    }
+    if ( projectM_isnan( bass ) ) {
+        bass = 0.0;
+    }
 
-	  if(bass_att>100)bass_att=100;
-	  if(bass >100)bass=100;
-	  if(mid_att>100)mid_att=100;
-	  if(mid >100)mid=100;
-	  if(treb_att>100)treb_att=100;
-	  if(treb >100)treb=100;
-      if(vol_att>100)vol_att=100;
-	  if(vol>100)vol=100;
-	  
-	   // *vol=(beat_instant[3])/(beat_history[3]);
-	  beat_buffer_pos++;
-	  if( beat_buffer_pos>79)beat_buffer_pos=0;
-	
+    treb_att = .6f * treb_att + .4f * treb;
+    mid_att  = .6f * mid_att + .4f * mid;
+    bass_att = .6f * bass_att + .4f * bass;
+    vol_att =  .6f * vol_att + .4f * vol;
+
+    if (bass_att>100) bass_att=100;
+    if (bass >100) bass=100;
+    if (mid_att>100) mid_att=100;
+    if (mid >100) mid=100;
+    if (treb_att>100) treb_att=100;
+    if (treb >100) treb=100;
+    if (vol_att>100) vol_att=100;
+    if (vol>100) vol=100;
+
+    beat_buffer_pos++;
+    if (beat_buffer_pos>79)
+        beat_buffer_pos=0;
 }
 
 

--- a/src/libprojectM/Renderer/BeatDetect.hpp
+++ b/src/libprojectM/Renderer/BeatDetect.hpp
@@ -59,7 +59,7 @@ class DLLEXPORT BeatDetect
 		void initBeatDetect();
 		void reset();
 		void detectFromSamples();
-		void getBeatVals ( float *vdataL, float *vdataR );
+		void getBeatVals( float samplerate, unsigned fft_length, float *vdataL, float *vdataR );
 		float getPCMScale()
 		{
 			// added to address https://github.com/projectM-visualizer/projectm/issues/161
@@ -74,17 +74,34 @@ class DLLEXPORT BeatDetect
 		}
 
 	private:
-		/** Vars */
-		float beat_buffer[32][80],
-		beat_instant[32],
-		beat_history[32];
-		float beat_val[32],
-		beat_att[32],
-		beat_variance[32];
 		int beat_buffer_pos;
-		float vol_buffer[80],
-		vol_instant;
-		float vol_history;
+        float bass_buffer[80];
+		float bass_history;
+        float bass_instant;
+
+		float mid_buffer[80];
+        float mid_history;
+		float mid_instant;
+
+		float treb_buffer[80];
+		float treb_history;
+		float treb_instant;
+
+        float vol_buffer[80];
+        float vol_history;
+        float vol_instant;
+
+    //		/** Vars */
+//		float beat_buffer[32][80],
+//		beat_instant[32],
+//		beat_history[32];
+//		float beat_val[32],
+//		beat_att[32],
+//		beat_variance[32];
+//		int beat_buffer_pos;
+//		float vol_buffer[80],
+//		vol_instant;
+//		float vol_history;
 };
 
 #endif /** !_BEAT_DETECT_H */

--- a/src/libprojectM/Renderer/BeatDetect.hpp
+++ b/src/libprojectM/Renderer/BeatDetect.hpp
@@ -70,7 +70,7 @@ class DLLEXPORT BeatDetect
 #undef max
 			//work0around
 #endif /** WIN32 */
-			return 0.5f / std::max(0.0001f,sqrtf(vol_history));
+			return 4.0f / std::max(0.0001f,sqrtf(vol_history));
 		}
 
 	private:

--- a/src/libprojectM/Renderer/BeatDetect.hpp
+++ b/src/libprojectM/Renderer/BeatDetect.hpp
@@ -37,6 +37,10 @@
 #include <cmath>
 
 
+// this is the size of the buffer used to determine avg levels of the input audio
+// the actual time represented in the history depends on FPS
+#define BEAT_HISTORY_LENGTH 80
+
 class DLLEXPORT BeatDetect
 {
 	public:
@@ -54,17 +58,20 @@ class DLLEXPORT BeatDetect
 		PCM *pcm;
 
 		/** Methods */
-		BeatDetect(PCM *pcm);
+		explicit BeatDetect(PCM *pcm);
 		~BeatDetect();
-		void initBeatDetect();
 		void reset();
 		void detectFromSamples();
 		void getBeatVals( float samplerate, unsigned fft_length, float *vdataL, float *vdataR );
+
+        // getPCMScale() was added to address https://github.com/projectM-visualizer/projectm/issues/161
+        // Returning 1.0 results in using the raw PCM data, which can make the presets look pretty unresponsive
+        // if the application volume is low.
 		float getPCMScale()
 		{
-			// added to address https://github.com/projectM-visualizer/projectm/issues/161
-			// Returning 1.0 results in using the raw PCM data, which can make the presets look pretty unresponsive
-			// if the application volume is low.
+			// the constant here just depends on the particulars of getBeatVals(), the
+			// range of vol_history, and what "looks right".
+			// larger value means larger, more jagged waveform.
 #ifdef WIN32
 // this is broken?
 #undef max
@@ -75,33 +82,21 @@ class DLLEXPORT BeatDetect
 
 	private:
 		int beat_buffer_pos;
-        float bass_buffer[80];
+        float bass_buffer[BEAT_HISTORY_LENGTH];
 		float bass_history;
         float bass_instant;
 
-		float mid_buffer[80];
+		float mid_buffer[BEAT_HISTORY_LENGTH];
         float mid_history;
 		float mid_instant;
 
-		float treb_buffer[80];
+		float treb_buffer[BEAT_HISTORY_LENGTH];
 		float treb_history;
 		float treb_instant;
 
-        float vol_buffer[80];
+        float vol_buffer[BEAT_HISTORY_LENGTH];
         float vol_history;
         float vol_instant;
-
-    //		/** Vars */
-//		float beat_buffer[32][80],
-//		beat_instant[32],
-//		beat_history[32];
-//		float beat_val[32],
-//		beat_att[32],
-//		beat_variance[32];
-//		int beat_buffer_pos;
-//		float vol_buffer[80],
-//		vol_instant;
-//		float vol_history;
 };
 
 #endif /** !_BEAT_DETECT_H */


### PR DESCRIPTION
This is a proposed fix for https://github.com/projectM-visualizer/projectm/issues/309

I think this simpler implementation does what it says it does.  At least it makes more sense to me.  It doesn't really seem to have that much noticeable affect how the presets render.  I wrote a new test preset so you can more directly evaluate the output.  

https://github.com/projectM-visualizer/projectm/blob/master/presets/tests/300-beatdetect-bassmidtreb.milk

It would be great if the regular contributors could 

  a) review the code change carefully (not that big) 
  b) verify your favorite presets
  c) if you like, play with various parameters (e.g. freq cutoffs) and see if the current version seems best.
