### PR TITLE
Fix off by 1 qvar errors, var names

### DIFF
--- a/src/libprojectM/MilkdropPresetFactory/BuiltinParams.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/BuiltinParams.cpp
@@ -396,7 +396,7 @@ int BuiltinParams::load_all_builtin_param(const PresetInputs & presetInputs, Pre
 
   for (unsigned int i = 0; i < NUM_Q_VARIABLES;i++) {
 	std::ostringstream os;
-	os << "q" << i;
+	os << "q" << i+1;
 	load_builtin_param_float(os.str().c_str(), (void*)&presetOutputs.q[i],  NULL, P_FLAG_QVAR, 0, MAX_DOUBLE_SIZE, -MAX_DOUBLE_SIZE, "");
 
   }

--- a/src/libprojectM/MilkdropPresetFactory/CustomShape.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/CustomShape.cpp
@@ -208,9 +208,9 @@ CustomShape::CustomShape ( int _id ) : Shape()
 		abort();
 	}
 
-   for (unsigned int i = 1; i <= NUM_Q_VARIABLES;i++) {
+   for (unsigned int i = 0; i < NUM_Q_VARIABLES;i++) {
 	std::ostringstream os;
-	os << "q" << i;
+	os << "q" << i+1;
 	param = Param::new_param_float ( os.str().c_str(), P_FLAG_QVAR, &this->q[i], NULL, MAX_DOUBLE_SIZE,
 		 -MAX_DOUBLE_SIZE, 0.0 );
     if ( !ParamUtils::insert ( param, &this->param_tree ) )

--- a/src/libprojectM/MilkdropPresetFactory/CustomWave.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/CustomWave.cpp
@@ -396,9 +396,9 @@ CustomWave::CustomWave(int _id) : Waveform(512),
     abort();
   }
 
-  for (unsigned int i = 1; i <= NUM_Q_VARIABLES;i++) {
+  for (unsigned int i = 0; i < NUM_Q_VARIABLES;i++) {
 	std::ostringstream os;
-	os << "q" << i;
+	os << "q" << i+1;
 	param = Param::new_param_float ( os.str().c_str(), P_FLAG_QVAR, &this->q[i], NULL, MAX_DOUBLE_SIZE,
 		 -MAX_DOUBLE_SIZE, 0.0 );
     if ( !ParamUtils::insert ( param, &this->param_tree ) )


### PR DESCRIPTION
This PR fixes an off by 1 bug where the variable `q0` is assumed to exist instead of `q32`. It also fixes possible memory bound violations when iterating over the `q` variables.
