### PR TITLE
Help menu

### DIFF
--- a/src/libprojectM/Renderer/Renderer.cpp
+++ b/src/libprojectM/Renderer/Renderer.cpp
@@ -157,6 +157,21 @@ Renderer::Renderer(int width, int height, int gx, int gy, BeatDetect* _beatDetec
 
 	this->drawtitle = 0;
 
+	// This is the default help menu for applications that have not defined any custom menu.
+	const char* defaultHelpMenu = "\n"
+		"F1: This help menu""\n"
+		"F3: Show preset name""\n"
+		"F5: Show FPS""\n"
+		"L: Lock/Unlock Preset""\n"
+		"R: Random preset""\n"
+		"N: Next preset""\n"
+		"P: Previous preset""\n"
+		"UP: Increase Beat Sensitivity""\n"
+		"DOWN: Decrease Beat Sensitivity""\n"
+		"CTRL-F: Fullscreen";
+
+	this->setHelpText(defaultHelpMenu);
+
 	//this->title = "Unknown";
 
 	/** Other stuff... */
@@ -656,17 +671,7 @@ void Renderer::draw_help()
 {
 #ifdef USE_TEXT_MENU
 	// TODO: match winamp/milkdrop bindings
-	drawText("\n"
-	         "F1: This help menu""\n"
-	         "F3: Show preset name""\n"
-		     "F5: Show FPS""\n"
-	         "L: Lock/Unlock Preset""\n"
-	         "R: Random preset""\n"
-	         "N: Next preset""\n"
-	         "P: Previous preset""\n"
-	         "UP: Increase Beat Sensitivity""\n"
-	         "DOWN: Decrease Beat Sensitivity""\n"
-	         "CTRL-F: Fullscreen", 30, 20, 2.5);
+	drawText(this->helpText().c_str(), 30, 20, 2.5);
 
 #endif /** USE_TEXT_MENU */
 }

--- a/src/libprojectM/Renderer/Renderer.cpp
+++ b/src/libprojectM/Renderer/Renderer.cpp
@@ -694,7 +694,7 @@ void Renderer::draw_stats()
 
 	stats += "\n";
 	stats += "Beat Detect:""\n";
-	stats += "Sensitivity: " + float_stats(beatDetect->beat_sensitivity) + "\n";
+	stats += "Sensitivity: " + float_stats(beatDetect->beatSensitivity) + "\n";
 	stats += "Bass: " + float_stats(beatDetect->bass) + "\n";
 	stats += "Mid Range: " + float_stats(beatDetect->mid) + "\n";
 	stats += "Treble: " + float_stats(beatDetect->treb) + "\n";

--- a/src/libprojectM/Renderer/Renderer.hpp
+++ b/src/libprojectM/Renderer/Renderer.hpp
@@ -67,6 +67,8 @@ public:
   milliseconds lastTimeToast;
   milliseconds currentTimeToast;
 
+  std::string m_helpText;
+
   int totalframes;
   float realfps;
 
@@ -101,6 +103,14 @@ public:
   std::string presetName() const
   {
     return m_presetName;
+  }
+
+  void setHelpText(const std::string& theValue) {
+		m_helpText = theValue; 
+  }
+
+  std::string helpText() const {
+		return m_helpText;
   }
 
   void setFPS(const int &theValue) {

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -1005,3 +1005,9 @@ void projectM::setToastMessage(const std::string & toastMessage)
         renderer->setToastMessage(toastMessage);
 }
 
+void projectM::setHelpText(const std::string & helpText)
+{
+    if ( renderer )
+        renderer->setHelpText(helpText);
+}
+

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -224,7 +224,7 @@ void projectM::readConfig (const std::string & configFile )
     
     // Beat Sensitivity impacts how reactive your visualizations are to volume, bass, mid-range, and treble. 
     // Preset authors have developed their visualizations with the default of 1.0.
-    _settings.beatSensitivity = beatDetect->beatSensitivity = config.read<float> ( "Beat Sensitivity", 1.0 );
+    _settings.beatSensitivity = config.read<float> ( "Beat Sensitivity", 1.0 );
 
 
     projectM_init ( _settings.meshX, _settings.meshY, _settings.fps,

--- a/src/libprojectM/projectM.hpp
+++ b/src/libprojectM/projectM.hpp
@@ -182,6 +182,7 @@ public:
   void changeHardcutDuration(int seconds);
   void changePresetDuration(int seconds);
   void getMeshSize(int *w, int *h);
+  void setHelpText(const std::string & helpText);
   void setToastMessage(const std::string & toastMessage);
   const Settings & settings() const {
 		return _settings;

--- a/src/projectM-sdl/pmSDL.cpp
+++ b/src/projectM-sdl/pmSDL.cpp
@@ -166,6 +166,10 @@ void projectMSDL::endAudioCapture() {
     SDL_PauseAudioDevice(audioDeviceID, true);
 }
 
+void projectMSDL::setHelpText(const std::string & helpText) {
+    projectM::setHelpText(helpText);
+}
+
 void projectMSDL::maximize() {
     SDL_DisplayMode dm;
     if (SDL_GetDesktopDisplayMode(0, &dm) != 0) {

--- a/src/projectM-sdl/pmSDL.hpp
+++ b/src/projectM-sdl/pmSDL.hpp
@@ -100,6 +100,7 @@ public:
 	void nextMonitor();
     void toggleFullScreen();
     void resize(unsigned int width, unsigned int height);
+    void setHelpText(const std::string& theValue);
     void renderFrame();
     void pollEvent();
     void maximize();

--- a/src/projectM-sdl/projectM_SDL_main.cpp
+++ b/src/projectM-sdl/projectM_SDL_main.cpp
@@ -365,6 +365,32 @@ srand((int)(time(NULL)));
         // init with settings
         app = new projectMSDL(settings, 0);
     }
+
+
+std::string modKey = "CTRL";
+
+#if __APPLE_
+modKey = "CMD";
+#endif
+
+	std::string sdlHelpMenu = "\n"
+		"F1: This help menu""\n"
+		"F3: Show preset name""\n"
+		"F5: Show FPS""\n"
+		"L or SPACE: Lock/Unlock Preset""\n"
+		"R: Random preset""\n"
+		"N: Next preset""\n"
+		"P: Previous preset""\n"
+		"UP: Increase Beat Sensitivity""\n"
+		"DOWN: Decrease Beat Sensitivity""\n" +
+		modKey + "-I: Audio Input (listen to next device)""\n" +
+		modKey + "-M: Change Monitor""\n" +
+		modKey + "-S: Stretch Monitors""\n" +
+		modKey + "-F: Fullscreen""\n" +
+		modKey + "-Q: Quit";
+
+	app->setHelpText(sdlHelpMenu.c_str());
+
     app->init(win, &glCtx);
 
 #if STEREOSCOPIC_SBS


### PR DESCRIPTION
The help menu right now is static and hard coded into the Renderer of libProjectM. This is not flexible for new projects / implementations that use this library.

This change makes it so the menu remains static (for backwards compatibility), but also allows your program to define the menu (because the program you develop might have new  / different keybinds). I updated SDL so it defines a custom help menu based on new supported features like full screen, locking with spacebar, and monitor manipulation.

I think you can ignore the beat sensitivity changes because I was one commit behind when I made this.