### PR TITLE
Display status

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ See [BUILDING.md](BUILDING.md)
 * Shift-P: previous preset with hard cut
 * L: lock current preset
 
-
-* F3: show preset (if supported)
-* F5: show FPS (if supported)
 * H or F1: show help (if supported)
+* F3: show preset (if supported)
+* F4: show stats (if supported)
+* F5: show FPS (if supported)
 
 #### Only ProjectM SDL:
 * Cmd/Ctrl-Q: *q*uit

--- a/src/libprojectM/KeyHandler.cpp
+++ b/src/libprojectM/KeyHandler.cpp
@@ -122,11 +122,10 @@ void projectM::default_key_handler( projectMEvent event, projectMKeycode keycode
 	      break;
 		case PROJECTM_K_h:
  		  renderer->showhelp = !renderer->showhelp;
-	      renderer->showstats= false;
+	      renderer->showstats=false;
 	    case PROJECTM_K_F1:
 	      renderer->showhelp = !renderer->showhelp;
 	      renderer->showstats=false;
-	      renderer->showfps=false;
 	      break;
 	    case PROJECTM_K_y:
 		this->setShuffleEnabled(!this->isShuffleEnabled());
@@ -147,6 +146,7 @@ void projectM::default_key_handler( projectMEvent event, projectMKeycode keycode
 	    case PROJECTM_K_F4:
 		if (!renderer->showhelp)
 	       		renderer->showstats = !renderer->showstats;
+	       		renderer->showhelp=false;
 	      break;
 	    case PROJECTM_K_F3: {
 	      renderer->showpreset = !renderer->showpreset;

--- a/src/libprojectM/Renderer/Renderer.cpp
+++ b/src/libprojectM/Renderer/Renderer.cpp
@@ -587,20 +587,40 @@ void Renderer::draw_help()
 #endif /** USE_TEXT_MENU */
 }
 
+// fake rounding - substr is good enough.
+std::string Renderer::float_stats(float stat)
+{
+    std::string num_text = std::to_string(stat);
+    std::string rounded = num_text.substr(0, num_text.find(".")+4);
+	return rounded;
+}
+
 // TODO
 void Renderer::draw_stats()
 {
 #ifdef USE_TEXT_MENU
+	std::string stats = "\n";
+	std::string warpShader = (!currentPipe->warpShader.programSource.empty()) ? "ON" : "OFF";
+	std::string compShader = (!currentPipe->compositeShader.programSource.empty()) ? "ON" : "OFF";
 
-	//sprintf(buffer, "      viewport: +%d,%d %d x %d", vstartx, vstarty, vw, vh);
-	//sprintf(buffer, "          mesh: %d x %d", mesh.width, mesh.height);
-	//sprintf(buffer, "       texsize: %d", renderTarget->texsize);
-	//other_font->Render((renderTarget->useFBO ? "           FBO: on" : "           FBO: off"));
-	//sprintf(buffer, "      textures: %.1fkB", textureManager->getTextureMemorySize() / 1000.0f);
-	//sprintf(buffer, "shader profile: %s", shaderEngine.profileName.c_str());
-	//sprintf(buffer, "   warp shader: %s", currentPipe->warpShader.enabled ? "on" : "off");
-	//sprintf(buffer, "   comp shader: %s", currentPipe->compositeShader.enabled ? "on" : "off");
+	stats += "Render:""\n";
+	stats += "Resolution: " + std::to_string(vw) + "x" + std::to_string(vh) + "\n";
+	stats += "Mesh X: " + std::to_string(mesh.width) + "\n";
+	stats += "Mesh Y: " + std::to_string(mesh.height) + "\n";
 
+	stats += "\n";
+	stats += "Beat Detect:""\n";
+	stats += "Sensitivity: " + float_stats(beatDetect->beat_sensitivity) + "\n";
+	stats += "Bass: " + float_stats(beatDetect->bass) + "\n";
+	stats += "Mid Range: " + float_stats(beatDetect->mid) + "\n";
+	stats += "Treble: " + float_stats(beatDetect->treb) + "\n";
+	stats += "Volume: " + float_stats(beatDetect->vol) + "\n";
+
+	stats += "\n";
+	stats += "Preset:""\n";
+	stats += "Warp Shader: " + warpShader + "\n";
+	stats += "Composite Shader: " + compShader + "\n";
+	drawText(stats.c_str(), 30, 20, 2.5);
 #endif /** USE_TEXT_MENU */
 }
 

--- a/src/libprojectM/Renderer/Renderer.hpp
+++ b/src/libprojectM/Renderer/Renderer.hpp
@@ -179,8 +179,10 @@ private:
   void draw_title();
   void draw_title_to_screen(bool flip);
   void draw_title_to_texture();
-
-  int nearestPower2( int value );
+  
+  std::string float_stats(float stat);
+  
+int nearestPower2( int value );
 
   GLuint textureRenderToTexture;
 


### PR DESCRIPTION
Display stats (Keybind: F4). I grabbed some immediately useful stuff that was exposed to the renderer. I think it is useful to learn / see how beat sensitivity is working and will allow people to confirm the audio device is being "heard" by projectM.

See screenshot below.

![image](https://user-images.githubusercontent.com/59471060/80920581-d14cf280-8d81-11ea-8187-1cbb1f54e5b7.png)
