### PR TITLE
Beat sensitivity implemented (?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ You can also download an enormous 41,000 preset pack of presets [here](https://m
 See [BUILDING.md](BUILDING.md)
 
 # Keyboard Controls:
-* Up: increase beat sensitivity
-* Down: decrease beat sensitivity
+* Up: increase beat sensitivity (max 5)
+* Down: decrease beat sensitivity (min 0)
 * Y: toggle shuffle enabled
 * R: jump to random preset
 * N: next preset

--- a/src/libprojectM/KeyHandler.cpp
+++ b/src/libprojectM/KeyHandler.cpp
@@ -113,12 +113,12 @@ void projectM::default_key_handler( projectMEvent event, projectMKeycode keycode
 	  switch( keycode )
 	    {
 	    case PROJECTM_K_UP:
-            beatDetect->beat_sensitivity += 0.25;
-			if (beatDetect->beat_sensitivity > 5.0) beatDetect->beat_sensitivity = 5.0;
+            beatDetect->beatSensitivity += 0.25;
+			if (beatDetect->beatSensitivity > 5.0) beatDetect->beatSensitivity = 5.0;
 	      break;
 	    case PROJECTM_K_DOWN:
-            beatDetect->beat_sensitivity -= 0.25;
-			if (beatDetect->beat_sensitivity < 0) beatDetect->beat_sensitivity = 0;
+            beatDetect->beatSensitivity -= 0.25;
+			if (beatDetect->beatSensitivity < 0) beatDetect->beatSensitivity = 0;
 	      break;
 		case PROJECTM_K_h:
  		  renderer->showhelp = !renderer->showhelp;

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -67,7 +67,7 @@ BeatDetect::BeatDetect(PCM *_pcm)
     this->mid = 0;
     this->bass = 0;
     this->vol_old = 0;
-    this->beat_sensitivity = 0.80;
+    this->beat_sensitivity = 1.00;
     this->treb_att = 0;
     this->mid_att = 0;
     this->bass_att = 0;

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -115,7 +115,9 @@ float BeatDetect::getPCMScale()
     // the constant here just depends on the particulars of getBeatVals(), the
     // range of vol_history, and what "looks right".
     // larger value means larger, more jagged waveform.
-    return 1.5 / fmax(0.0001f,sqrtf(vol_history));
+
+    // this is also impacted by beat_sensitivity.
+    return (1.5 / fmax(0.0001f,sqrtf(vol_history)))*beat_sensitivity;
 }
 
 

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -67,7 +67,7 @@ BeatDetect::BeatDetect(PCM *_pcm)
     this->mid = 0;
     this->bass = 0;
     this->vol_old = 0;
-    this->beat_sensitivity = 10.00;
+    this->beat_sensitivity = 0.80;
     this->treb_att = 0;
     this->mid_att = 0;
     this->bass_att = 0;
@@ -185,6 +185,18 @@ void BeatDetect::getBeatVals( float samplerate, unsigned fft_length, float *vdat
     mid_att  = .6f * mid_att + .4f * mid;
     bass_att = .6f * bass_att + .4f * bass;
     vol_att =  .6f * vol_att + .4f * vol;
+
+    // Use beat sensitivity as a multiplier
+    // 0 is "dead"
+    // 5 is pretty wild so above that doesn't make sense
+    bass_att = bass_att * beat_sensitivity;
+    bass = bass * beat_sensitivity;
+    mid_att = mid_att * beat_sensitivity;
+    mid = mid * beat_sensitivity;
+    treb_att = treb_att * beat_sensitivity;
+    treb = treb * beat_sensitivity;
+    vol_att = vol_att * beat_sensitivity;
+    vol = vol * beat_sensitivity;
 
     if (bass_att>100) bass_att=100;
     if (bass >100) bass=100;

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -67,7 +67,7 @@ BeatDetect::BeatDetect(PCM *_pcm)
     this->mid = 0;
     this->bass = 0;
     this->vol_old = 0;
-    this->beat_sensitivity = 1.00;
+    this->beatSensitivity = 1.00;
     this->treb_att = 0;
     this->mid_att = 0;
     this->bass_att = 0;
@@ -116,8 +116,8 @@ float BeatDetect::getPCMScale()
     // range of vol_history, and what "looks right".
     // larger value means larger, more jagged waveform.
 
-    // this is also impacted by beat_sensitivity.
-    return (1.5 / fmax(0.0001f,sqrtf(vol_history)))*beat_sensitivity;
+    // this is also impacted by beatSensitivity.
+    return (1.5 / fmax(0.0001f,sqrtf(vol_history)))*beatSensitivity;
 }
 
 
@@ -191,14 +191,14 @@ void BeatDetect::getBeatVals( float samplerate, unsigned fft_length, float *vdat
     // Use beat sensitivity as a multiplier
     // 0 is "dead"
     // 5 is pretty wild so above that doesn't make sense
-    bass_att = bass_att * beat_sensitivity;
-    bass = bass * beat_sensitivity;
-    mid_att = mid_att * beat_sensitivity;
-    mid = mid * beat_sensitivity;
-    treb_att = treb_att * beat_sensitivity;
-    treb = treb * beat_sensitivity;
-    vol_att = vol_att * beat_sensitivity;
-    vol = vol * beat_sensitivity;
+    bass_att = bass_att * beatSensitivity;
+    bass = bass * beatSensitivity;
+    mid_att = mid_att * beatSensitivity;
+    mid = mid * beatSensitivity;
+    treb_att = treb_att * beatSensitivity;
+    treb = treb * beatSensitivity;
+    vol_att = vol_att * beatSensitivity;
+    vol = vol * beatSensitivity;
 
     if (bass_att>100) bass_att=100;
     if (bass >100) bass=100;

--- a/src/libprojectM/Renderer/BeatDetect.hpp
+++ b/src/libprojectM/Renderer/BeatDetect.hpp
@@ -48,7 +48,7 @@ class DLLEXPORT BeatDetect
 		float mid ;
 		float bass ;
 		float vol_old ;
-		float beat_sensitivity;
+		float beatSensitivity;
 		float treb_att ;
 		float mid_att ;
 		float bass_att ;

--- a/src/libprojectM/TimeKeeper.cpp
+++ b/src/libprojectM/TimeKeeper.cpp
@@ -7,10 +7,11 @@
 #include "TimeKeeper.hpp"
 #include "RandomNumberGenerators.hpp"
 
-TimeKeeper::TimeKeeper(double presetDuration, double smoothDuration, double easterEgg)
+TimeKeeper::TimeKeeper(double presetDuration, double smoothDuration, double hardcutDuration, double easterEgg)
   {
     _smoothDuration = smoothDuration;
     _presetDuration = presetDuration;
+    _hardcutDuration = hardcutDuration;
     _easterEgg = easterEgg;
 
 #ifndef WIN32
@@ -59,7 +60,7 @@ TimeKeeper::TimeKeeper(double presetDuration, double smoothDuration, double east
 
   bool TimeKeeper::CanHardCut()
   {
-    return ((_currentTime - _presetTimeA) > HARD_CUT_DELAY);
+    return ((_currentTime - _presetTimeA) > _hardcutDuration);
   }
 
   double TimeKeeper::SmoothRatio()

--- a/src/libprojectM/TimeKeeper.hpp
+++ b/src/libprojectM/TimeKeeper.hpp
@@ -14,7 +14,7 @@ class TimeKeeper
 
 public:
 
-  TimeKeeper(double presetDuration, double smoothDuration, double easterEgg);
+  TimeKeeper(double presetDuration, double smoothDuration, double hardcutDuration, double easterEgg);
 
   void UpdateTimers();
 
@@ -40,6 +40,7 @@ public:
 
   double sampledPresetDuration();
 
+  void ChangeHardcutDuration(int seconds) { _hardcutDuration = seconds; }
   void ChangePresetDuration(int seconds) { _presetDuration = seconds; }
 
 #ifndef WIN32
@@ -56,6 +57,7 @@ private:
   double _presetDurationA;
   double _presetDurationB;
   double _smoothDuration;
+  double _hardcutDuration;
 
   double _currentTime;
   double _presetTimeA;

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -589,6 +589,7 @@ void projectM::projectM_resetengine()
     {
         beatDetect->reset();
     }
+    beatDetect->beat_sensitivity = _settings.beatSensitivity;
 
 }
 

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -215,12 +215,21 @@ void projectM::readConfig (const std::string & configFile )
     _settings.softCutRatingsEnabled =
             config.read<bool> ( "Soft Cut Ratings Enabled", false);
 
+    // Hard Cuts are preset transitions that occur when your music becomes louder. They only occur after a hard cut duration threshold has passed.
+    _settings.hardcutEnabled = config.read<bool> ( "Hard Cuts Enabled", false );
+    // Hard Cut duration is the number of seconds before you become eligible for a hard cut.
+    _settings.hardcutDuration = config.read<int> ( "Hard Cut Duration", 60 );
+    // Hard Cut sensitivity is the volume difference before a "hard cut" is triggered.
+    _settings.hardcutSensitivity = config.read<float> ( "Hard Cut Sensitivity", 1.0 );
+    
+    // Beat Sensitivity impacts how reactive your visualizations are to volume, bass, mid-range, and treble. 
+    // Preset authors have developed their visualizations with the default of 1.0.
+    _settings.beatSensitivity = beatDetect->beatSensitivity = config.read<float> ( "Beat Sensitivity", 1.0 );
+
+
     projectM_init ( _settings.meshX, _settings.meshY, _settings.fps,
-                    _settings.textureSize, _settings.windowWidth,_settings.windowHeight);
-
-    _settings.beatSensitivity = beatDetect->beat_sensitivity = config.read<float> ( "Hard Cut Sensitivity", 1.0 );
-
-
+                _settings.textureSize, _settings.windowWidth,_settings.windowHeight);
+    
     if ( config.read ( "Aspect Correction", true ) )
     {
         _settings.aspectCorrection = true;
@@ -256,13 +265,17 @@ void projectM::readSettings (const Settings & settings )
 
     _settings.easterEgg = settings.easterEgg;
 
+    _settings.hardcutEnabled = settings.hardcutEnabled;
+    _settings.hardcutDuration = settings.hardcutDuration;
+    _settings.hardcutSensitivity = settings.hardcutSensitivity;
+    
+    _settings.beatSensitivity = settings.beatSensitivity;
+    
     projectM_init ( _settings.meshX, _settings.meshY, _settings.fps,
                     _settings.textureSize, _settings.windowWidth,_settings.windowHeight);
+    
 
-
-    _settings.beatSensitivity = settings.beatSensitivity;
     _settings.aspectCorrection = settings.aspectCorrection;
-
 }
 
 #ifdef USE_THREADS
@@ -362,12 +375,9 @@ Pipeline * projectM::renderFrameOnlyPass1(Pipeline *pPipeline) /*pPipeline is a 
                 selectRandom(false);
             else
                 selectNext(false);
-        }
-
-        else if ((beatDetect->vol-beatDetect->vol_old>beatDetect->beat_sensitivity ) &&
-                 timeKeeper->CanHardCut())
+        } else if (settings().hardcutEnabled && (beatDetect->vol-beatDetect->vol_old>settings().hardcutSensitivity) && timeKeeper->CanHardCut())
         {
-            // printf("Hard Cut\n");
+            // Hard Cuts must be enabled, must have passed the hardcut duration, and the volume must be a greater difference than the hardcut sensitivity.
             if (settings().shuffleEnabled)
                 selectRandom(true);
             else
@@ -534,7 +544,7 @@ void projectM::projectM_reset()
 void projectM::projectM_init ( int gx, int gy, int fps, int texsize, int width, int height )
 {
     /** Initialise start time */
-    timeKeeper = new TimeKeeper(_settings.presetDuration,_settings.smoothPresetDuration, _settings.easterEgg);
+    timeKeeper = new TimeKeeper(_settings.presetDuration,_settings.smoothPresetDuration, _settings.hardcutDuration, _settings.easterEgg);
 
     /** Nullify frame stash */
 
@@ -588,7 +598,7 @@ void projectM::projectM_resetengine()
     if ( beatDetect != NULL )
     {
         beatDetect->reset();
-        beatDetect->beat_sensitivity = _settings.beatSensitivity;
+        beatDetect->beatSensitivity = _settings.beatSensitivity;
     }
 
 }
@@ -973,7 +983,9 @@ void projectM::changeTextureSize(int size) {
                             _settings.titleFontURL, _settings.menuFontURL,
                             _settings.datadir);
 }
-
+void projectM::changeHardcutDuration(int seconds) {
+    timeKeeper->ChangeHardcutDuration(seconds);
+}
 void projectM::changePresetDuration(int seconds) {
     timeKeeper->ChangePresetDuration(seconds);
 }

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -218,7 +218,7 @@ void projectM::readConfig (const std::string & configFile )
     projectM_init ( _settings.meshX, _settings.meshY, _settings.fps,
                     _settings.textureSize, _settings.windowWidth,_settings.windowHeight);
 
-    _settings.beatSensitivity = beatDetect->beat_sensitivity = config.read<float> ( "Hard Cut Sensitivity", 0.8 );
+    _settings.beatSensitivity = beatDetect->beat_sensitivity = config.read<float> ( "Hard Cut Sensitivity", 1.0 );
 
 
     if ( config.read ( "Aspect Correction", true ) )

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -218,7 +218,7 @@ void projectM::readConfig (const std::string & configFile )
     projectM_init ( _settings.meshX, _settings.meshY, _settings.fps,
                     _settings.textureSize, _settings.windowWidth,_settings.windowHeight);
 
-    _settings.beatSensitivity = beatDetect->beat_sensitivity = config.read<float> ( "Hard Cut Sensitivity", 10.0 );
+    _settings.beatSensitivity = beatDetect->beat_sensitivity = config.read<float> ( "Hard Cut Sensitivity", 0.8 );
 
 
     if ( config.read ( "Aspect Correction", true ) )

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -588,8 +588,8 @@ void projectM::projectM_resetengine()
     if ( beatDetect != NULL )
     {
         beatDetect->reset();
+        beatDetect->beat_sensitivity = _settings.beatSensitivity;
     }
-    beatDetect->beat_sensitivity = _settings.beatSensitivity;
 
 }
 

--- a/src/libprojectM/projectM.hpp
+++ b/src/libprojectM/projectM.hpp
@@ -134,6 +134,9 @@ public:
         std::string datadir;
         int smoothPresetDuration;
         int presetDuration;
+        bool hardcutEnabled;
+        int hardcutDuration;
+        float hardcutSensitivity;
         float beatSensitivity;
         bool aspectCorrection;
         float easterEgg;
@@ -149,7 +152,10 @@ public:
             windowHeight(512),
             smoothPresetDuration(10),
             presetDuration(15),
-            beatSensitivity(10.0),
+            hardcutEnabled(false),
+            hardcutDuration(60),
+            hardcutSensitivity(2.0),
+            beatSensitivity(1.0),
             aspectCorrection(true),
             easterEgg(0.0),
             shuffleEnabled(true),
@@ -173,6 +179,7 @@ public:
   virtual ~projectM();
 
   void changeTextureSize(int size);
+  void changeHardcutDuration(int seconds);
   void changePresetDuration(int seconds);
   void getMeshSize(int *w, int *h);
 

--- a/src/projectM-sdl/config.inp
+++ b/src/projectM-sdl/config.inp
@@ -17,6 +17,8 @@ Hard Cuts Enabled = false  # Hard Cuts are preset transitions that occur when yo
 Hard Cut Duration = 60     # Number of seconds before you become eligible for a hard cut.
 Hard Cut Sensitivity = 1.0 # Volume sensitivity before a hard cut is triggered.
 
+Beat Sensitivity = 1.0 # Beat Sensitivity impacts how reactive your visualizations are to volume, bass, mid-range, and treble. Range: 0 - 5 (from "dead" to VERY reactive)
+
 Easter Egg Parameter = 1
 
 Aspect Correction = true	# Custom Shape Aspect Correction

--- a/src/projectM-sdl/config.inp
+++ b/src/projectM-sdl/config.inp
@@ -17,7 +17,7 @@ Hard Cuts Enabled = false  # Hard Cuts are preset transitions that occur when yo
 Hard Cut Duration = 60     # Number of seconds before you become eligible for a hard cut.
 Hard Cut Sensitivity = 1.0 # Volume sensitivity before a hard cut is triggered.
 
-Beat Sensitivity = 1.0 # Beat Sensitivity impacts how reactive your visualizations are to volume, bass, mid-range, and treble. Range: 0 - 5 (from "dead" to VERY reactive)
+Beat Sensitivity = 1.0 # Beat Sensitivity impacts how reactive your visualizations are to volume, bass, mid-range, and treble. Default 1.0. Range: 0 - 5 (from "dead" to VERY reactive).
 
 Easter Egg Parameter = 1
 

--- a/src/projectM-sdl/config.inp
+++ b/src/projectM-sdl/config.inp
@@ -12,9 +12,13 @@ Window Height = 512            	# startup window height
 
 Smooth Transition Duration = 1  # in seconds
 Preset Duration = 10 	     	# in seconds
+
+Hard Cuts Enabled = false  # Hard Cuts are preset transitions that occur when your music becomes louder. They only occur after a hard cut duration threshold has passed. 
+Hard Cut Duration = 60     # Number of seconds before you become eligible for a hard cut.
+Hard Cut Sensitivity = 1.0 # Volume sensitivity before a hard cut is triggered.
+
 Easter Egg Parameter = 1
 
-Hard Cut Sensitivity = 10       # Lower to make hard cuts more frequent
 Aspect Correction = true	# Custom Shape Aspect Correction
 
 Preset Path = presets # preset location

--- a/src/projectM-sdl/projectM_SDL_main.cpp
+++ b/src/projectM-sdl/projectM_SDL_main.cpp
@@ -350,7 +350,7 @@ srand((int)(time(NULL)));
 		settings.fps = maxRefreshRate;
         settings.smoothPresetDuration = 3; // seconds
         settings.presetDuration = 22; // seconds
-        settings.beatSensitivity = 0.8;
+        settings.beatSensitivity = 1.0;
         settings.aspectCorrection = 1;
         settings.shuffleEnabled = 1;
         settings.softCutRatingsEnabled = 1; // ???

--- a/src/projectM-sdl/projectM_SDL_main.cpp
+++ b/src/projectM-sdl/projectM_SDL_main.cpp
@@ -352,7 +352,7 @@ srand((int)(time(NULL)));
         settings.presetDuration = 22; // seconds
 		settings.hardcutEnabled = true;
 		settings.hardcutDuration = 60;
-		settings.hardcutSensitivity = 2.0;
+		settings.hardcutSensitivity = 1.0;
         settings.beatSensitivity = 1.0;
         settings.aspectCorrection = 1;
         settings.shuffleEnabled = 1;

--- a/src/projectM-sdl/projectM_SDL_main.cpp
+++ b/src/projectM-sdl/projectM_SDL_main.cpp
@@ -350,6 +350,9 @@ srand((int)(time(NULL)));
 		settings.fps = maxRefreshRate;
         settings.smoothPresetDuration = 3; // seconds
         settings.presetDuration = 22; // seconds
+		settings.hardcutEnabled = true;
+		settings.hardcutDuration = 60;
+		settings.hardcutSensitivity = 2.0;
         settings.beatSensitivity = 1.0;
         settings.aspectCorrection = 1;
         settings.shuffleEnabled = 1;


### PR DESCRIPTION
By showing the current beat sensitivity with the new stats key (F4), I noticed that it had no effect if I used the Up and Down arrow to adjust it.

I looked into the BeatDetect source and saw it tracks this value but does nothing with it. I also noticed the beat sensitivity defaults are very inconsistent with hard coded settings have it at 10.0, SDL defaulting to 0.8, and KeyHandler.cpp putting a limit of 5 with Up and Down arrow keys, 

I came up a simple idea: make beat sensitivity a multiplier for the key areas in beat detect like bass, mid range, and treble.

By doing this I immediately noticed how amazing beat sensitivity is! My PR adjusts the following:

- Default is now 1.0.
- Anything below 1.0 will decrease sensitivity of beat detect.
- A sensitivity of 0 will make it seem like there is no beat / audio (what I expected originally).
- Anything from 1.0 to 5.0 increases the beat detect (as originally intended).
- 5.0 looks wild (seizure warning)! 

Note: a fun visualization to test is Flexi - infused with the spiral.milk
