### PR TITLE
Sdl config

### DIFF
--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -140,8 +140,7 @@ projectM::projectM(ConfigPreset configPreset, int flags)
 			_matcher(NULL),
 			_merger(NULL)
 {
-	struct stat sb;
-	if (!configPreset.config_file.empty() && stat(configPreset.config_file.c_str(), &sb) == 0)
+	if (!configPreset.config_file.empty())
 	{
 		readConfig(configPreset.config_file, configPreset.settings);
 	}
@@ -271,7 +270,7 @@ void projectM::readConfig (const std::string & configFile )
     settings.easterEgg = 0.0;
     settings.softCutRatingsEnabled = 0;
 
-    settings.beatSensitivity = beatDetect->beat_sensitivity = 10.0;
+    settings.beatSensitivity = 10.0;
 
     settings.aspectCorrection = 1;
     

--- a/src/libprojectM/projectM.hpp
+++ b/src/libprojectM/projectM.hpp
@@ -156,8 +156,15 @@ public:
             softCutRatingsEnabled(false) {}
     };
 
+    struct ConfigPreset
+	{
+		std::string config_file;
+		Settings settings;
+	};
+
   projectM(std::string config_file, int flags = FLAG_NONE);
   projectM(Settings settings, int flags = FLAG_NONE);
+  projectM(ConfigPreset configPreset, int flags = FLAG_NONE);
 
   void projectM_resetGL( int width, int height );
   void projectM_resetTextures();

--- a/src/libprojectM/projectM.hpp
+++ b/src/libprojectM/projectM.hpp
@@ -317,6 +317,7 @@ private:
   float fpsstart;
 
   void readConfig(const std::string &configFile);
+  void readConfig(const std::string &configFile, const Settings &settings);
   void readSettings(const Settings &settings);
   void projectM_init(int gx, int gy, int fps, int texsize, int width, int height);
   void projectM_reset();

--- a/src/projectM-sdl/pmSDL.cpp
+++ b/src/projectM-sdl/pmSDL.cpp
@@ -453,6 +453,14 @@ projectMSDL::projectMSDL(std::string config_file, int flags) : projectM(config_f
     isFullScreen = false;
 }
 
+projectMSDL::projectMSDL(ConfigPreset configPreset, int flags) : projectM(configPreset, flags)
+{
+	width = getWindowWidth();
+	height = getWindowHeight();
+	done = 0;
+	isFullScreen = false;
+}
+
 void projectMSDL::init(SDL_Window *window, SDL_GLContext *_glCtx, const bool _renderToTexture) {
     win = window;
     glCtx = _glCtx;

--- a/src/projectM-sdl/pmSDL.hpp
+++ b/src/projectM-sdl/pmSDL.hpp
@@ -90,6 +90,7 @@ public:
     bool done;
     projectMSDL(Settings settings, int flags);
     projectMSDL(std::string config_file, int flags);
+    projectMSDL(ConfigPreset configPreset, int flags);
     void init(SDL_Window *window, SDL_GLContext *glCtx, const bool renderToTexture = false);
     int openAudioInput();
     int toggleAudioInput();

--- a/src/projectM-sdl/pmSDL.hpp
+++ b/src/projectM-sdl/pmSDL.hpp
@@ -76,7 +76,7 @@
         #define DATADIR_PATH "."
         #warning "DATADIR_PATH is not defined - falling back to ./"
     #else
-        #define DATADIR_PATH "/usr/local/share/projectM"
+        #define DATADIR_PATH "/usr/local/share/projectM/"
 #ifndef WIN32
         #warning "DATADIR_PATH is not defined - falling back to /usr/local/share/projectM"
 #endif /** WIN32 */

--- a/src/projectM-sdl/projectM_SDL_main.cpp
+++ b/src/projectM-sdl/projectM_SDL_main.cpp
@@ -385,7 +385,12 @@ srand((int)(time(NULL)));
         
 	// init with settings & config (if config was found)
 	projectM::ConfigPreset configPreset;
-	configPreset.config_file = configFilePath + "config.inp";
+	if (!configFilePath.empty()) {
+		configPreset.config_file = configFilePath + "config.inp";
+	}
+	else {
+		configPreset.config_file = "";
+	}
 	configPreset.settings = settings;
 	
     app = new projectMSDL(configPreset, 0);

--- a/src/projectM-sdl/projectM_SDL_main.cpp
+++ b/src/projectM-sdl/projectM_SDL_main.cpp
@@ -343,7 +343,7 @@ srand((int)(time(NULL)));
     
     std::string base_path = DATADIR_PATH;
 
-    // load configuration file folder (t might be different than DATADIR_PATH)
+    // load configuration file folder (it might be different than DATADIR_PATH)
     std::string configFilePath = getConfigFilePath(base_path);
 
     if (configFilePath.empty()) base_path = SDL_GetBasePath(); // if no configfile was found, use SDL base path.


### PR DESCRIPTION


**SDL Fix 1 of 2:**
_Problem:_
SDL only looks at /usr/local/share/projectM/ for config.inp.
If this fails it falls back on the built-in config, which users can't easily edit.

_Solution:_
SDL will now:
1. Look in /usr/local/share/projectM/
2. Look in %APPDATA%\projectM\ on Windows and ~/.projectM/ on other OS's.
3. Look in the current working directory.
If all of the above fails it falls back on the built-in config.

**libProjectM Fix**
_Problem:_
Once I got SDL easily loading a config file, I realized:
- Some configs are best set by SDL because it has awareness of your monitor settings.
- A user might only want to tweak 1 setting. By doing this, libProjectM will fall back on it's internal defaults which are really bad.

_Solution:_
libProjectM can be initialized two ways:
1. With a config file
2. With predefined settings.

The solution / fix in this commit is to give libProjectM a third option to initialize with:
3. With a config file AND predefined settings. 

With this new way to load libProjectM you can provide it with dynamic settings like height/width but let users modify only something like FPS or meshX/meshY.

This should not break libProjectM for any projects as the first two options are still in-tact.

**SDL Fix 2 of 2:**
SDL now supplies both a config file and built-in settings. If no config file was found during the load libProjectM will ignore the empty config file and just use the built-in settings.