### PR TITLE
Automatically update version string in projectM.hpp

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,6 +66,7 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([
   Makefile
   src/Makefile
+  src/libprojectM/projectM.hpp
   src/libprojectM/Makefile
   src/libprojectM/Renderer/Makefile
   src/libprojectM/NativePresetFactory/Makefile

--- a/src/libprojectM/projectM.hpp.in
+++ b/src/libprojectM/projectM.hpp.in
@@ -92,8 +92,8 @@ class MasterRenderItemMerge;
 #endif
 
 /** KEEP THIS UP TO DATE! */
-#define PROJECTM_VERSION "2.0.00"
-#define PROJECTM_TITLE "projectM 2.0.00"
+#define PROJECTM_VERSION "@PACKAGE_VERSION@"
+#define PROJECTM_TITLE "@PACKAGE_STRING@"
 
 /** Interface types */
 typedef enum {


### PR DESCRIPTION
There is a copy of that header for the Android JNI, but the macros are not used in that case.