### PR TITLE
SDL and libprojectM updates on config handling.

### DIFF
--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -1,23 +1,23 @@
 /**
-* projectM -- Milkdrop-esque visualisation SDK
-* Copyright (C)2003-2004 projectM Team
-*
-* This library is free software; you can redistribute it and/or
-* modify it under the terms of the GNU Lesser General Public
-* License as published by the Free Software Foundation; either
-* version 2.1 of the License, or (at your option) any later version.
-*
-* This library is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* Lesser General Public License for more details.
-*
-* You should have received a copy of the GNU Lesser General Public
-* License along with this library; if not, write to the Free Software
-* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-* See 'LICENSE.txt' included within this release
-*
-*/
+ * projectM -- Milkdrop-esque visualisation SDK
+ * Copyright (C)2003-2004 projectM Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * See 'LICENSE.txt' included within this release
+ *
+ */
 
 #include "RenderItemMatcher.hpp"
 #include "RenderItemMergeFunction.hpp"
@@ -43,7 +43,7 @@
 #include "BeatDetect.hpp"
 #include "Preset.hpp"
 #include "PipelineMerger.hpp"
-#include "PCM.hpp"                    //Sound data handler (buffering, FFT, etc.)
+#include "PCM.hpp" //Sound data handler (buffering, FFT, etc.)
 
 #include <map>
 
@@ -70,914 +70,947 @@ pthread_mutex_t preset_mutex;
 projectM::~projectM()
 {
 #ifdef USE_THREADS
-    void *status;
-    worker_sync.finish_up();
-    pthread_join(thread, &status);
-    #ifdef SYNC_PRESET_SWITCHES
-    pthread_mutex_destroy( &preset_mutex );
-    #endif
-    std::cout << std::endl;
+	void *status;
+	worker_sync.finish_up();
+	pthread_join(thread, &status);
+#ifdef SYNC_PRESET_SWITCHES
+	pthread_mutex_destroy(&preset_mutex);
 #endif
-    destroyPresetTools();
+	std::cout << std::endl;
+#endif
+	destroyPresetTools();
 
-    if ( renderer )
-        delete ( renderer );
-    if ( beatDetect )
-        delete ( beatDetect );
-    if ( _pcm ) {
-        delete ( _pcm );
-        _pcm = 0;
-    }
+	if (renderer) delete (renderer);
+	if (beatDetect) delete (beatDetect);
+	if (_pcm)
+	{
+		delete (_pcm);
+		_pcm = 0;
+	}
 
-    if(timeKeeper) {
-        delete timeKeeper;
-        timeKeeper = NULL;
-    }
+	if (timeKeeper)
+	{
+		delete timeKeeper;
+		timeKeeper = NULL;
+	}
 
-    delete(_pipelineContext);
-    delete(_pipelineContext2);
+	delete (_pipelineContext);
+	delete (_pipelineContext2);
 }
 
 unsigned projectM::initRenderToTexture()
 {
-    return renderer->initRenderToTexture();
+	return renderer->initRenderToTexture();
 }
 
 void projectM::projectM_resetTextures()
 {
-    renderer->ResetTextures();
+	renderer->ResetTextures();
 }
 
-
-projectM::projectM ( std::string config_file, int flags) :
-        _pcm(0), beatDetect ( 0 ), renderer ( 0 ), _pipelineContext(new PipelineContext()), _pipelineContext2(new PipelineContext()), m_presetPos(0),
-        timeKeeper(NULL), m_flags(flags), _matcher(NULL), _merger(NULL)
+projectM::projectM(std::string config_file, int flags)
+		: _pcm(0),
+			beatDetect(0),
+			renderer(0),
+			_pipelineContext(new PipelineContext()),
+			_pipelineContext2(new PipelineContext()),
+			m_presetPos(0),
+			timeKeeper(NULL),
+			m_flags(flags),
+			_matcher(NULL),
+			_merger(NULL)
 {
-    readConfig(config_file);
-    projectM_reset();
-    projectM_resetGL(_settings.windowWidth, _settings.windowHeight);
-
+	readConfig(config_file);
+	projectM_reset();
+	projectM_resetGL(_settings.windowWidth, _settings.windowHeight);
 }
 
-projectM::projectM(Settings settings, int flags):
-        _pcm(0), beatDetect ( 0 ), renderer ( 0 ), _pipelineContext(new PipelineContext()), _pipelineContext2(new PipelineContext()), m_presetPos(0),
-        timeKeeper(NULL), m_flags(flags), _matcher(NULL), _merger(NULL)
+projectM::projectM(ConfigPreset configPreset, int flags)
+		: _pcm(0),
+			beatDetect(0),
+			renderer(0),
+			_pipelineContext(new PipelineContext()),
+			_pipelineContext2(new PipelineContext()),
+			m_presetPos(0),
+			timeKeeper(NULL),
+			m_flags(flags),
+			_matcher(NULL),
+			_merger(NULL)
 {
-    readSettings(settings);
-    projectM_reset();
-    projectM_resetGL(_settings.windowWidth, _settings.windowHeight);
+	struct stat sb;
+	if (!configPreset.config_file.empty() && stat(configPreset.config_file.c_str(), &sb) == 0)
+	{
+		readConfig(configPreset.config_file, configPreset.settings);
+	}
+	else
+	{
+		readSettings(configPreset.settings);
+	}
+	projectM_reset();
+	projectM_resetGL(_settings.windowWidth, _settings.windowHeight);
 }
 
-
-bool projectM::writeConfig(const std::string & configFile, const Settings & settings) {
-
-    ConfigFile config ( configFile );
-
-    config.add("Mesh X", settings.meshX);
-    config.add("Mesh Y", settings.meshY);
-    config.add("Texture Size", settings.textureSize);
-    config.add("FPS", settings.fps);
-    config.add("Window Width", settings.windowWidth);
-    config.add("Window Height", settings.windowHeight);
-    config.add("Smooth Preset Duration", settings.smoothPresetDuration);
-    config.add("Preset Duration", settings.presetDuration);
-    config.add("Preset Path", settings.presetURL);
-    config.add("Title Font", settings.titleFontURL);
-    config.add("Menu Font", settings.menuFontURL);
-    config.add("Hard Cut Sensitivity", settings.beatSensitivity);
-    config.add("Aspect Correction", settings.aspectCorrection);
-    config.add("Easter Egg Parameter", settings.easterEgg);
-    config.add("Shuffle Enabled", settings.shuffleEnabled);
-    config.add("Soft Cut Ratings Enabled", settings.softCutRatingsEnabled);
-    std::fstream file(configFile.c_str());
-    if (file) {
-        file << config;
-        return true;
-    } else
-        return false;
-}
-
-
-
-void projectM::readConfig (const std::string & configFile )
+projectM::projectM(Settings settings, int flags)
+		: _pcm(0),
+			beatDetect(0),
+			renderer(0),
+			_pipelineContext(new PipelineContext()),
+			_pipelineContext2(new PipelineContext()),
+			m_presetPos(0),
+			timeKeeper(NULL),
+			m_flags(flags),
+			_matcher(NULL),
+			_merger(NULL)
 {
-    std::cout << "[projectM] config file: " << configFile << std::endl;
+	readSettings(settings);
+	projectM_reset();
+	projectM_resetGL(_settings.windowWidth, _settings.windowHeight);
+}
 
-    ConfigFile config ( configFile );
-    _settings.meshX = config.read<int> ( "Mesh X", 32 );
-    _settings.meshY = config.read<int> ( "Mesh Y", 24 );
-    _settings.textureSize = config.read<int> ( "Texture Size", 512 );
-    _settings.fps = config.read<int> ( "FPS", 35 );
-    _settings.windowWidth  = config.read<int> ( "Window Width", 512 );
-    _settings.windowHeight = config.read<int> ( "Window Height", 512 );
-    _settings.smoothPresetDuration =  config.read<int>
-            ( "Smooth Preset Duration", config.read<int>("Smooth Transition Duration", 10));
-    _settings.presetDuration = config.read<int> ( "Preset Duration", 15 );
+bool projectM::writeConfig(const std::string &configFile, const Settings &settings)
+{
+
+	ConfigFile config(configFile);
+
+	config.add("Mesh X", settings.meshX);
+	config.add("Mesh Y", settings.meshY);
+	config.add("Texture Size", settings.textureSize);
+	config.add("FPS", settings.fps);
+	config.add("Window Width", settings.windowWidth);
+	config.add("Window Height", settings.windowHeight);
+	config.add("Smooth Preset Duration", settings.smoothPresetDuration);
+	config.add("Preset Duration", settings.presetDuration);
+	config.add("Preset Path", settings.presetURL);
+	config.add("Title Font", settings.titleFontURL);
+	config.add("Menu Font", settings.menuFontURL);
+	config.add("Hard Cut Sensitivity", settings.beatSensitivity);
+	config.add("Aspect Correction", settings.aspectCorrection);
+	config.add("Easter Egg Parameter", settings.easterEgg);
+	config.add("Shuffle Enabled", settings.shuffleEnabled);
+	config.add("Soft Cut Ratings Enabled", settings.softCutRatingsEnabled);
+	std::fstream file(configFile.c_str());
+	if (file)
+	{
+		file << config;
+		return true;
+	}
+	else
+		return false;
+}
+
+void projectM::readConfig(const std::string &configFile, const Settings &settings)
+{
+	std::cout << "[projectM] config file: " << configFile << std::endl;
+
+	ConfigFile config(configFile);
+	_settings.meshX = config.read<int>("Mesh X", settings.meshX);
+	_settings.meshY = config.read<int>("Mesh Y", settings.meshY);
+	_settings.textureSize = config.read<int>("Texture Size", settings.textureSize);
+	_settings.fps = config.read<int>("FPS", settings.fps);
+	_settings.windowWidth = config.read<int>("Window Width", settings.windowWidth);
+	_settings.windowHeight = config.read<int>("Window Height", settings.windowHeight);
+	_settings.smoothPresetDuration = config.read<int>("Smooth Preset Duration",
+		config.read<int>("Smooth Transition Duration", settings.smoothPresetDuration));
+	_settings.presetDuration = config.read<int>("Preset Duration", settings.presetDuration);
+
+	_settings.presetURL = config.read<string>("Preset Path", settings.presetURL);
+
+	_settings.titleFontURL = config.read<string>("Title Font", settings.titleFontURL);
+	_settings.menuFontURL = config.read<string>("Menu Font", settings.menuFontURL);
+
+	_settings.shuffleEnabled = config.read<bool>("Shuffle Enabled", settings.shuffleEnabled);
+
+	_settings.easterEgg = config.read<float>("Easter Egg Parameter", settings.easterEgg);
+	_settings.softCutRatingsEnabled =
+		config.read<bool>("Soft Cut Ratings Enabled", settings.softCutRatingsEnabled);
+
+	projectM_init(_settings.meshX, _settings.meshY, _settings.fps, _settings.textureSize,
+		_settings.windowWidth, _settings.windowHeight);
+
+	_settings.beatSensitivity = beatDetect->beat_sensitivity =
+		config.read<float>("Hard Cut Sensitivity", 10.0);
+
+	if (config.read("Aspect Correction", settings.aspectCorrection))
+	{
+		_settings.aspectCorrection = true;
+		renderer->correction = true;
+	}
+	else
+	{
+		_settings.aspectCorrection = false;
+		renderer->correction = false;
+	}
+}
+
+void projectM::readConfig(const std::string &configFile)
+{
+	// if you read a config file with no default settings supplied, we will set them here.
+	projectM::Settings settings;
+	settings.windowWidth = 512;
+	settings.windowHeight = 512;
+	settings.meshX = 32;
+	settings.meshY = 24;
+	settings.fps = 35;
+	settings.smoothPresetDuration = 10;
+	settings.presetDuration = 15;
+	settings.beatSensitivity = 10;
+	settings.aspectCorrection = 1;
+	settings.shuffleEnabled = 1;
+	settings.softCutRatingsEnabled = 0;
+	settings.easterEgg = 0.0;
 
 #ifdef __unix__
-    _settings.presetURL = config.read<string> ( "Preset Path", "/usr/local/share/projectM/presets" );
+	settings.presetURL = "/usr/local/share/projectM/presets";
 #endif
 
 #ifdef __APPLE__
-    /// @bug awful hardcoded hack- need to add intelligence to cmake wrt bundling - carm
-    _settings.presetURL = config.read<string> ( "Preset Path", "../Resources/presets" );
+	/// @bug awful hardcoded hack- need to add intelligence to cmake wrt bundling - carm
+	settings.presetURL = "../Resources/presets";
 #endif
 
 #ifdef WIN32
-    _settings.presetURL = config.read<string> ( "Preset Path", "/usr/local/share/projectM/presets" );
+	settings.presetURL = "/usr/local/share/projectM/presets";
 #endif
 
 #ifdef __APPLE__
-    _settings.titleFontURL = config.read<string>
-    ( "Title Font",  "../Resources/fonts/Vera.tff");
-    _settings.menuFontURL = config.read<string>
-    ( "Menu Font", "../Resources/fonts/VeraMono.ttf");
+	settings.titleFontURL = "../Resources/fonts/Vera.tff";
+	settings.menuFontURL = "../Resources/fonts/VeraMono.ttf";
 #endif
 
 #ifdef __unix__
-    _settings.titleFontURL = config.read<string>
-            ( "Title Font", "/usr/local/share/projectM/fonts/Vera.tff" );
-    _settings.menuFontURL = config.read<string>
-            ( "Menu Font", "/usr/local/share/projectM/fonts/VeraMono.tff" );
+	settings.titleFontURL = "Title Font", "/usr/local/share/projectM/fonts/Vera.tff";
+	settings.menuFontURL = "/usr/local/share/projectM/fonts/VeraMono.tff";
 #endif
 
 #ifdef WIN32
-    _settings.titleFontURL = config.read<string>
-    ( "Title Font", projectM_FONT_TITLE );
-    _settings.menuFontURL = config.read<string>
-    ( "Menu Font", projectM_FONT_MENU );
+	settings.titleFontURL = projectM_FONT_TITLE;
+	settings.menuFontURL = projectM_FONT_MENU;
 #endif
 
-
-    _settings.shuffleEnabled = config.read<bool> ( "Shuffle Enabled", true);
-
-    _settings.easterEgg = config.read<float> ( "Easter Egg Parameter", 0.0);
-    _settings.softCutRatingsEnabled =
-            config.read<bool> ( "Soft Cut Ratings Enabled", false);
-
-    projectM_init ( _settings.meshX, _settings.meshY, _settings.fps,
-                    _settings.textureSize, _settings.windowWidth,_settings.windowHeight);
-
-    _settings.beatSensitivity = beatDetect->beat_sensitivity = config.read<float> ( "Hard Cut Sensitivity", 10.0 );
-
-
-    if ( config.read ( "Aspect Correction", true ) )
-    {
-        _settings.aspectCorrection = true;
-        renderer->correction = true;
-    }
-    else
-    {
-        _settings.aspectCorrection = false;
-        renderer->correction = false;
-    }
-
-
+	// now we can load the config with default settings.
+	readConfig(configFile, settings);
 }
-
-
-void projectM::readSettings (const Settings & settings )
+void projectM::readSettings(const Settings &settings)
 {
-    _settings.meshX = settings.meshX;
-    _settings.meshY = settings.meshY;
-    _settings.textureSize = settings.textureSize;
-    _settings.fps = settings.fps;
-    _settings.windowWidth  = settings.windowWidth;
-    _settings.windowHeight = settings.windowHeight;
-    _settings.smoothPresetDuration = settings.smoothPresetDuration;
-    _settings.presetDuration = settings.presetDuration;
-    _settings.softCutRatingsEnabled = settings.softCutRatingsEnabled;
+	_settings.meshX = settings.meshX;
+	_settings.meshY = settings.meshY;
+	_settings.textureSize = settings.textureSize;
+	_settings.fps = settings.fps;
+	_settings.windowWidth = settings.windowWidth;
+	_settings.windowHeight = settings.windowHeight;
+	_settings.smoothPresetDuration = settings.smoothPresetDuration;
+	_settings.presetDuration = settings.presetDuration;
+	_settings.softCutRatingsEnabled = settings.softCutRatingsEnabled;
 
-    _settings.presetURL = settings.presetURL;
-    _settings.titleFontURL = settings.titleFontURL;
-    _settings.menuFontURL =  settings.menuFontURL;
-    _settings.shuffleEnabled = settings.shuffleEnabled;
-    _settings.datadir = settings.datadir;
+	_settings.presetURL = settings.presetURL;
+	_settings.titleFontURL = settings.titleFontURL;
+	_settings.menuFontURL = settings.menuFontURL;
+	_settings.shuffleEnabled = settings.shuffleEnabled;
+	_settings.datadir = settings.datadir;
 
-    _settings.easterEgg = settings.easterEgg;
+	_settings.easterEgg = settings.easterEgg;
 
-    projectM_init ( _settings.meshX, _settings.meshY, _settings.fps,
-                    _settings.textureSize, _settings.windowWidth,_settings.windowHeight);
+	projectM_init(_settings.meshX, _settings.meshY, _settings.fps, _settings.textureSize,
+		_settings.windowWidth, _settings.windowHeight);
 
-
-    _settings.beatSensitivity = settings.beatSensitivity;
-    _settings.aspectCorrection = settings.aspectCorrection;
-
+	_settings.beatSensitivity = settings.beatSensitivity;
+	_settings.aspectCorrection = settings.aspectCorrection;
 }
 
 #ifdef USE_THREADS
 static void *thread_callback(void *prjm)
 {
-    projectM *p = (projectM *)prjm;
-    p->thread_func(prjm);
-    return NULL;
+	projectM *p = (projectM *)prjm;
+	p->thread_func(prjm);
+	return NULL;
 }
-
 
 void *projectM::thread_func(void *vptr_args)
 {
-    //  printf("in thread: %f\n", timeKeeper->PresetProgressB());
-    while (true)
-    {
-        if (!worker_sync.wait_for_work())
-            return NULL;
-        evaluateSecondPreset();
-        worker_sync.finished_work();
-    }
+	//  printf("in thread: %f\n", timeKeeper->PresetProgressB());
+	while (true)
+	{
+		if (!worker_sync.wait_for_work()) return NULL;
+		evaluateSecondPreset();
+		worker_sync.finished_work();
+	}
 }
 #endif
 
 void projectM::evaluateSecondPreset()
 {
-    pipelineContext2().time = timeKeeper->GetRunningTime();
-    pipelineContext2().presetStartTime = timeKeeper->PresetTimeB();
-    pipelineContext2().frame = timeKeeper->PresetFrameB();
-    pipelineContext2().progress = timeKeeper->PresetProgressB();
+	pipelineContext2().time = timeKeeper->GetRunningTime();
+	pipelineContext2().presetStartTime = timeKeeper->PresetTimeB();
+	pipelineContext2().frame = timeKeeper->PresetFrameB();
+	pipelineContext2().progress = timeKeeper->PresetProgressB();
 
-    m_activePreset2->Render(*beatDetect, pipelineContext2());
+	m_activePreset2->Render(*beatDetect, pipelineContext2());
 }
 
 void projectM::renderFrame()
 {
-    Pipeline pipeline;
-    Pipeline *comboPipeline;
-    
-    comboPipeline = renderFrameOnlyPass1(&pipeline);
-    
-    renderFrameOnlyPass2(comboPipeline,0,0,0);
-    
-    projectM::renderFrameEndOnSeparatePasses(comboPipeline);
+	Pipeline pipeline;
+	Pipeline *comboPipeline;
+
+	comboPipeline = renderFrameOnlyPass1(&pipeline);
+
+	renderFrameOnlyPass2(comboPipeline, 0, 0, 0);
+
+	projectM::renderFrameEndOnSeparatePasses(comboPipeline);
 }
 
-
-
-
-
-
-
-
-Pipeline * projectM::renderFrameOnlyPass1(Pipeline *pPipeline) /*pPipeline is a pointer to a Pipeline for use in pass 2. returns the pointer if it was used, else returns NULL */
+Pipeline *projectM::renderFrameOnlyPass1(
+	Pipeline *pPipeline) /*pPipeline is a pointer to a Pipeline for use in pass 2. returns the pointer
+													if it was used, else returns NULL */
 {
 #ifdef SYNC_PRESET_SWITCHES
-    pthread_mutex_lock(&preset_mutex);
+	pthread_mutex_lock(&preset_mutex);
 #endif
 
 #ifdef DEBUG
-    char fname[1024];
-    FILE *f = NULL;
-    int index = 0;
-    int x, y;
+	char fname[1024];
+	FILE *f = NULL;
+	int index = 0;
+	int x, y;
 #endif
 
-    timeKeeper->UpdateTimers();
-/*
-    if (timeKeeper->IsSmoothing())
-    {
-        printf("Smoothing A:%f, B:%f, S:%f\n", timeKeeper->PresetProgressA(), timeKeeper->PresetProgressB(), timeKeeper->SmoothRatio());
-    }
-    else
-    {
-        printf("          A:%f\n", timeKeeper->PresetProgressA());
-    }*/
+	timeKeeper->UpdateTimers();
+	/*
+			if (timeKeeper->IsSmoothing())
+			{
+					printf("Smoothing A:%f, B:%f, S:%f\n", timeKeeper->PresetProgressA(),
+		 timeKeeper->PresetProgressB(), timeKeeper->SmoothRatio());
+			}
+			else
+			{
+					printf("          A:%f\n", timeKeeper->PresetProgressA());
+			}*/
 
-    mspf= ( int ) ( 1000.0/ ( float ) settings().fps ); //milliseconds per frame
+	mspf = (int)(1000.0 / (float)settings().fps); // milliseconds per frame
 
-    /// @bug who is responsible for updating this now?"
-    pipelineContext().time = timeKeeper->GetRunningTime();
-    pipelineContext().presetStartTime = timeKeeper->PresetTimeA();
-    pipelineContext().frame = timeKeeper->PresetFrameA();
-    pipelineContext().progress = timeKeeper->PresetProgressA();
+	/// @bug who is responsible for updating this now?"
+	pipelineContext().time = timeKeeper->GetRunningTime();
+	pipelineContext().presetStartTime = timeKeeper->PresetTimeA();
+	pipelineContext().frame = timeKeeper->PresetFrameA();
+	pipelineContext().progress = timeKeeper->PresetProgressA();
 
-    beatDetect->detectFromSamples();
+	beatDetect->detectFromSamples();
 
-    //m_activePreset->evaluateFrame();
+	// m_activePreset->evaluateFrame();
 
-    //if the preset isn't locked and there are more presets
-    if ( renderer->noSwitch==false && !m_presetChooser->empty() )
-    {
-        //if preset is done and we're not already switching
-        if ( timeKeeper->PresetProgressA()>=1.0 && !timeKeeper->IsSmoothing())
-        {
-            if (settings().shuffleEnabled)
-                selectRandom(false);
-            else
-                selectNext(false);
-        }
+	// if the preset isn't locked and there are more presets
+	if (renderer->noSwitch == false && !m_presetChooser->empty())
+	{
+		// if preset is done and we're not already switching
+		if (timeKeeper->PresetProgressA() >= 1.0 && !timeKeeper->IsSmoothing())
+		{
+			if (settings().shuffleEnabled)
+				selectRandom(false);
+			else
+				selectNext(false);
+		}
 
-        else if ((beatDetect->vol-beatDetect->vol_old>beatDetect->beat_sensitivity ) &&
-                 timeKeeper->CanHardCut())
-        {
-            // printf("Hard Cut\n");
-            if (settings().shuffleEnabled)
-                selectRandom(true);
-            else
-                selectNext(true);
-        }
-    }
+		else if ((beatDetect->vol - beatDetect->vol_old > beatDetect->beat_sensitivity)
+						 && timeKeeper->CanHardCut())
+		{
+			// printf("Hard Cut\n");
+			if (settings().shuffleEnabled)
+				selectRandom(true);
+			else
+				selectNext(true);
+		}
+	}
 
-
-    if ( timeKeeper->IsSmoothing() && timeKeeper->SmoothRatio() <= 1.0 && !m_presetChooser->empty() )
-    {
-        //	 printf("start thread\n");
-        assert ( m_activePreset2.get() );
+	if (timeKeeper->IsSmoothing() && timeKeeper->SmoothRatio() <= 1.0 && !m_presetChooser->empty())
+	{
+		//	 printf("start thread\n");
+		assert(m_activePreset2.get());
 
 #ifdef USE_THREADS
-        worker_sync.wake_up_bg();
+		worker_sync.wake_up_bg();
 #endif
 
-        m_activePreset->Render(*beatDetect, pipelineContext());
+		m_activePreset->Render(*beatDetect, pipelineContext());
 
 #ifdef USE_THREADS
-        worker_sync.wait_for_bg_to_finish();
+		worker_sync.wait_for_bg_to_finish();
 #else
-        evaluateSecondPreset();
+		evaluateSecondPreset();
 #endif
 
+		pPipeline->setStaticPerPixel(settings().meshX, settings().meshY);
 
-        pPipeline->setStaticPerPixel(settings().meshX, settings().meshY);
+		assert(_matcher);
+		PipelineMerger::mergePipelines(m_activePreset->pipeline(), m_activePreset2->pipeline(),
+			*pPipeline, _matcher->matchResults(), *_merger, timeKeeper->SmoothRatio());
 
-        assert(_matcher);
-        PipelineMerger::mergePipelines( m_activePreset->pipeline(),
-                                        m_activePreset2->pipeline(), *pPipeline,
-                                        _matcher->matchResults(),
-                                        *_merger, timeKeeper->SmoothRatio());
+		renderer->RenderFrameOnlyPass1(*pPipeline, pipelineContext());
 
-        renderer->RenderFrameOnlyPass1(*pPipeline, pipelineContext());
+		return pPipeline;
+	}
+	else
+	{
 
+		if (timeKeeper->IsSmoothing() && timeKeeper->SmoothRatio() > 1.0)
+		{
+			// printf("End Smooth\n");
+			m_activePreset = std::move(m_activePreset2);
+			timeKeeper->EndSmoothing();
+		}
+		// printf("Normal\n");
 
-        return pPipeline;
+		m_activePreset->Render(*beatDetect, pipelineContext());
+		renderer->RenderFrameOnlyPass1(m_activePreset->pipeline(), pipelineContext());
+		return NULL; // indicating no transition
+	}
 
-    }
-    else
-    {
-
-
-        if ( timeKeeper->IsSmoothing() && timeKeeper->SmoothRatio() > 1.0 )
-        {
-            //printf("End Smooth\n");
-            m_activePreset = std::move(m_activePreset2);
-            timeKeeper->EndSmoothing();
-        }
-        //printf("Normal\n");
-
-        m_activePreset->Render(*beatDetect, pipelineContext());
-        renderer->RenderFrameOnlyPass1 (m_activePreset->pipeline(), pipelineContext());
-	return NULL; // indicating no transition
-
-    }
-
-    //	std::cout<< m_activePreset->absoluteFilePath()<<std::endl;
-    //	renderer->presetName = m_activePreset->absoluteFilePath();
-
-
-
-
+	//	std::cout<< m_activePreset->absoluteFilePath()<<std::endl;
+	//	renderer->presetName = m_activePreset->absoluteFilePath();
 }
-
-
-
-
 
 /* eye is 0,or 1, or who knows?*/
-void projectM::renderFrameOnlyPass2(Pipeline *pPipeline,int xoffset,int yoffset,int eye) /*pPipeline can be null if we re not in transition */
+void projectM::renderFrameOnlyPass2(Pipeline *pPipeline, int xoffset, int yoffset,
+	int eye) /*pPipeline can be null if we re not in transition */
 {
-/* eye is currently ignored */
-
+	/* eye is currently ignored */
 
 #ifdef DEBUG
-    char fname[1024];
-    FILE *f = NULL;
-    int index = 0;
-    int x, y;
+	char fname[1024];
+	FILE *f = NULL;
+	int index = 0;
+	int x, y;
 #endif
 
-    if (pPipeline) 
-//    if ( timeKeeper->IsSmoothing() && timeKeeper->SmoothRatio() <= 1.0 && !m_presetChooser->empty() )
-    {
-        //	 printf("start thread\n");
-        assert ( m_activePreset2.get() );
+	if (pPipeline)
+	//    if ( timeKeeper->IsSmoothing() && timeKeeper->SmoothRatio() <= 1.0 &&
+	//    !m_presetChooser->empty() )
+	{
+		//	 printf("start thread\n");
+		assert(m_activePreset2.get());
 
+		/* was other stuff */
 
-        /* was other stuff */
-	
-        renderer->RenderFrameOnlyPass2(*pPipeline, pipelineContext(),xoffset,yoffset,eye);
+		renderer->RenderFrameOnlyPass2(*pPipeline, pipelineContext(), xoffset, yoffset, eye);
+	}
+	else
+	{
 
-    }
-    else
-    {
-
-
-        renderer->RenderFrameOnlyPass2 (m_activePreset->pipeline(), pipelineContext(),xoffset,yoffset,eye);
-
-
-    }
-
+		renderer->RenderFrameOnlyPass2(
+			m_activePreset->pipeline(), pipelineContext(), xoffset, yoffset, eye);
+	}
 }
 
+void projectM::renderFrameEndOnSeparatePasses(Pipeline *pPipeline)
+{
 
+	if (pPipeline)
+	{
+		// mergePipelines() sets masterAlpha for each RenderItem, reset it before we forget
+		for (RenderItem *drawable : pPipeline->drawables)
+		{
+			drawable->masterAlpha = 1.0;
+		}
+		pPipeline->drawables.clear();
+	}
 
-
-void projectM::renderFrameEndOnSeparatePasses(Pipeline *pPipeline) {
-
-    if (pPipeline) {
-       // mergePipelines() sets masterAlpha for each RenderItem, reset it before we forget
-       for (RenderItem *drawable : pPipeline->drawables) {
-           drawable->masterAlpha = 1.0;
-       }
-    pPipeline->drawables.clear();
-    }
-  
-    count++;
+	count++;
 #ifndef WIN32
-    /** Frame-rate limiter */
-    /** Compute once per preset */
-    if ( this->count%100==0 )
-    {
-        this->renderer->realfps=100.0/ ( ( getTicks ( &timeKeeper->startTime )-this->fpsstart ) /1000 );
-        this->fpsstart=getTicks ( &timeKeeper->startTime );
-    }
+	/** Frame-rate limiter */
+	/** Compute once per preset */
+	if (this->count % 100 == 0)
+	{
+		this->renderer->realfps = 100.0 / ((getTicks(&timeKeeper->startTime) - this->fpsstart) / 1000);
+		this->fpsstart = getTicks(&timeKeeper->startTime);
+	}
 
 #ifndef UNLOCK_FPS
-    int timediff = getTicks ( &timeKeeper->startTime )-this->timestart;
+	int timediff = getTicks(&timeKeeper->startTime) - this->timestart;
 
-    if ( timediff < this->mspf )
-    {
-        // printf("%s:",this->mspf-timediff);
-        int sleepTime = ( unsigned int ) ( this->mspf-timediff ) * 1000;
-        //		DWRITE ( "usleep: %d\n", sleepTime );
-        if ( sleepTime > 0 && sleepTime < 100000 )
-        {
-            if ( usleep ( sleepTime ) != 0 ) {}}
-    }
-    this->timestart=getTicks ( &timeKeeper->startTime );
+	if (timediff < this->mspf)
+	{
+		// printf("%s:",this->mspf-timediff);
+		int sleepTime = (unsigned int)(this->mspf - timediff) * 1000;
+		//		DWRITE ( "usleep: %d\n", sleepTime );
+		if (sleepTime > 0 && sleepTime < 100000)
+		{
+			if (usleep(sleepTime) != 0)
+			{
+			}
+		}
+	}
+	this->timestart = getTicks(&timeKeeper->startTime);
 #endif
 
 #endif /** !WIN32 */
 #ifdef SYNC_PRESET_SWITCHES
-    pthread_mutex_unlock(&preset_mutex);
+	pthread_mutex_unlock(&preset_mutex);
 #endif
-return;
+	return;
 }
 
 void projectM::projectM_reset()
 {
-    this->mspf = 0;
-    this->timed = 0;
-    this->timestart = 0;
-    this->count = 0;
+	this->mspf = 0;
+	this->timed = 0;
+	this->timestart = 0;
+	this->count = 0;
 
-    this->fpsstart = 0;
+	this->fpsstart = 0;
 
-    projectM_resetengine();
+	projectM_resetengine();
 }
 
-void projectM::projectM_init ( int gx, int gy, int fps, int texsize, int width, int height )
+void projectM::projectM_init(int gx, int gy, int fps, int texsize, int width, int height)
 {
-    /** Initialise start time */
-    timeKeeper = new TimeKeeper(_settings.presetDuration,_settings.smoothPresetDuration, _settings.easterEgg);
+	/** Initialise start time */
+	timeKeeper =
+		new TimeKeeper(_settings.presetDuration, _settings.smoothPresetDuration, _settings.easterEgg);
 
-    /** Nullify frame stash */
+	/** Nullify frame stash */
 
-    /** Initialise per-pixel matrix calculations */
-    /** We need to initialise this before the builtin param db otherwise bass/mid etc won't bind correctly */
-    assert ( !beatDetect );
+	/** Initialise per-pixel matrix calculations */
+	/** We need to initialise this before the builtin param db otherwise bass/mid etc won't bind
+	 * correctly */
+	assert(!beatDetect);
 
-    if (!_pcm)
-        _pcm = new PCM();
-    assert(pcm());
-    beatDetect = new BeatDetect ( _pcm );
+	if (!_pcm) _pcm = new PCM();
+	assert(pcm());
+	beatDetect = new BeatDetect(_pcm);
 
-    if ( _settings.fps > 0 )
-        mspf= ( int ) ( 1000.0/ ( float ) _settings.fps );
-    else mspf = 0;
+	if (_settings.fps > 0)
+		mspf = (int)(1000.0 / (float)_settings.fps);
+	else
+		mspf = 0;
 
-    this->renderer = new Renderer ( width, height, gx, gy, beatDetect, settings().presetURL, settings().titleFontURL, settings().menuFontURL, settings().datadir );
+	this->renderer = new Renderer(width, height, gx, gy, beatDetect, settings().presetURL,
+		settings().titleFontURL, settings().menuFontURL, settings().datadir);
 
-    initPresetTools(gx, gy);
-
+	initPresetTools(gx, gy);
 
 #ifdef USE_THREADS
 
-    #ifdef SYNC_PRESET_SWITCHES
-    pthread_mutex_init(&preset_mutex, NULL);
+#ifdef SYNC_PRESET_SWITCHES
+	pthread_mutex_init(&preset_mutex, NULL);
 #endif
 
-    worker_sync.reset();
-    if (pthread_create(&thread, NULL, thread_callback, this) != 0)
-    {
+	worker_sync.reset();
+	if (pthread_create(&thread, NULL, thread_callback, this) != 0)
+	{
 
-        std::cerr << "[projectM] failed to allocate a thread! try building with option USE_THREADS turned off" << std::endl;;
-        exit(EXIT_FAILURE);
-    }
+		std::cerr
+			<< "[projectM] failed to allocate a thread! try building with option USE_THREADS turned off"
+			<< std::endl;
+		;
+		exit(EXIT_FAILURE);
+	}
 #endif
 
-    /// @bug order of operatoins here is busted
-    //renderer->setPresetName ( m_activePreset->name() );
-    timeKeeper->StartPreset();
-    assert(pcm());
+	/// @bug order of operatoins here is busted
+	// renderer->setPresetName ( m_activePreset->name() );
+	timeKeeper->StartPreset();
+	assert(pcm());
 
-    pipelineContext().fps = fps;
-    pipelineContext2().fps = fps;
-
+	pipelineContext().fps = fps;
+	pipelineContext2().fps = fps;
 }
 
 /* Reinitializes the engine variables to a default (conservative and sane) value */
 void projectM::projectM_resetengine()
 {
 
-    if ( beatDetect != NULL )
-    {
-        beatDetect->reset();
-    }
-
+	if (beatDetect != NULL)
+	{
+		beatDetect->reset();
+	}
 }
 
 /** Resets OpenGL state */
-void projectM::projectM_resetGL ( int w, int h )
+void projectM::projectM_resetGL(int w, int h)
 {
-    /** sanity check **/
-    assert(w > 0);
-    assert(h > 0);
+	/** sanity check **/
+	assert(w > 0);
+	assert(h > 0);
 
-    /** Stash the new dimensions */
-    _settings.windowWidth = w;
-    _settings.windowHeight = h;
-    renderer->reset ( w,h );
+	/** Stash the new dimensions */
+	_settings.windowWidth = w;
+	_settings.windowHeight = h;
+	renderer->reset(w, h);
 }
 
 /** Sets the title to display */
-void projectM::projectM_setTitle ( std::string title ) {
+void projectM::projectM_setTitle(std::string title)
+{
 
-    if ( title != renderer->title )
-    {
-        renderer->title=title;
-        renderer->drawtitle=1;
-    }
+	if (title != renderer->title)
+	{
+		renderer->title = title;
+		renderer->drawtitle = 1;
+	}
 }
-
 
 int projectM::initPresetTools(int gx, int gy)
 {
 
-    /* Set the seed to the current time in seconds */
-    srand ( time ( NULL ) );
+	/* Set the seed to the current time in seconds */
+	srand(time(NULL));
 
-    std::string url = (m_flags & FLAG_DISABLE_PLAYLIST_LOAD) ? std::string() : settings().presetURL;
+	std::string url = (m_flags & FLAG_DISABLE_PLAYLIST_LOAD) ? std::string() : settings().presetURL;
 
-    if ( ( m_presetLoader = new PresetLoader ( gx, gy, url) ) == 0 )
-    {
-        m_presetLoader = 0;
-        std::cerr << "[projectM] error allocating preset loader" << std::endl;
-        return PROJECTM_FAILURE;
-    }
+	if ((m_presetLoader = new PresetLoader(gx, gy, url)) == 0)
+	{
+		m_presetLoader = 0;
+		std::cerr << "[projectM] error allocating preset loader" << std::endl;
+		return PROJECTM_FAILURE;
+	}
 
-    if ( ( m_presetChooser = new PresetChooser ( *m_presetLoader, settings().softCutRatingsEnabled ) ) == 0 )
-    {
-        delete ( m_presetLoader );
+	if ((m_presetChooser = new PresetChooser(*m_presetLoader, settings().softCutRatingsEnabled)) == 0)
+	{
+		delete (m_presetLoader);
 
-        m_presetChooser = 0;
-        m_presetLoader = 0;
+		m_presetChooser = 0;
+		m_presetLoader = 0;
 
-        std::cerr << "[projectM] error allocating preset chooser" << std::endl;
-        return PROJECTM_FAILURE;
-    }
+		std::cerr << "[projectM] error allocating preset chooser" << std::endl;
+		return PROJECTM_FAILURE;
+	}
 
-    // Start the iterator
-    if (!m_presetPos)
-        m_presetPos = new PresetIterator();
+	// Start the iterator
+	if (!m_presetPos) m_presetPos = new PresetIterator();
 
-    // Initialize a preset queue position as well
-    //	m_presetQueuePos = new PresetIterator();
+	// Initialize a preset queue position as well
+	//	m_presetQueuePos = new PresetIterator();
 
-    // Start at end ptr- this allows next/previous to easily be done from this position.
-    *m_presetPos = m_presetChooser->end();
+	// Start at end ptr- this allows next/previous to easily be done from this position.
+	*m_presetPos = m_presetChooser->end();
 
-    // Load idle preset
-//        std::cerr << "[projectM] Allocating idle preset..." << std::endl;
-    m_activePreset = m_presetLoader->loadPreset
-            ("idle://Geiss & Sperl - Feedback (projectM idle HDR mix).milk");
+	// Load idle preset
+	//        std::cerr << "[projectM] Allocating idle preset..." << std::endl;
+	m_activePreset =
+		m_presetLoader->loadPreset("idle://Geiss & Sperl - Feedback (projectM idle HDR mix).milk");
 	renderer->setPresetName("Geiss & Sperl - Feedback (projectM idle HDR mix)");
 
-    renderer->SetPipeline(m_activePreset->pipeline());
+	renderer->SetPipeline(m_activePreset->pipeline());
 
-    // Case where no valid presets exist in directory. Could also mean
-    // playlist initialization was deferred
-    if (m_presetChooser->empty())
-    {
-        //std::cerr << "[projectM] warning: no valid files found in preset directory \""
-        ///< m_presetLoader->directoryName() << "\"" << std::endl;
-    }
+	// Case where no valid presets exist in directory. Could also mean
+	// playlist initialization was deferred
+	if (m_presetChooser->empty())
+	{
+		// std::cerr << "[projectM] warning: no valid files found in preset directory \""
+		///< m_presetLoader->directoryName() << "\"" << std::endl;
+	}
 
-    _matcher = new RenderItemMatcher();
-    _merger = new MasterRenderItemMerge();
-    //_merger->add(new WaveFormMergeFunction());
-    _merger->add(new ShapeMerge());
-    _merger->add(new BorderMerge());
-    //_merger->add(new BorderMergeFunction());
+	_matcher = new RenderItemMatcher();
+	_merger = new MasterRenderItemMerge();
+	//_merger->add(new WaveFormMergeFunction());
+	_merger->add(new ShapeMerge());
+	_merger->add(new BorderMerge());
+	//_merger->add(new BorderMergeFunction());
 
-    /// @bug These should be requested by the preset factories.
-    _matcher->distanceFunction().addMetric(new ShapeXYDistance());
+	/// @bug These should be requested by the preset factories.
+	_matcher->distanceFunction().addMetric(new ShapeXYDistance());
 
-    //std::cerr << "[projectM] Idle preset allocated." << std::endl;
+	// std::cerr << "[projectM] Idle preset allocated." << std::endl;
 
-    projectM_resetengine();
+	projectM_resetengine();
 
-    //std::cerr << "[projectM] engine has been reset." << std::endl;
-    return PROJECTM_SUCCESS;
+	// std::cerr << "[projectM] engine has been reset." << std::endl;
+	return PROJECTM_SUCCESS;
 }
 
 void projectM::destroyPresetTools()
 {
 
-    if ( m_presetPos )
-        delete ( m_presetPos );
+	if (m_presetPos) delete (m_presetPos);
 
-    m_presetPos = 0;
+	m_presetPos = 0;
 
-    if ( m_presetChooser )
-        delete ( m_presetChooser );
+	if (m_presetChooser) delete (m_presetChooser);
 
-    m_presetChooser = 0;
+	m_presetChooser = 0;
 
-    if ( m_presetLoader )
-        delete ( m_presetLoader );
+	if (m_presetLoader) delete (m_presetLoader);
 
-    m_presetLoader = 0;
+	m_presetLoader = 0;
 
-    if (_matcher) {
-        delete _matcher;
-        _matcher = NULL;
-    }
+	if (_matcher)
+	{
+		delete _matcher;
+		_matcher = NULL;
+	}
 
-    if (_merger) {
-        delete _merger;
-        _merger = NULL;
-    }
+	if (_merger)
+	{
+		delete _merger;
+		_merger = NULL;
+	}
 }
 
 /// @bug queuePreset case isn't handled
-void projectM::removePreset(unsigned int index) {
+void projectM::removePreset(unsigned int index)
+{
 
-    size_t chooserIndex = **m_presetPos;
+	size_t chooserIndex = **m_presetPos;
 
-    m_presetLoader->removePreset(index);
+	m_presetLoader->removePreset(index);
 
+	// Case: no more presets, set iterator to end
+	if (m_presetChooser->empty()) *m_presetPos = m_presetChooser->end();
 
-    // Case: no more presets, set iterator to end
-    if (m_presetChooser->empty())
-        *m_presetPos = m_presetChooser->end();
+	// Case: chooser index has become one less due to removal of an index below it
+	else if (chooserIndex > index)
+	{
+		chooserIndex--;
+		*m_presetPos = m_presetChooser->begin(chooserIndex);
+	}
 
-        // Case: chooser index has become one less due to removal of an index below it
-    else if (chooserIndex > index) {
-        chooserIndex--;
-        *m_presetPos = m_presetChooser->begin(chooserIndex);
-    }
-
-        // Case: we have deleted the active preset position
-        // Set iterator to end of chooser
-    else if (chooserIndex == index) {
-        *m_presetPos = m_presetChooser->end();
-    }
-
-
-
+	// Case: we have deleted the active preset position
+	// Set iterator to end of chooser
+	else if (chooserIndex == index)
+	{
+		*m_presetPos = m_presetChooser->end();
+	}
 }
 
-unsigned int projectM::addPresetURL ( const std::string & presetURL, const std::string & presetName, const RatingList & ratings)
+unsigned int projectM::addPresetURL(
+	const std::string &presetURL, const std::string &presetName, const RatingList &ratings)
 {
-    bool restorePosition = false;
+	bool restorePosition = false;
 
-    if (*m_presetPos == m_presetChooser->end())
-        restorePosition = true;
+	if (*m_presetPos == m_presetChooser->end()) restorePosition = true;
 
-    int index = m_presetLoader->addPresetURL ( presetURL, presetName, ratings);
+	int index = m_presetLoader->addPresetURL(presetURL, presetName, ratings);
 
-    if (restorePosition)
-        *m_presetPos = m_presetChooser->end();
+	if (restorePosition) *m_presetPos = m_presetChooser->end();
 
-    return index;
+	return index;
 }
 
 void projectM::selectPreset(unsigned int index, bool hardCut)
 {
 
-    if (m_presetChooser->empty())
-        return;
+	if (m_presetChooser->empty()) return;
 
-
-    *m_presetPos = m_presetChooser->begin(index);
-    switchPreset(hardCut);
+	*m_presetPos = m_presetChooser->begin(index);
+	switchPreset(hardCut);
 }
 
-void projectM::switchPreset(const bool hardCut) {
-    std::string result;
+void projectM::switchPreset(const bool hardCut)
+{
+	std::string result;
 
-    if (!hardCut) {
-        result = switchPreset(m_activePreset2);
-    } else {
-        result = switchPreset(m_activePreset);
-        if (result.empty())
-            timeKeeper->StartPreset();
-    }
+	if (!hardCut)
+	{
+		result = switchPreset(m_activePreset2);
+	}
+	else
+	{
+		result = switchPreset(m_activePreset);
+		if (result.empty()) timeKeeper->StartPreset();
+	}
 
-    if (result.empty() && !hardCut) {
-        timeKeeper->StartSmoothing();
-    }
+	if (result.empty() && !hardCut)
+	{
+		timeKeeper->StartSmoothing();
+	}
 
-    if (result.empty()) {
-        presetSwitchedEvent(hardCut, **m_presetPos);
-        errorLoadingCurrentPreset = false;
-    } else {
-        presetSwitchFailedEvent(hardCut, **m_presetPos, result);
-        errorLoadingCurrentPreset = true;
-
-    }
+	if (result.empty())
+	{
+		presetSwitchedEvent(hardCut, **m_presetPos);
+		errorLoadingCurrentPreset = false;
+	}
+	else
+	{
+		presetSwitchFailedEvent(hardCut, **m_presetPos, result);
+		errorLoadingCurrentPreset = true;
+	}
 }
 
+void projectM::selectRandom(const bool hardCut)
+{
 
-void projectM::selectRandom(const bool hardCut) {
+	if (m_presetChooser->empty()) return;
 
-    if (m_presetChooser->empty())
-        return;
+	*m_presetPos = m_presetChooser->weightedRandom(hardCut);
 
-    *m_presetPos = m_presetChooser->weightedRandom(hardCut);
-
-    switchPreset(hardCut);
-
+	switchPreset(hardCut);
 }
 
-void projectM::selectPrevious(const bool hardCut) {
+void projectM::selectPrevious(const bool hardCut)
+{
 
-    if (m_presetChooser->empty())
-        return;
+	if (m_presetChooser->empty()) return;
 
+	m_presetChooser->previousPreset(*m_presetPos);
 
-    m_presetChooser->previousPreset(*m_presetPos);
-
-    switchPreset(hardCut);
+	switchPreset(hardCut);
 }
 
-void projectM::selectNext(const bool hardCut) {
+void projectM::selectNext(const bool hardCut)
+{
 
-    if (m_presetChooser->empty())
-        return;
+	if (m_presetChooser->empty()) return;
 
-    m_presetChooser->nextPreset(*m_presetPos);
+	m_presetChooser->nextPreset(*m_presetPos);
 
-    switchPreset(hardCut);
+	switchPreset(hardCut);
 }
 
 /**
-* Switches to the target preset.
-* @param targetPreset
-* @return a message indicating an error, empty otherwise.
-*/
-std::string projectM::switchPreset(std::unique_ptr<Preset> & targetPreset) {
+ * Switches to the target preset.
+ * @param targetPreset
+ * @return a message indicating an error, empty otherwise.
+ */
+std::string projectM::switchPreset(std::unique_ptr<Preset> &targetPreset)
+{
 
-    std::string result;
-
-#ifdef SYNC_PRESET_SWITCHES
-    pthread_mutex_lock(&preset_mutex);
-#endif
-    try {
-        targetPreset = m_presetPos->allocate();
-    } catch (const PresetFactoryException & e) {
-#ifdef SYNC_PRESET_SWITCHES
-        pthread_mutex_unlock(&preset_mutex);
-#endif
-        std::cerr << "problem allocating target preset: " << e.message() << std::endl;
-        return e.message();
-    }
-
-// Set preset name here- event is not done because at the moment this function is oblivious to smooth/hard switches
-    renderer->setPresetName(targetPreset->name());
-    result = renderer->SetPipeline(targetPreset->pipeline());
+	std::string result;
 
 #ifdef SYNC_PRESET_SWITCHES
-    pthread_mutex_unlock(&preset_mutex);
+	pthread_mutex_lock(&preset_mutex);
+#endif
+	try
+	{
+		targetPreset = m_presetPos->allocate();
+	}
+	catch (const PresetFactoryException &e)
+	{
+#ifdef SYNC_PRESET_SWITCHES
+		pthread_mutex_unlock(&preset_mutex);
+#endif
+		std::cerr << "problem allocating target preset: " << e.message() << std::endl;
+		return e.message();
+	}
+
+	// Set preset name here- event is not done because at the moment this function is oblivious to
+	// smooth/hard switches
+	renderer->setPresetName(targetPreset->name());
+	result = renderer->SetPipeline(targetPreset->pipeline());
+
+#ifdef SYNC_PRESET_SWITCHES
+	pthread_mutex_unlock(&preset_mutex);
 #endif
 
-    return result;
+	return result;
 }
 
-void projectM::setPresetLock ( bool isLocked )
+void projectM::setPresetLock(bool isLocked)
 {
-    renderer->noSwitch = isLocked;
+	renderer->noSwitch = isLocked;
 }
 
 bool projectM::isPresetLocked() const
 {
-    return renderer->noSwitch;
+	return renderer->noSwitch;
 }
 
-std::string projectM::getPresetURL ( unsigned int index ) const
+std::string projectM::getPresetURL(unsigned int index) const
 {
-    return m_presetLoader->getPresetURL(index);
+	return m_presetLoader->getPresetURL(index);
 }
 
-int projectM::getPresetRating ( unsigned int index, const PresetRatingType ratingType) const
+int projectM::getPresetRating(unsigned int index, const PresetRatingType ratingType) const
 {
-    return m_presetLoader->getPresetRating(index, ratingType);
+	return m_presetLoader->getPresetRating(index, ratingType);
 }
 
-std::string projectM::getPresetName ( unsigned int index ) const
+std::string projectM::getPresetName(unsigned int index) const
 {
-    return m_presetLoader->getPresetName(index);
+	return m_presetLoader->getPresetName(index);
 }
 
-void projectM::clearPlaylist ( )
+void projectM::clearPlaylist()
 {
-    m_presetLoader->clear();
-    *m_presetPos = m_presetChooser->end();
+	m_presetLoader->clear();
+	*m_presetPos = m_presetChooser->end();
 }
 
-void projectM::selectPresetPosition(unsigned int index) {
-    *m_presetPos = m_presetChooser->begin(index);
+void projectM::selectPresetPosition(unsigned int index)
+{
+	*m_presetPos = m_presetChooser->begin(index);
 }
 
-bool projectM::selectedPresetIndex(unsigned int & index) const {
+bool projectM::selectedPresetIndex(unsigned int &index) const
+{
 
-    if (*m_presetPos == m_presetChooser->end())
-        return false;
+	if (*m_presetPos == m_presetChooser->end()) return false;
 
-    index = **m_presetPos;
-    return true;
+	index = **m_presetPos;
+	return true;
 }
 
+bool projectM::presetPositionValid() const
+{
 
-bool projectM::presetPositionValid() const {
-
-    return (*m_presetPos != m_presetChooser->end());
+	return (*m_presetPos != m_presetChooser->end());
 }
 
 unsigned int projectM::getPlaylistSize() const
 {
-    return m_presetLoader->size();
+	return m_presetLoader->size();
 }
 
-void projectM::changePresetRating (unsigned int index, int rating, const PresetRatingType ratingType) {
-    m_presetLoader->setRating(index, rating, ratingType);
-    presetRatingChanged(index, rating, ratingType);
-}
-
-void projectM::insertPresetURL(unsigned int index, const std::string & presetURL, const std::string & presetName, const RatingList & ratings)
+void projectM::changePresetRating(unsigned int index, int rating, const PresetRatingType ratingType)
 {
-    bool atEndPosition = false;
-
-    int newSelectedIndex = 0;
-
-
-    if (*m_presetPos == m_presetChooser->end()) // Case: preset not selected
-    {
-        atEndPosition = true;
-    }
-
-    else if (**m_presetPos < index) // Case: inserting before selected preset
-    {
-        newSelectedIndex = **m_presetPos;
-    }
-
-    else if (**m_presetPos > index) // Case: inserting after selected preset
-    {
-        newSelectedIndex++;
-    }
-
-    else  // Case: inserting at selected preset
-    {
-        newSelectedIndex++;
-    }
-
-    m_presetLoader->insertPresetURL (index, presetURL, presetName, ratings);
-
-    if (atEndPosition)
-        *m_presetPos = m_presetChooser->end();
-    else
-        *m_presetPos = m_presetChooser->begin(newSelectedIndex);
-
-
+	m_presetLoader->setRating(index, rating, ratingType);
+	presetRatingChanged(index, rating, ratingType);
 }
 
-void projectM::changePresetName ( unsigned int index, std::string name ) {
-    m_presetLoader->setPresetName(index, name);
+void projectM::insertPresetURL(unsigned int index, const std::string &presetURL,
+	const std::string &presetName, const RatingList &ratings)
+{
+	bool atEndPosition = false;
+
+	int newSelectedIndex = 0;
+
+	if (*m_presetPos == m_presetChooser->end()) // Case: preset not selected
+	{
+		atEndPosition = true;
+	}
+
+	else if (**m_presetPos < index) // Case: inserting before selected preset
+	{
+		newSelectedIndex = **m_presetPos;
+	}
+
+	else if (**m_presetPos > index) // Case: inserting after selected preset
+	{
+		newSelectedIndex++;
+	}
+
+	else // Case: inserting at selected preset
+	{
+		newSelectedIndex++;
+	}
+
+	m_presetLoader->insertPresetURL(index, presetURL, presetName, ratings);
+
+	if (atEndPosition)
+		*m_presetPos = m_presetChooser->end();
+	else
+		*m_presetPos = m_presetChooser->begin(newSelectedIndex);
 }
 
-
-void projectM::changeTextureSize(int size) {
-    _settings.textureSize = size;
-
-    delete renderer;
-    renderer = new Renderer(_settings.windowWidth, _settings.windowHeight,
-                            _settings.meshX, _settings.meshY,
-                            beatDetect, _settings.presetURL,
-                            _settings.titleFontURL, _settings.menuFontURL,
-                            _settings.datadir);
+void projectM::changePresetName(unsigned int index, std::string name)
+{
+	m_presetLoader->setPresetName(index, name);
 }
 
-void projectM::changePresetDuration(int seconds) {
-    timeKeeper->ChangePresetDuration(seconds);
-}
-void projectM::getMeshSize(int *w, int *h)	{
-    *w = _settings.meshX;
-    *h = _settings.meshY;
+void projectM::changeTextureSize(int size)
+{
+	_settings.textureSize = size;
+
+	delete renderer;
+	renderer = new Renderer(_settings.windowWidth, _settings.windowHeight, _settings.meshX,
+		_settings.meshY, beatDetect, _settings.presetURL, _settings.titleFontURL, _settings.menuFontURL,
+		_settings.datadir);
 }
 
+void projectM::changePresetDuration(int seconds)
+{
+	timeKeeper->ChangePresetDuration(seconds);
+}
+void projectM::getMeshSize(int *w, int *h)
+{
+	*w = _settings.meshX;
+	*h = _settings.meshY;
+}

--- a/src/libprojectM/projectM.hpp
+++ b/src/libprojectM/projectM.hpp
@@ -156,8 +156,15 @@ public:
             softCutRatingsEnabled(false) {}
     };
 
+    struct ConfigPreset
+	{
+		std::string config_file;
+		Settings settings;
+	};
+
   projectM(std::string config_file, int flags = FLAG_NONE);
   projectM(Settings settings, int flags = FLAG_NONE);
+  projectM(ConfigPreset configPreset, int flags = FLAG_NONE);
 
   void projectM_resetGL( int width, int height );
   void projectM_resetTextures();
@@ -310,6 +317,7 @@ private:
   float fpsstart;
 
   void readConfig(const std::string &configFile);
+  void readConfig(const std::string &configFile, const Settings &settings);
   void readSettings(const Settings &settings);
   void projectM_init(int gx, int gy, int fps, int texsize, int width, int height);
   void projectM_reset();

--- a/src/projectM-sdl/pmSDL.cpp
+++ b/src/projectM-sdl/pmSDL.cpp
@@ -439,18 +439,28 @@ void projectMSDL::renderFrame() {
     SDL_GL_SwapWindow(win);
 }
 
-projectMSDL::projectMSDL(Settings settings, int flags) : projectM(settings, flags) {
-    width = getWindowWidth();
-    height = getWindowHeight();
-    done = 0;
-    isFullScreen = false;
+projectMSDL::projectMSDL(Settings settings, int flags) : projectM(settings, flags)
+{
+	width = getWindowWidth();
+	height = getWindowHeight();
+	done = 0;
+	isFullScreen = false;
 }
 
-projectMSDL::projectMSDL(std::string config_file, int flags) : projectM(config_file, flags) {
-    width = getWindowWidth();
-    height = getWindowHeight();
-    done = 0;
-    isFullScreen = false;
+projectMSDL::projectMSDL(std::string config_file, int flags) : projectM(config_file, flags)
+{
+	width = getWindowWidth();
+	height = getWindowHeight();
+	done = 0;
+	isFullScreen = false;
+}
+
+projectMSDL::projectMSDL(ConfigPreset configPreset, int flags) : projectM(configPreset, flags)
+{
+	width = getWindowWidth();
+	height = getWindowHeight();
+	done = 0;
+	isFullScreen = false;
 }
 
 void projectMSDL::init(SDL_Window *window, SDL_GLContext *_glCtx, const bool _renderToTexture) {

--- a/src/projectM-sdl/pmSDL.hpp
+++ b/src/projectM-sdl/pmSDL.hpp
@@ -78,10 +78,7 @@
     #else
         #define DATADIR_PATH "/usr/local/share/projectM"
 #ifndef WIN32
-        std::string configFilePath = "";
-        configFilePath += getenv("APPDATA");
-        configFilePath += "\\projectM\\"
-        #define DATADIR_PATH "C:\\test"
+        #warning "DATADIR_PATH is not defined - falling back to /usr/local/share/projectM"
 #endif /** WIN32 */
     #endif
 #endif

--- a/src/projectM-sdl/pmSDL.hpp
+++ b/src/projectM-sdl/pmSDL.hpp
@@ -78,7 +78,10 @@
     #else
         #define DATADIR_PATH "/usr/local/share/projectM"
 #ifndef WIN32
-        #warning "DATADIR_PATH is not defined - falling back to /usr/local/share/projectM"
+        std::string configFilePath = "";
+        configFilePath += getenv("APPDATA");
+        configFilePath += "\\projectM\\"
+        #define DATADIR_PATH "C:\\test"
 #endif /** WIN32 */
     #endif
 #endif
@@ -88,8 +91,9 @@ public:
 
 
     bool done;
-    projectMSDL(Settings settings, int flags);
-    projectMSDL(std::string config_file, int flags);
+	projectMSDL(Settings settings, int flags);
+	projectMSDL(std::string config_file, int flags);
+	projectMSDL(ConfigPreset configPreset, int flags);
     void init(SDL_Window *window, SDL_GLContext *glCtx, const bool renderToTexture = false);
     int openAudioInput();
     int toggleAudioInput();

--- a/src/projectM-sdl/projectM_SDL_main.cpp
+++ b/src/projectM-sdl/projectM_SDL_main.cpp
@@ -1,104 +1,131 @@
 /**
-* projectM -- Milkdrop-esque visualisation SDK
-* Copyright (C)2003-2019 projectM Team
-*
-* This library is free software; you can redistribute it and/or
-* modify it under the terms of the GNU Lesser General Public
-* License as published by the Free Software Foundation; either
-* version 2.1 of the License, or (at your option) any later version.
-*
-* This library is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* Lesser General Public License for more details.
-*
-* You should have received a copy of the GNU Lesser General Public
-* License along with this library; if not, write to the Free Software
-* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-* See 'LICENSE.txt' included within this release
-*
-* projectM-sdl
-* This is an implementation of projectM using libSDL2
-* 
-* main.cpp
-* Authors: Created by Mischa Spiegelmock on 6/3/15.
-*
-* 
-*	RobertPancoast77@gmail.com :
-* experimental Stereoscopic SBS driver functionality
-* WASAPI looback implementation
-* 
-*
-*/
+ * projectM -- Milkdrop-esque visualisation SDK
+ * Copyright (C)2003-2019 projectM Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * See 'LICENSE.txt' included within this release
+ *
+ * projectM-sdl
+ * This is an implementation of projectM using libSDL2
+ *
+ * main.cpp
+ * Authors: Created by Mischa Spiegelmock on 6/3/15.
+ *
+ *
+ *	RobertPancoast77@gmail.com :
+ * experimental Stereoscopic SBS driver functionality
+ * WASAPI looback implementation
+ *
+ *
+ */
 
 #include "pmSDL.hpp"
 
 #if OGL_DEBUG
-void DebugLog(GLenum source,
-               GLenum type,
-               GLuint id,
-               GLenum severity,
-               GLsizei length,
-               const GLchar* message,
-               const void* userParam) {
+void DebugLog(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length,
+	const GLchar *message, const void *userParam)
+{
 
-    /*if (type != GL_DEBUG_TYPE_OTHER)*/ 
+	/*if (type != GL_DEBUG_TYPE_OTHER)*/
 	{
-        std::cerr << " -- \n" << "Type: " <<
-           type << "; Source: " <<
-           source <<"; ID: " << id << "; Severity: " <<
-           severity << "\n" << message << "\n";
-       }
- }
+		std::cerr << " -- \n"
+							<< "Type: " << type << "; Source: " << source << "; ID: " << id
+							<< "; Severity: " << severity << "\n"
+							<< message << "\n";
+	}
+}
 #endif
 
 // return path to config file to use
-std::string getConfigFilePath(std::string datadir_path) {
-    struct stat sb;
-    const char *path = datadir_path.c_str();
-    
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Looking for configuration file in data dir: %s.\n", path);
-    
-    // check if datadir exists.
-    // it should exist if this application was installed. if not, assume we're developing it and use currect directory
-    if (stat(path, &sb) != 0) {
-        SDL_LogWarn(SDL_LOG_CATEGORY_ERROR, "Could not open datadir path %s\n", path);
-    }
-    
-    std::string configFilePath = path;
-    configFilePath += "/config.inp";
-    
-    // check if config file exists
-    if (stat(configFilePath.c_str(), &sb) != 0) {
-        SDL_LogWarn(SDL_LOG_CATEGORY_ERROR, "No config file %s found. Using development settings.\n", configFilePath.c_str());
-        return "";
-    }
-    
-    return configFilePath;
+std::string getConfigFilePath(std::string datadir_path)
+{
+	struct stat sb;
+	const char *path = datadir_path.c_str();
+
+	SDL_LogInfo(
+		SDL_LOG_CATEGORY_APPLICATION, "Looking for configuration file in data directory: %s\n", path);
+
+	std::string configFilePath = "";
+
+	// check if datadir exists.
+	// it should exist if this application was installed. if not, try the settings directory.
+	if (stat(path, &sb) != 0)
+	{
+#ifdef WIN32
+		configFilePath += getenv("APPDATA");
+		configFilePath += "\\projectM\\config.inp";
+#else
+		configFilePath += getenv("home");
+		configFilePath += "/.projectM/config.inp";
+#endif
+		SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+			"Looking for configuration file in settings directory: %s\n", configFilePath.c_str());
+	}
+	else
+	{
+		configFilePath = path;
+		configFilePath += "config.inp";
+	}
+
+	// check if settings config file exists.
+	// if not, assume we're developing it and use the current working directory.
+	if (stat(configFilePath.c_str(), &sb) != 0)
+	{
+		configFilePath = "";
+#ifdef WIN32
+		configFilePath += ".\\config.inp";
+#else
+		configFilePath += "./config.inp";
+#endif
+		SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+			"Looking for configuration file in current working directory: %s\n", configFilePath.c_str());
+	}
+
+	// check if config file exists
+	if (stat(configFilePath.c_str(), &sb) != 0)
+	{
+		SDL_LogWarn(SDL_LOG_CATEGORY_ERROR, "No config file %s found. Using development settings.\n",
+			configFilePath.c_str());
+		return "";
+	}
+
+	return configFilePath;
 }
 
-
-// ref https://blogs.msdn.microsoft.com/matthew_van_eerde/2008/12/16/sample-wasapi-loopback-capture-record-what-you-hear/
+// ref
+// https://blogs.msdn.microsoft.com/matthew_van_eerde/2008/12/16/sample-wasapi-loopback-capture-record-what-you-hear/
 #ifdef WASAPI_LOOPBACK
 
-HRESULT get_default_device(IMMDevice **ppMMDevice) {
+HRESULT get_default_device(IMMDevice **ppMMDevice)
+{
 	HRESULT hr = S_OK;
 	IMMDeviceEnumerator *pMMDeviceEnumerator;
 
 	// activate a device enumerator
-	hr = CoCreateInstance(
-		__uuidof(MMDeviceEnumerator), NULL, CLSCTX_ALL,
-		__uuidof(IMMDeviceEnumerator),
-		(void**)&pMMDeviceEnumerator
-	);
-	if (FAILED(hr)) {
+	hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), NULL, CLSCTX_ALL,
+		__uuidof(IMMDeviceEnumerator), (void **)&pMMDeviceEnumerator);
+	if (FAILED(hr))
+	{
 		ERR(L"CoCreateInstance(IMMDeviceEnumerator) failed: hr = 0x%08x", hr);
 		return hr;
 	}
 
 	// get the default render endpoint
 	hr = pMMDeviceEnumerator->GetDefaultAudioEndpoint(eRender, eConsole, ppMMDevice);
-	if (FAILED(hr)) {
+	if (FAILED(hr))
+	{
 		ERR(L"IMMDeviceEnumerator::GetDefaultAudioEndpoint failed: hr = 0x%08x", hr);
 		return hr;
 	}
@@ -108,41 +135,41 @@ HRESULT get_default_device(IMMDevice **ppMMDevice) {
 
 #endif /** WASAPI_LOOPBACK */
 
-int main(int argc, char *argv[]) {
+int main(int argc, char *argv[])
+{
 #ifndef WIN32
-srand((int)(time(NULL)));
+	srand((int)(time(NULL)));
 #endif
 
 #ifdef WASAPI_LOOPBACK
 	HRESULT hr;
 
-    hr = CoInitialize(NULL);
-    if (FAILED(hr)) {
-        ERR(L"CoInitialize failed: hr = 0x%08x", hr);
-    }
-
+	hr = CoInitialize(NULL);
+	if (FAILED(hr))
+	{
+		ERR(L"CoInitialize failed: hr = 0x%08x", hr);
+	}
 
 	IMMDevice *pMMDevice(NULL);
-    // open default device if not specified
-    if (NULL == pMMDevice) {
-        hr = get_default_device(&pMMDevice);
-        if (FAILED(hr)) {
-            return hr;
-        }
-    }
+	// open default device if not specified
+	if (NULL == pMMDevice)
+	{
+		hr = get_default_device(&pMMDevice);
+		if (FAILED(hr))
+		{
+			return hr;
+		}
+	}
 
 	bool bInt16 = false;
-    UINT32 foo = 0;
+	UINT32 foo = 0;
 	PUINT32 pnFrames = &foo;
 
 	// activate an IAudioClient
 	IAudioClient *pAudioClient;
-	hr = pMMDevice->Activate(
-		__uuidof(IAudioClient),
-		CLSCTX_ALL, NULL,
-		(void**)&pAudioClient
-	);
-	if (FAILED(hr)) {
+	hr = pMMDevice->Activate(__uuidof(IAudioClient), CLSCTX_ALL, NULL, (void **)&pAudioClient);
+	if (FAILED(hr))
+	{
 		ERR(L"IMMDevice::Activate(IAudioClient) failed: hr = 0x%08x", hr);
 		return hr;
 	}
@@ -150,7 +177,8 @@ srand((int)(time(NULL)));
 	// get the default device periodicity
 	REFERENCE_TIME hnsDefaultDevicePeriod;
 	hr = pAudioClient->GetDevicePeriod(&hnsDefaultDevicePeriod, NULL);
-	if (FAILED(hr)) {
+	if (FAILED(hr))
+	{
 		ERR(L"IAudioClient::GetDevicePeriod failed: hr = 0x%08x", hr);
 		return hr;
 	}
@@ -158,47 +186,53 @@ srand((int)(time(NULL)));
 	// get the default device format
 	WAVEFORMATEX *pwfx;
 	hr = pAudioClient->GetMixFormat(&pwfx);
-	if (FAILED(hr)) {
+	if (FAILED(hr))
+	{
 		ERR(L"IAudioClient::GetMixFormat failed: hr = 0x%08x", hr);
 		return hr;
 	}
 
-	if (bInt16) {
+	if (bInt16)
+	{
 		// coerce int-16 wave format
 		// can do this in-place since we're not changing the size of the format
 		// also, the engine will auto-convert from float to int for us
-		switch (pwfx->wFormatTag) {
-		case WAVE_FORMAT_IEEE_FLOAT:
-			pwfx->wFormatTag = WAVE_FORMAT_PCM;
-			pwfx->wBitsPerSample = 16;
-			pwfx->nBlockAlign = pwfx->nChannels * pwfx->wBitsPerSample / 8;
-			pwfx->nAvgBytesPerSec = pwfx->nBlockAlign * pwfx->nSamplesPerSec;
-			break;
-
-		case WAVE_FORMAT_EXTENSIBLE:
+		switch (pwfx->wFormatTag)
 		{
-			// naked scope for case-local variable
-			PWAVEFORMATEXTENSIBLE pEx = reinterpret_cast<PWAVEFORMATEXTENSIBLE>(pwfx);
-			if (IsEqualGUID(KSDATAFORMAT_SUBTYPE_IEEE_FLOAT, pEx->SubFormat)) {
-				pEx->SubFormat = KSDATAFORMAT_SUBTYPE_PCM;
-				pEx->Samples.wValidBitsPerSample = 16;
+			case WAVE_FORMAT_IEEE_FLOAT:
+				pwfx->wFormatTag = WAVE_FORMAT_PCM;
 				pwfx->wBitsPerSample = 16;
 				pwfx->nBlockAlign = pwfx->nChannels * pwfx->wBitsPerSample / 8;
 				pwfx->nAvgBytesPerSec = pwfx->nBlockAlign * pwfx->nSamplesPerSec;
-			}
-			else {
-				ERR(L"%s", L"Don't know how to coerce mix format to int-16");
-				return E_UNEXPECTED;
-			}
-		}
-		break;
+				break;
 
-		default:
-			ERR(L"Don't know how to coerce WAVEFORMATEX with wFormatTag = 0x%08x to int-16", pwfx->wFormatTag);
-			return E_UNEXPECTED;
+			case WAVE_FORMAT_EXTENSIBLE:
+			{
+				// naked scope for case-local variable
+				PWAVEFORMATEXTENSIBLE pEx = reinterpret_cast<PWAVEFORMATEXTENSIBLE>(pwfx);
+				if (IsEqualGUID(KSDATAFORMAT_SUBTYPE_IEEE_FLOAT, pEx->SubFormat))
+				{
+					pEx->SubFormat = KSDATAFORMAT_SUBTYPE_PCM;
+					pEx->Samples.wValidBitsPerSample = 16;
+					pwfx->wBitsPerSample = 16;
+					pwfx->nBlockAlign = pwfx->nChannels * pwfx->wBitsPerSample / 8;
+					pwfx->nAvgBytesPerSec = pwfx->nBlockAlign * pwfx->nSamplesPerSec;
+				}
+				else
+				{
+					ERR(L"%s", L"Don't know how to coerce mix format to int-16");
+					return E_UNEXPECTED;
+				}
+			}
+			break;
+
+			default:
+				ERR(L"Don't know how to coerce WAVEFORMATEX with wFormatTag = 0x%08x to int-16",
+					pwfx->wFormatTag);
+				return E_UNEXPECTED;
 		}
 	}
-        
+
 	UINT32 nBlockAlign = pwfx->nBlockAlign;
 	*pnFrames = 0;
 
@@ -207,84 +241,83 @@ srand((int)(time(NULL)));
 	// do not work together...
 	// the "data ready" event never gets set
 	// so we're going to do a timer-driven loop
-	hr = pAudioClient->Initialize(
-		AUDCLNT_SHAREMODE_SHARED,
-		AUDCLNT_STREAMFLAGS_LOOPBACK,
-		0, 0, pwfx, 0
-	);
-	if (FAILED(hr)) {
+	hr =
+		pAudioClient->Initialize(AUDCLNT_SHAREMODE_SHARED, AUDCLNT_STREAMFLAGS_LOOPBACK, 0, 0, pwfx, 0);
+	if (FAILED(hr))
+	{
 		ERR(L"pAudioClient->Initialize error");
 		return hr;
 	}
 
 	// activate an IAudioCaptureClient
 	IAudioCaptureClient *pAudioCaptureClient;
-	hr = pAudioClient->GetService(
-		__uuidof(IAudioCaptureClient),
-		(void**)&pAudioCaptureClient
-	);
-	if (FAILED(hr)) {
+	hr = pAudioClient->GetService(__uuidof(IAudioCaptureClient), (void **)&pAudioCaptureClient);
+	if (FAILED(hr))
+	{
 		ERR(L"pAudioClient->GetService error");
 		return hr;
 	}
 
 	// call IAudioClient::Start
 	hr = pAudioClient->Start();
-	if (FAILED(hr)) {
+	if (FAILED(hr))
+	{
 		ERR(L"pAudioClient->Start error");
 		return hr;
 	}
 
 	bool bDone = false;
 	bool bFirstPacket = true;
-    UINT32 nPasses = 0;
+	UINT32 nPasses = 0;
 
 #endif /** WASAPI_LOOPBACK */
 
 #if UNLOCK_FPS
-    setenv("vblank_mode", "0", 1);
+	setenv("vblank_mode", "0", 1);
 #endif
-    SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO);
+	SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO);
 
-    if (! SDL_VERSION_ATLEAST(2, 0, 5)) {
-        SDL_Log("SDL version 2.0.5 or greater is required. You have %i.%i.%i", SDL_MAJOR_VERSION, SDL_MINOR_VERSION, SDL_PATCHLEVEL);
-        return 1;
-    }
+	if (!SDL_VERSION_ATLEAST(2, 0, 5))
+	{
+		SDL_Log("SDL version 2.0.5 or greater is required. You have %i.%i.%i", SDL_MAJOR_VERSION,
+			SDL_MINOR_VERSION, SDL_PATCHLEVEL);
+		return 1;
+	}
 
-    // default window size to usable bounds (e.g. minus menubar and dock)
-    SDL_Rect initialWindowBounds;
+	// default window size to usable bounds (e.g. minus menubar and dock)
+	SDL_Rect initialWindowBounds;
 #if SDL_VERSION_ATLEAST(2, 0, 5)
-    // new and better
-    SDL_GetDisplayUsableBounds(0, &initialWindowBounds);
+	// new and better
+	SDL_GetDisplayUsableBounds(0, &initialWindowBounds);
 #else
-    SDL_GetDisplayBounds(0, &initialWindowBounds);
+	SDL_GetDisplayBounds(0, &initialWindowBounds);
 #endif
-    int width = initialWindowBounds.w;
-    int height = initialWindowBounds.h;
+	int width = initialWindowBounds.w;
+	int height = initialWindowBounds.h;
 
 #ifdef USE_GLES
-    // use GLES 2.0 (this may need adjusting)
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+	// use GLES 2.0 (this may need adjusting)
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
 
 #else
 	// Disabling compatibility profile
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
 
 #endif
 
-    
-    SDL_Window *win = SDL_CreateWindow("projectM", 0, 0, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
-    
-    SDL_GL_GetDrawableSize(win,&width,&height);
-    
+	SDL_Window *win = SDL_CreateWindow("projectM", 0, 0, width, height,
+		SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
+
+	SDL_GL_GetDrawableSize(win, &width, &height);
+
 #if STEREOSCOPIC_SBS
 
 	// enable stereo
-	if (SDL_GL_SetAttribute(SDL_GL_STEREO, 1) == 0) 
+	if (SDL_GL_SetAttribute(SDL_GL_STEREO, 1) == 0)
 	{
 		SDL_Log("SDL_GL_STEREO: true");
 	}
@@ -295,151 +328,142 @@ srand((int)(time(NULL)));
 
 #endif
 
-
 	SDL_GLContext glCtx = SDL_GL_CreateContext(win);
 
+	SDL_Log("GL_VERSION: %s", glGetString(GL_VERSION));
+	SDL_Log("GL_SHADING_LANGUAGE_VERSION: %s", glGetString(GL_SHADING_LANGUAGE_VERSION));
+	SDL_Log("GL_VENDOR: %s", glGetString(GL_VENDOR));
 
-    SDL_Log("GL_VERSION: %s", glGetString(GL_VERSION));
-    SDL_Log("GL_SHADING_LANGUAGE_VERSION: %s", glGetString(GL_SHADING_LANGUAGE_VERSION));
-    SDL_Log("GL_VENDOR: %s", glGetString(GL_VENDOR));
+	SDL_SetWindowTitle(win, "projectM Visualizer");
 
-    SDL_SetWindowTitle(win, "projectM Visualizer");
-    
-    SDL_GL_MakeCurrent(win, glCtx);  // associate GL context with main window
-    int avsync = SDL_GL_SetSwapInterval(-1); // try to enable adaptive vsync
-    if (avsync == -1) { // adaptive vsync not supported
-        SDL_GL_SetSwapInterval(1); // enable updates synchronized with vertical retrace
-    }
+	SDL_GL_MakeCurrent(win, glCtx);					 // associate GL context with main window
+	int avsync = SDL_GL_SetSwapInterval(-1); // try to enable adaptive vsync
+	if (avsync == -1)
+	{														 // adaptive vsync not supported
+		SDL_GL_SetSwapInterval(1); // enable updates synchronized with vertical retrace
+	}
 
-    
-    projectMSDL *app;
-    
-    std::string base_path = DATADIR_PATH;
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Using data directory: %s\n", base_path.c_str());
+	projectMSDL *app;
 
-    // load configuration file
-    std::string configFilePath = getConfigFilePath(base_path);
+	std::string base_path = DATADIR_PATH;
+	SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Using data directory: %s\n", base_path.c_str());
 
-    if (! configFilePath.empty()) {
-        // found config file, use it
-        app = new projectMSDL(configFilePath, 0);
-        SDL_Log("Using config from %s", configFilePath.c_str());
-    } else {
-        base_path = SDL_GetBasePath();
-        SDL_Log("Config file not found, using built-in settings. Data directory=%s\n", base_path.c_str());
+	// load configuration file
+	std::string configFilePath = getConfigFilePath(base_path);
 
-		// Get max refresh rate from attached displays to use as built-in max FPS.
-		int i = 0;
-		int maxRefreshRate = 0;
-		SDL_DisplayMode current;
-		for (i = 0; i < SDL_GetNumVideoDisplays(); ++i)
+	// prepare default settings
+	// Get max refresh rate from attached displays to use as built-in max FPS.
+	int i = 0;
+	int maxRefreshRate = 0;
+	SDL_DisplayMode current;
+	for (i = 0; i < SDL_GetNumVideoDisplays(); ++i)
+	{
+		if (SDL_GetCurrentDisplayMode(i, &current) == 0)
 		{
-			if (SDL_GetCurrentDisplayMode(i, &current) == 0)
-			{
-				if (current.refresh_rate > maxRefreshRate) maxRefreshRate = current.refresh_rate;
-			}
+			if (current.refresh_rate > maxRefreshRate) maxRefreshRate = current.refresh_rate;
 		}
-		if (maxRefreshRate <= 60) maxRefreshRate = 60;
+	}
+	if (maxRefreshRate <= 60) maxRefreshRate = 60;
 
-        float heightWidthRatio = (float)height / (float)width;
-        projectM::Settings settings;
-        settings.windowWidth = width;
-        settings.windowHeight = height;
-        settings.meshX = 128;
-        settings.meshY = settings.meshX * heightWidthRatio;
-		settings.fps = maxRefreshRate;
-        settings.smoothPresetDuration = 3; // seconds
-        settings.presetDuration = 22; // seconds
-        settings.beatSensitivity = 0.8;
-        settings.aspectCorrection = 1;
-        settings.shuffleEnabled = 1;
-        settings.softCutRatingsEnabled = 1; // ???
-        // get path to our app, use CWD or resource dir for presets/fonts/etc
-        settings.presetURL = base_path + "presets";
-//        settings.presetURL = base_path + "presets/presets_shader_test";
-        settings.menuFontURL = base_path + "fonts/Vera.ttf";
-        settings.titleFontURL = base_path + "fonts/Vera.ttf";
-        // init with settings
-        app = new projectMSDL(settings, 0);
-    }
-    app->init(win, &glCtx);
+	float heightWidthRatio = (float)height / (float)width;
+	projectM::Settings settings;
+	settings.windowWidth = width;
+	settings.windowHeight = height;
+	settings.meshX = 128;
+	settings.meshY = settings.meshX * heightWidthRatio;
+	settings.fps = maxRefreshRate;
+	settings.smoothPresetDuration = 3; // seconds
+	settings.presetDuration = 22;			 // seconds
+	settings.beatSensitivity = 0.8;
+	settings.aspectCorrection = 1;
+	settings.shuffleEnabled = 1;
+	settings.softCutRatingsEnabled = 1; // ???
+	// get path to our app, use CWD or resource dir for presets/fonts/etc
+	settings.presetURL = base_path + "presets";
+	//        settings.presetURL = base_path + "presets/presets_shader_test";
+	settings.menuFontURL = base_path + "fonts/Vera.ttf";
+	settings.titleFontURL = base_path + "fonts/Vera.ttf";
+
+	projectM::ConfigPreset configPreset;
+	configPreset.config_file = configFilePath;
+	configPreset.settings = settings;
+	
+	app = new projectMSDL(configPreset, 0);
+	app->init(win, &glCtx);
 
 #if STEREOSCOPIC_SBS
 	app->toggleFullScreen();
 #endif
 
 #if OGL_DEBUG && !USE_GLES
-    glEnable(GL_DEBUG_OUTPUT);
-    glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
-    glDebugMessageCallback(DebugLog, NULL);
+	glEnable(GL_DEBUG_OUTPUT);
+	glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
+	glDebugMessageCallback(DebugLog, NULL);
 #endif
 
 #if !FAKE_AUDIO && !WASAPI_LOOPBACK
-    // get an audio input device
-    if (app->openAudioInput())
-	    app->beginAudioCapture();
+	// get an audio input device
+	if (app->openAudioInput()) app->beginAudioCapture();
 #endif
 
 #if TEST_ALL_PRESETS
-    uint buildErrors = 0;
-    for(unsigned int i = 0; i < app->getPlaylistSize(); i++) {
-        std::cout << i << "\t" << app->getPresetName(i) << std::endl;
-        app->selectPreset(i);
-        if (app->getErrorLoadingCurrentPreset()) {
-            buildErrors++;
-        }
-    }
+	uint buildErrors = 0;
+	for (unsigned int i = 0; i < app->getPlaylistSize(); i++)
+	{
+		std::cout << i << "\t" << app->getPresetName(i) << std::endl;
+		app->selectPreset(i);
+		if (app->getErrorLoadingCurrentPreset())
+		{
+			buildErrors++;
+		}
+	}
 
-    if (app->getPlaylistSize()) {
-        fprintf(stdout, "Preset loading errors: %d/%d [%d%%]\n", buildErrors, app->getPlaylistSize(), (buildErrors*100) / app->getPlaylistSize());
-    }
+	if (app->getPlaylistSize())
+	{
+		fprintf(stdout, "Preset loading errors: %d/%d [%d%%]\n", buildErrors, app->getPlaylistSize(),
+			(buildErrors * 100) / app->getPlaylistSize());
+	}
 
-    delete app;
+	delete app;
 
-    return PROJECTM_SUCCESS;
+	return PROJECTM_SUCCESS;
 #endif
 
 #if UNLOCK_FPS
-    int32_t frame_count = 0;
-    struct timespec now;
-    clock_gettime(CLOCK_MONOTONIC_RAW, &now);
-    int64_t start = ( ((int64_t)now.tv_sec * 1000L) + (now.tv_nsec / 1000000L) );
+	int32_t frame_count = 0;
+	struct timespec now;
+	clock_gettime(CLOCK_MONOTONIC_RAW, &now);
+	int64_t start = (((int64_t)now.tv_sec * 1000L) + (now.tv_nsec / 1000000L));
 #endif
 
-    // standard main loop
-    int fps = app->settings().fps;
-    printf("fps: %d\n", fps);
-    if (fps <= 0)
-        fps = 60;
-    const Uint32 frame_delay = 1000/fps;
-    Uint32 last_time = SDL_GetTicks();
-    while (! app->done) {
-        app->renderFrame();
+	// standard main loop
+	int fps = app->settings().fps;
+	printf("fps: %d\n", fps);
+	if (fps <= 0) fps = 60;
+	const Uint32 frame_delay = 1000 / fps;
+	Uint32 last_time = SDL_GetTicks();
+	while (!app->done)
+	{
+		app->renderFrame();
 #if FAKE_AUDIO
-        app->addFakePCM();
+		app->addFakePCM();
 #endif
 #ifdef WASAPI_LOOPBACK
-        // drain data while it is available
-        nPasses++;
+		// drain data while it is available
+		nPasses++;
 		UINT32 nNextPacketSize;
-		for (
-			hr = pAudioCaptureClient->GetNextPacketSize(&nNextPacketSize);
-			SUCCEEDED(hr) && nNextPacketSize > 0;
-			hr = pAudioCaptureClient->GetNextPacketSize(&nNextPacketSize)
-			) {
+		for (hr = pAudioCaptureClient->GetNextPacketSize(&nNextPacketSize);
+				 SUCCEEDED(hr) && nNextPacketSize > 0;
+				 hr = pAudioCaptureClient->GetNextPacketSize(&nNextPacketSize))
+		{
 			// get the captured data
 			BYTE *pData;
 			UINT32 nNumFramesToRead;
 			DWORD dwFlags;
 
-			hr = pAudioCaptureClient->GetBuffer(
-				&pData,
-				&nNumFramesToRead,
-				&dwFlags,
-				NULL,
-				NULL
-			);
-			if (FAILED(hr)) {
+			hr = pAudioCaptureClient->GetBuffer(&pData, &nNumFramesToRead, &dwFlags, NULL, NULL);
+			if (FAILED(hr))
+			{
 				return hr;
 			}
 
@@ -451,44 +475,44 @@ srand((int)(time(NULL)));
 			*pnFrames += nNumFramesToRead;
 
 			hr = pAudioCaptureClient->ReleaseBuffer(nNumFramesToRead);
-			if (FAILED(hr)) {
+			if (FAILED(hr))
+			{
 				return hr;
 			}
 
 			bFirstPacket = false;
 		}
 
-		if (FAILED(hr)) {
+		if (FAILED(hr))
+		{
 			return hr;
 		}
 
 #endif /** WASAPI_LOOPBACK */
 
 #if UNLOCK_FPS
-        frame_count++;
-        clock_gettime(CLOCK_MONOTONIC_RAW, &now);
-        if (( ((int64_t)now.tv_sec * 1000L) + (now.tv_nsec / 1000000L) ) - start > 5000) {
-            SDL_GL_DeleteContext(glCtx);
-            delete(app);
-            fprintf(stdout, "Frames[%d]\n", frame_count);
-            exit(0);
-        }
+		frame_count++;
+		clock_gettime(CLOCK_MONOTONIC_RAW, &now);
+		if ((((int64_t)now.tv_sec * 1000L) + (now.tv_nsec / 1000000L)) - start > 5000)
+		{
+			SDL_GL_DeleteContext(glCtx);
+			delete (app);
+			fprintf(stdout, "Frames[%d]\n", frame_count);
+			exit(0);
+		}
 #else
-        app->pollEvent();
-        Uint32 elapsed = SDL_GetTicks() - last_time;
-        if (elapsed < frame_delay)
-            SDL_Delay(frame_delay - elapsed);
-        last_time = SDL_GetTicks();
+		app->pollEvent();
+		Uint32 elapsed = SDL_GetTicks() - last_time;
+		if (elapsed < frame_delay) SDL_Delay(frame_delay - elapsed);
+		last_time = SDL_GetTicks();
 #endif
-    }
-    
-    SDL_GL_DeleteContext(glCtx);
+	}
+
+	SDL_GL_DeleteContext(glCtx);
 #if !FAKE_AUDIO && !WASAPI_LOOPBACK
-    app->endAudioCapture();
+	app->endAudioCapture();
 #endif
-    delete app;
+	delete app;
 
-    return PROJECTM_SUCCESS;
+	return PROJECTM_SUCCESS;
 }
-
-


### PR DESCRIPTION
**SDL Fix 1 of 2:**
_Problem:_
SDL only looks at /usr/local/share/projectM/ for config.inp.
If this fails it falls back on the built-in config, which users can't easily edit.

_Solution:_
SDL will now:
1. Look in /usr/local/share/projectM/
2. Look in %APPDATA%\projectM\ on Windows and ~/.projectM/ on other OS's.
3. Look in the current working directory.
If all of the above fails it falls back on the built-in config.

**libProjectM Fix**
_Problem:_
Once I got SDL easily loading a config file, I realized:
- Some configs are best set by SDL because it has awareness of your monitor settings.
- A user might only want to tweak 1 setting. By doing this, libProjectM will fall back on it's internal defaults which are really bad.

_Solution:_
libProjectM can be initialized two ways:
1. With a config file
2. With predefined settings.

The solution / fix in this commit is to give libProjectM a third option to initialize with:
3. With a config file AND predefined settings. 

With this new way to load libProjectM you can provide it with dynamic settings like height/width but let users modify only something like FPS or meshX/meshY.

This should not break libProjectM for any projects as the first two options are still in-tact.

**SDL Fix 2 of 2:**
SDL now supplies both a config file and built-in settings. If no config file was found during the load libProjectM will ignore the empty config file and just use the built-in settings.