### PR TITLE
SDL Monitor Fixes

### DIFF
--- a/src/projectM-sdl/pmSDL.cpp
+++ b/src/projectM-sdl/pmSDL.cpp
@@ -187,29 +187,28 @@ void projectMSDL::stretchMonitors()
 			SDL_GetDisplayBounds(i, &displayBounds.back());
 		}
 
-        int mostX = 0;
+		int mostXLeft = 0;
+		int mostXRight = 0;
 		int mostWide = 0;
-		int mostY = 0;
+		int mostYUp = 0;
+		int mostYDown = 0;
 		int mostHigh = 0;
 
 		for (int i = 0; i < displayCount; i++)
 		{
-			if (displayBounds[i].x < mostX) mostX = displayBounds[i].x;
+			if (displayBounds[i].x < mostXLeft) mostXLeft = displayBounds[i].x;
+			if ((displayBounds[i].x + displayBounds[i].w) > mostXRight) mostXRight = displayBounds[i].x + displayBounds[i].w;
 		}
 		for (int i = 0; i < displayCount; i++)
 		{
-			if ((displayBounds[i].x + displayBounds[i].w) > mostWide) mostWide = (displayBounds[i].x + displayBounds[i].w + abs(mostX));
-		}
-		for (int i = 0; i < displayCount; i++)
-		{
-			if (displayBounds[i].y < mostY) mostY = displayBounds[i].y;
-		}
-		for (int i = 0; i < displayCount; i++)
-		{
-			if ((displayBounds[i].y + displayBounds[i].h) > mostHigh) mostHigh = (displayBounds[i].y + displayBounds[i].h + abs(mostY));
+			if (displayBounds[i].y < mostYUp) mostYUp = displayBounds[i].y;
+			if ((displayBounds[i].y + displayBounds[i].h) > mostYDown) mostYDown = displayBounds[i].y + + displayBounds[i].h;
 		}
 
-		SDL_SetWindowPosition(win, mostX, mostY);
+        mostWide = abs(mostXLeft) + abs(mostXRight);
+		mostHigh = abs(mostYUp) + abs(mostYDown);
+
+		SDL_SetWindowPosition(win, mostXLeft, mostYUp);
 		SDL_SetWindowSize(win, mostWide, mostHigh);
 	}
 }

--- a/src/projectM-sdl/pmSDL.cpp
+++ b/src/projectM-sdl/pmSDL.cpp
@@ -202,11 +202,11 @@ void projectMSDL::stretchMonitors()
 		for (int i = 0; i < displayCount; i++)
 		{
 			if (displayBounds[i].y < mostYUp) mostYUp = displayBounds[i].y;
-			if ((displayBounds[i].y + displayBounds[i].h) > mostYDown) mostYDown = displayBounds[i].y + + displayBounds[i].h;
+			if ((displayBounds[i].y + displayBounds[i].h) > mostYDown) mostYDown = displayBounds[i].y + displayBounds[i].h;
 		}
 
         mostWide = abs(mostXLeft) + abs(mostXRight);
-		mostHigh = abs(mostYUp) + abs(mostYDown);
+        mostHigh = abs(mostYUp) + abs(mostYDown);
 
 		SDL_SetWindowPosition(win, mostXLeft, mostYUp);
 		SDL_SetWindowSize(win, mostWide, mostHigh);

--- a/src/projectM-sdl/pmSDL.cpp
+++ b/src/projectM-sdl/pmSDL.cpp
@@ -187,55 +187,30 @@ void projectMSDL::stretchMonitors()
 			SDL_GetDisplayBounds(i, &displayBounds.back());
 		}
 
-		int furthestX = 0;
-		int furthestY = 0;
-		int widest = 0;
-		int highest = 0;
-		int spanX = 0;
-		int spanY = 0;
-		int spanWidth = 0;
-		int spanHeight = 0;
-
-		bool horizontal = true;
-		bool vertical = true;
+        int mostX = 0;
+		int mostWide = 0;
+		int mostY = 0;
+		int mostHigh = 0;
 
 		for (int i = 0; i < displayCount; i++)
 		{
-			if (displayBounds[0].x != displayBounds[i].x) vertical = false;
-			if (displayBounds[0].y != displayBounds[i].y) horizontal = false;
+			if (displayBounds[i].x < mostX) mostX = displayBounds[i].x;
+		}
+		for (int i = 0; i < displayCount; i++)
+		{
+			if ((displayBounds[i].x + displayBounds[i].w) > mostWide) mostWide = (displayBounds[i].x + displayBounds[i].w + abs(mostX));
+		}
+		for (int i = 0; i < displayCount; i++)
+		{
+			if (displayBounds[i].y < mostY) mostY = displayBounds[i].y;
+		}
+		for (int i = 0; i < displayCount; i++)
+		{
+			if ((displayBounds[i].y + displayBounds[i].h) > mostHigh) mostHigh = (displayBounds[i].y + displayBounds[i].h + abs(mostY));
 		}
 
-		if (!vertical && !horizontal)
-		{
-			// If multiple montors are not perfectly aligned it's a bit of work to get the correct x,y and
-			// dimensions But in my testing on Windows 10 even with the screen did not render correctly.
-			// @todo more testing and make it work.
-			SDL_Log(
-				"SDL currently only supports multiple monitors that are aligned evenly in a vertical or "
-				"horizontal position.");
-		}
-		else
-		{
-			for (int i = 0; i < displayCount; i++)
-			{
-				if (displayBounds[i].x < furthestX) spanX = displayBounds[i].x; // X furthest left device
-				if (displayBounds[i].y < furthestY) spanY = displayBounds[i].y; // Y highest device
-				if (displayBounds[i].h > highest) highest = displayBounds[i].h; // highest resolution Height
-				if (displayBounds[i].h > widest) widest = displayBounds[i].w;		// highest resolution Width
-				if (horizontal) // perfectly aligned horizonal monitors.
-				{
-					spanHeight = highest;
-					spanWidth = spanWidth + displayBounds[i].w;
-				}
-				else if (vertical) // perfectly aligned vertical monitors.
-				{
-					spanHeight = spanHeight + displayBounds[i].h;
-					spanWidth = widest;
-				}
-			}
-			SDL_SetWindowPosition(win, spanX, spanY);
-			SDL_SetWindowSize(win, spanWidth, spanHeight);
-		}
+		SDL_SetWindowPosition(win, mostX, mostY);
+		SDL_SetWindowSize(win, mostWide, mostHigh);
 	}
 }
 

--- a/src/projectM-sdl/pmSDL.cpp
+++ b/src/projectM-sdl/pmSDL.cpp
@@ -223,7 +223,7 @@ void projectMSDL::nextMonitor()
 	{
 		std::vector<SDL_Rect> displayBounds;
 		int nextWindow = currentWindowIndex + 1;
-		if (nextWindow > displayCount) nextWindow = 0;
+		if (nextWindow >= displayCount) nextWindow = 0;
 
 		for (int i = 0; i < displayCount; i++)
 		{
@@ -232,7 +232,6 @@ void projectMSDL::nextMonitor()
 		}
 		SDL_SetWindowPosition(win, displayBounds[nextWindow].x, displayBounds[nextWindow].y);
 		SDL_SetWindowSize(win, displayBounds[nextWindow].w, displayBounds[nextWindow].h);
-		maximize();
 	}
 }
 


### PR DESCRIPTION
**Cmd/Ctrl-S: stretch monitors**
This should make stretching much more flexible. Before it was basic and would only work for monitors perfectly aligned vertically or horizontally.

**Cmd/Ctrl-M: change monitor**
There was a bug where it would try to go to a monitor that doesn't exist (diff between displayCount which starts at 1 and displayIndex which starts at 0)
