### PR TITLE
Implement toast messages

### DIFF
--- a/src/libprojectM/KeyHandler.cpp
+++ b/src/libprojectM/KeyHandler.cpp
@@ -202,12 +202,7 @@ void projectM::default_key_handler( projectMEvent event, projectMKeycode keycode
 	      selectPrevious(false);
 	      break;
 	    case PROJECTM_K_l:
-			renderer->noSwitch=!renderer->noSwitch;
-			if (renderer->noSwitch) {
-				renderer->setToastMessage("Preset Locked");
-			} else {
-				renderer->setToastMessage("Unlocked");
-			}
+			setPresetLock(!isPresetLocked());
 			break;
 	    case PROJECTM_K_s:
             	renderer->studio = !renderer->studio;

--- a/src/libprojectM/KeyHandler.cpp
+++ b/src/libprojectM/KeyHandler.cpp
@@ -135,8 +135,8 @@ void projectM::default_key_handler( projectMEvent event, projectMKeycode keycode
 	    case PROJECTM_K_F5:
 		  renderer->showfps = !renderer->showfps;
 			// Initialize counters and reset frame count.
-			renderer->lastTime = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
-			renderer->currentTime = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
+			renderer->lastTimeFPS = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
+			renderer->currentTimeFPS = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
 			renderer->totalframes = 0;
 			// Hide preset name from screen and replace it with FPS counter.
 			if (renderer->showfps)
@@ -202,8 +202,13 @@ void projectM::default_key_handler( projectMEvent event, projectMKeycode keycode
 	      selectPrevious(false);
 	      break;
 	    case PROJECTM_K_l:
-		renderer->noSwitch=!renderer->noSwitch;
-	      break;
+			renderer->noSwitch=!renderer->noSwitch;
+			if (renderer->noSwitch) {
+				renderer->setToastMessage("Preset Locked");
+			} else {
+				renderer->setToastMessage("Unlocked");
+			}
+			break;
 	    case PROJECTM_K_s:
             	renderer->studio = !renderer->studio;
 	    case PROJECTM_K_i:

--- a/src/libprojectM/Renderer/Renderer.cpp
+++ b/src/libprojectM/Renderer/Renderer.cpp
@@ -32,7 +32,7 @@ void Renderer::drawText(const char* string, GLfloat x, GLfloat y, GLfloat scale,
 }
 
 void Renderer::drawText(GLTtext* text, const char* string, GLfloat x, GLfloat y, GLfloat scale,
-                        int horizontalAlignment = GLT_LEFT, int verticalAlignment = GLT_TOP)
+	int horizontalAlignment = GLT_LEFT, int verticalAlignment = GLT_TOP)
 {
 	// Initialize glText
 	gltInit();
@@ -42,8 +42,8 @@ void Renderer::drawText(GLTtext* text, const char* string, GLfloat x, GLfloat y,
 	// Begin text drawing (this for instance calls glUseProgram)
 	gltBeginDraw();
 
-	// Draw any amount of text between begin and end
-	gltColor(1.0f, 1.0f, 1.0f, 1.0f);
+	// Draw text transparently first.
+	gltColor(0.0f, 0.0f, 0.0f, 0.0f);
 
 	gltSetText(text, string);
 	// Where horizontal is either:
@@ -56,6 +56,68 @@ void Renderer::drawText(GLTtext* text, const char* string, GLfloat x, GLfloat y,
 	// - GLT_CENTER
 	// - GLT_BOTTOM
 	gltDrawText2DAligned(text, x, y, scale, horizontalAlignment, verticalAlignment);
+	GLfloat textWidth = gltGetTextWidth(text, scale);
+	
+	float windowWidth = vw;
+	if (horizontalAlignment == GLT_LEFT) {
+		// if left aligned factor in X offset
+		windowWidth = vw - x;
+	}
+
+	// if our window is greater than the text width, there is no overflow so let's display it normally.
+	if (windowWidth > textWidth)
+	{
+		// redraw without transparency
+		gltColor(1.0f, 1.0f, 1.0f, 1.0f);
+		gltSetText(text, string);
+		gltDrawText2DAligned(text, x, y, scale, horizontalAlignment, verticalAlignment);
+	}
+	else {
+		// if the text is greater than the window width, we have a problem.
+
+		// Option 1: Reduce text length until it fits.
+		// If it's a single line of text then reduce the text and add a "..." to the end.
+		// Before: Geiss & Sperl - Feedback (projectM idle HDR mix)
+		// After: Geiss & Sperl - Feed...
+		//
+		// If it's multiline then just cut the text off.
+		// Before: F1: This help menu
+		//         UP: Increase Beat Sensitivity
+		// After : F1: This help menu
+		//         UP: Increase Beat Sensi 
+
+		std::string substring(string);
+		while (textWidth > windowWidth) {
+			substring.pop_back();
+			string = substring.c_str();
+			gltSetText(text, string);
+
+			gltDrawText2DAligned(text, x, y, scale, horizontalAlignment, verticalAlignment);
+			textWidth = gltGetTextWidth(text, scale);
+		}
+		// if it's not multi-line then append a ...
+		if (substring.find("\n") == -1) {
+			substring.pop_back();
+			substring.pop_back();
+			substring.pop_back();
+			substring += "...";
+		}
+		string = substring.c_str();
+
+		// Option 2: Reduce the scale (size) of the text until it fits.
+		/*
+		while (textWidth > windowWidth) {
+			scale = scale - 0.1;
+			gltDrawText2DAligned(text, x, y, scale, horizontalAlignment, verticalAlignment);
+			textWidth = gltGetTextWidth(text, scale);
+		}
+		*/
+
+		// Redraw now that the text fits.
+		gltColor(1.0f, 1.0f, 1.0f, 1.0f);
+		gltSetText(text, string);
+		gltDrawText2DAligned(text, x, y, scale, horizontalAlignment, verticalAlignment);
+	}
 
 	// Finish drawing text
 	gltEndDraw();
@@ -76,10 +138,10 @@ Renderer::Renderer(int width, int height, int gx, int gy, BeatDetect* _beatDetec
 	title_fontURL(_titlefontURL), menu_fontURL(_menufontURL), presetURL(_presetURL)
 {
 	this->totalframes = 1;
-	this->lastTimeFPS = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
-	this->currentTimeFPS = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
-	this->lastTimeToast = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
-	this->currentTimeToast = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
+	this->lastTimeFPS = nowMilliseconds();
+	this->currentTimeFPS = nowMilliseconds();
+	this->lastTimeToast = nowMilliseconds();
+	this->currentTimeToast = nowMilliseconds();
 	this->noSwitch = false;
 	this->showfps = false;
 	this->showtoast = false;
@@ -248,15 +310,12 @@ void Renderer::SetupPass1(const Pipeline& pipeline, const PipelineContext& pipel
 	*/
 	if (this->showfps)
 	{
-		this->currentTimeFPS = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
-		milliseconds ms = std::chrono::duration_cast<std::chrono::milliseconds>(this->currentTimeFPS - this->lastTimeFPS);
-		double diff = ms.count();
-		if (diff >= 250)
-		{
-			this->realfps = totalframes * (1000 / diff);
+		this->currentTimeFPS = nowMilliseconds();
+		if (timeCheck(this->currentTimeFPS, this->lastTimeFPS, (double)250)) {
+			this->realfps = totalframes * (1000 / 250);
 			setFPS(realfps);
 			totalframes = 0;
-			this->lastTimeFPS = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
+			this->lastTimeFPS = nowMilliseconds();
 		}
 	}
 	glViewport(0, 0, texsizeX, texsizeY);
@@ -548,6 +607,26 @@ void Renderer::draw_title_to_texture()
 
 float title_y;
 
+bool Renderer::timeCheck(const milliseconds currentTime, const milliseconds lastTime, const double difference) {
+	milliseconds ms = std::chrono::duration_cast<std::chrono::milliseconds>(currentTime - lastTime);
+	double diff = ms.count();
+	if (diff >= difference)
+	{
+		return true;
+	} else {
+		return false;
+	}
+}
+
+void Renderer::setToastMessage(const std::string& theValue)
+{
+	// Initialize counters
+	lastTimeToast= nowMilliseconds();
+	currentTimeToast = nowMilliseconds();
+	m_toastMessage = theValue;
+	showtoast = true;
+}
+
 // TODO:
 void Renderer::draw_title_to_screen(bool flip)
 {
@@ -623,12 +702,10 @@ void Renderer::draw_toast()
 	drawText(this->toastMessage().c_str(), (vw/2), (vh/2), 2.5, GLT_CENTER, GLT_CENTER);
 #endif /** USE_TEXT_MENU */
 
-	this->currentTimeToast = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
-	milliseconds ms = std::chrono::duration_cast<std::chrono::milliseconds>(this->currentTimeToast - this->lastTimeToast);
-	double diff = ms.count();
-	if (diff >= (TOAST_TIME * 1000)) {
-		this->currentTimeToast = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
-		this->lastTimeToast = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
+	this->currentTimeToast = nowMilliseconds();
+	if (timeCheck(this->currentTimeToast,this->lastTimeToast,(double)(TOAST_TIME*1000))) {
+		this->currentTimeToast = nowMilliseconds();
+		this->lastTimeToast = nowMilliseconds();
 		this->showtoast = false;
 	}
 }

--- a/src/libprojectM/Renderer/Renderer.hpp
+++ b/src/libprojectM/Renderer/Renderer.hpp
@@ -24,6 +24,8 @@ using namespace std::chrono;
 
 #endif /** USE_TEXT_MENU */
 
+#define TOAST_TIME 2
+
 // for final composite grid:
 #define FCGSX 32 // final composite gridsize - # verts - should be EVEN.
 #define FCGSY 24 // final composite gridsize - # verts - should be EVEN.
@@ -41,12 +43,13 @@ typedef struct
 class Texture;
 class BeatDetect;
 class TextureManager;
+class TimeKeeper;
 
 class Renderer
 {
 
 public:
-
+  bool showtoast;
   bool showfps;
   bool showtitle;
   bool showpreset;
@@ -58,8 +61,11 @@ public:
 
   bool noSwitch;
 
-  milliseconds lastTime;
-  milliseconds currentTime;
+  milliseconds lastTimeFPS;
+  milliseconds currentTimeFPS;
+
+  milliseconds lastTimeToast;
+  milliseconds currentTimeToast;
 
   int totalframes;
   float realfps;
@@ -102,6 +108,19 @@ public:
   std::string fps() const {
 		return m_fps;
   }
+
+  void setToastMessage(const std::string& theValue)
+  {
+    // Initialize counters
+	lastTimeToast= duration_cast<milliseconds>(system_clock::now().time_since_epoch());
+	currentTimeToast = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
+    m_toastMessage = theValue;
+    showtoast = true;
+  }
+  
+  std::string toastMessage() const {
+    return m_toastMessage;
+  }
   
 private:
 
@@ -109,6 +128,8 @@ private:
   BeatDetect *beatDetect;
   TextureManager *textureManager;
   static Pipeline* currentPipe;
+  TimeKeeper *timeKeeperFPS;
+  TimeKeeper *timeKeeperToast;
 
 #ifdef USE_TEXT_MENU
 
@@ -124,6 +145,7 @@ private:
   std::string m_presetName;
   std::string m_datadir;
   std::string m_fps;
+  std::string m_toastMessage;
 
   float* p;
 
@@ -172,6 +194,7 @@ private:
 
   void rescale_per_pixel_matrices();
 
+  void draw_toast();
   void draw_fps();
   void draw_stats();
   void draw_help();

--- a/src/libprojectM/Renderer/Renderer.hpp
+++ b/src/libprojectM/Renderer/Renderer.hpp
@@ -89,6 +89,8 @@ public:
   void reset(int w, int h);
   GLuint initRenderToTexture();
 
+  bool timeCheck(const milliseconds currentTime, const milliseconds lastTime, const double difference);
+
   std::string SetPipeline(Pipeline &pipeline);
 
   void setPresetName(const std::string& theValue)
@@ -109,15 +111,12 @@ public:
 		return m_fps;
   }
 
-  void setToastMessage(const std::string& theValue)
-  {
-    // Initialize counters
-	lastTimeToast= duration_cast<milliseconds>(system_clock::now().time_since_epoch());
-	currentTimeToast = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
-    m_toastMessage = theValue;
-    showtoast = true;
+  milliseconds nowMilliseconds() {
+		return duration_cast<milliseconds>(system_clock::now().time_since_epoch());;
   }
-  
+
+  void setToastMessage(const std::string& theValue);
+
   std::string toastMessage() const {
     return m_toastMessage;
   }

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -863,6 +863,11 @@ std::string projectM::switchPreset(std::unique_ptr<Preset> & targetPreset) {
 void projectM::setPresetLock ( bool isLocked )
 {
     renderer->noSwitch = isLocked;
+    if (isPresetLocked()) {
+        renderer->setToastMessage("Preset Locked");
+    } else {
+        renderer->setToastMessage("Unlocked");
+    }
 }
 
 bool projectM::isPresetLocked() const

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -981,3 +981,9 @@ void projectM::getMeshSize(int *w, int *h)	{
     *h = _settings.meshY;
 }
 
+void projectM::setToastMessage(const std::string & toastMessage)
+{
+    if ( renderer )
+        renderer->setToastMessage(toastMessage);
+}
+

--- a/src/libprojectM/projectM.hpp
+++ b/src/libprojectM/projectM.hpp
@@ -175,7 +175,7 @@ public:
   void changeTextureSize(int size);
   void changePresetDuration(int seconds);
   void getMeshSize(int *w, int *h);
-
+  void setToastMessage(const std::string & toastMessage);
   const Settings & settings() const {
 		return _settings;
   }

--- a/src/projectM-sdl/pmSDL.cpp
+++ b/src/projectM-sdl/pmSDL.cpp
@@ -269,7 +269,6 @@ void projectMSDL::keyHandler(SDL_Event *sdl_evt) {
         case SDLK_i:
                 if (sdl_mod & KMOD_LGUI || sdl_mod & KMOD_RGUI || sdl_mod & KMOD_LCTRL)
                 {
-                    projectM::setToastMessage("Audio DEvice CHANGED LOL");
                     toggleAudioInput();
                     return; // handled
                 }

--- a/src/projectM-sdl/pmSDL.cpp
+++ b/src/projectM-sdl/pmSDL.cpp
@@ -110,6 +110,9 @@ int projectMSDL::initAudioInput() {
 
     // read characteristics of opened capture device
     SDL_Log("Opened audio capture device index=%i devId=%i: %s", selectedAudioDevice, audioDeviceID, SDL_GetAudioDeviceName(selectedAudioDevice, true));
+    std::string deviceToast = "Listening to ";
+    deviceToast += SDL_GetAudioDeviceName(selectedAudioDevice, true);
+    projectM::setToastMessage(deviceToast);
     SDL_Log("Samples: %i, frequency: %i, channels: %i, format: %i", have.samples, have.freq, have.channels, have.format);
     audioChannelsCount = have.channels;
     audioSampleRate = have.freq;
@@ -266,6 +269,7 @@ void projectMSDL::keyHandler(SDL_Event *sdl_evt) {
         case SDLK_i:
                 if (sdl_mod & KMOD_LGUI || sdl_mod & KMOD_RGUI || sdl_mod & KMOD_LCTRL)
                 {
+                    projectM::setToastMessage("Audio DEvice CHANGED LOL");
                     toggleAudioInput();
                     return; // handled
                 }


### PR DESCRIPTION
For lack of a better word, this PR implements toast notifications. For now they are displayed centered in the screen with a hard coded timeout of 2 seconds (I can't imagine a reason for this being configurable).

For immediate use: lock/unlock in messages are displayed in libprojectM and audio toggle in SDL will produce a useful message.

Obligatory demo video as POC here: https://streamable.com/4mgxx8. 

With fast transitions the feedback of locking is really helpful. Also audio toggle from SDL is implemented showing the device name on the screen as per feedback here https://github.com/projectM-visualizer/projectm/issues/350.

![image](https://user-images.githubusercontent.com/59471060/81317793-5a279f00-909e-11ea-92a2-0bb4facbed6f.png)

