### PR TITLE
Random preset browsing update

### DIFF
--- a/src/libprojectM/PresetChooser.hpp
+++ b/src/libprojectM/PresetChooser.hpp
@@ -219,7 +219,6 @@ inline bool PresetChooser::empty() const {
 }
 
 inline std::unique_ptr<Preset> PresetChooser::directoryIndex(std::size_t index) const {
-    printf("directoryIndex! %i\n", index);
 	return _presetLoader->loadPreset(index);
 }
 

--- a/src/libprojectM/PresetChooser.hpp
+++ b/src/libprojectM/PresetChooser.hpp
@@ -36,6 +36,9 @@ public:
     /// \brief Returns the indexing value used by the current iterator.
     std::size_t operator*() const;
 
+    // Return previous index.
+    std::size_t lastIndex() const;
+
     ///  Allocate a new preset given this iterator's associated preset name
     /// \param presetInputs the preset inputs to associate with the preset upon construction
     /// \param presetOutputs the preset outputs to associate with the preset upon construction
@@ -121,6 +124,10 @@ inline void PresetIterator::setChooser(const PresetChooser & chooser) {
 }
 
 inline std::size_t PresetIterator::operator*() const {
+    return _currentIndex;
+}
+
+inline std::size_t PresetIterator::lastIndex() const {
     return _currentIndex;
 }
 
@@ -212,7 +219,7 @@ inline bool PresetChooser::empty() const {
 }
 
 inline std::unique_ptr<Preset> PresetChooser::directoryIndex(std::size_t index) const {
-
+    printf("directoryIndex! %i\n", index);
 	return _presetLoader->loadPreset(index);
 }
 

--- a/src/libprojectM/Renderer/Renderer.cpp
+++ b/src/libprojectM/Renderer/Renderer.cpp
@@ -694,7 +694,7 @@ void Renderer::draw_stats()
 
 	stats += "\n";
 	stats += "Beat Detect:""\n";
-	stats += "Sensitivity: " + float_stats(beatDetect->beat_sensitivity) + "\n";
+	stats += "Sensitivity: " + float_stats(beatDetect->beatSensitivity) + "\n";
 	stats += "Bass: " + float_stats(beatDetect->bass) + "\n";
 	stats += "Mid Range: " + float_stats(beatDetect->mid) + "\n";
 	stats += "Treble: " + float_stats(beatDetect->treb) + "\n";

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -810,6 +810,9 @@ void projectM::selectRandom(const bool hardCut) {
     if (m_presetChooser->empty())
         return;
     presetHistory.push_back(m_presetPos->lastIndex());
+    // If presetHistory is tracking more than 10, then delete the oldest entry so we cap to a history of 10.
+    if (presetHistory.size() >= 10)
+        presetHistory.erase(presetHistory.begin());
     presetFuture.clear();
     *m_presetPos = m_presetChooser->weightedRandom(hardCut);
 

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -822,8 +822,6 @@ void projectM::selectPrevious(const bool hardCut) {
         return;
 
     if (settings().shuffleEnabled && presetHistory.size() >= 1 && presetHistory.back() != m_presetLoader->size()) { // if randomly browsing presets, "previous" should return to last random preset not the index--. Avoid returning to size() because that's the idle:// preset.
-        for (std::vector<int>::const_iterator i = presetFuture.begin(); i != presetFuture.end(); ++i)
-            std::cout << *i << ' ';
         presetFuture.push_back(m_presetPos->lastIndex());
         selectPreset(presetHistory.back());
         presetHistory.pop_back();

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -224,7 +224,7 @@ void projectM::readConfig (const std::string & configFile )
     
     // Beat Sensitivity impacts how reactive your visualizations are to volume, bass, mid-range, and treble. 
     // Preset authors have developed their visualizations with the default of 1.0.
-    _settings.beatSensitivity = beatDetect->beatSensitivity = config.read<float> ( "Beat Sensitivity", 1.0 );
+    _settings.beatSensitivity = config.read<float> ( "Beat Sensitivity", 1.0 );
 
 
     projectM_init ( _settings.meshX, _settings.meshY, _settings.fps,

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -807,10 +807,10 @@ void projectM::switchPreset(const bool hardCut) {
 
 
 void projectM::selectRandom(const bool hardCut) {
-
     if (m_presetChooser->empty())
         return;
-
+    random = true;
+    lastPreset = m_presetPos->lastIndex();
     *m_presetPos = m_presetChooser->weightedRandom(hardCut);
 
     switchPreset(hardCut);
@@ -818,23 +818,26 @@ void projectM::selectRandom(const bool hardCut) {
 }
 
 void projectM::selectPrevious(const bool hardCut) {
-
     if (m_presetChooser->empty())
         return;
 
-
-    m_presetChooser->previousPreset(*m_presetPos);
-
-    switchPreset(hardCut);
+    if (random && lastPreset != m_presetLoader->size()) { // if randomly browsing presets, "previous" should return to last random preset not the index--. Avoid returning to size() because that's the idle:// preset.
+        selectPreset(lastPreset);
+        random = false;
+    }
+    else {
+        m_presetChooser->previousPreset(*m_presetPos);
+        switchPreset(hardCut);
+    }
 }
 
 void projectM::selectNext(const bool hardCut) {
-
     if (m_presetChooser->empty())
         return;
 
     m_presetChooser->nextPreset(*m_presetPos);
-
+    
+    random = false;
     switchPreset(hardCut);
 }
 

--- a/src/libprojectM/projectM.hpp
+++ b/src/libprojectM/projectM.hpp
@@ -63,6 +63,7 @@
 #include "dlldefs.h"
 #include "event.h"
 #include "fatal.h"
+#include <vector>
 
 class PipelineContext;
 #include "PCM.hpp"
@@ -286,11 +287,13 @@ public:
   PipelineContext & pipelineContext2() { return *_pipelineContext2; }
 
   int lastPreset = 0;
+  std::vector<int> presetHistory;  
+  std::vector<int> presetFuture;  
+
 
   void selectPrevious(const bool);
   void selectNext(const bool);
   void selectRandom(const bool);
-  bool random = false;
     
   int getWindowWidth() { return _settings.windowWidth; }
   int getWindowHeight() { return _settings.windowHeight; }

--- a/src/libprojectM/projectM.hpp
+++ b/src/libprojectM/projectM.hpp
@@ -338,7 +338,7 @@ private:
   /// The current position of the directory iterator
   PresetIterator * m_presetPos;
 
-  /// Last PresetPost (when randomizing)
+  /// Last preset index (when randomizing)
   PresetIterator * m_lastPresetPos;
 
   /// Required by the preset chooser. Manages a loaded preset directory

--- a/src/libprojectM/projectM.hpp
+++ b/src/libprojectM/projectM.hpp
@@ -285,10 +285,12 @@ public:
   PipelineContext & pipelineContext() { return *_pipelineContext; }
   PipelineContext & pipelineContext2() { return *_pipelineContext2; }
 
+  int lastPreset = 0;
 
   void selectPrevious(const bool);
   void selectNext(const bool);
   void selectRandom(const bool);
+  bool random = false;
     
   int getWindowWidth() { return _settings.windowWidth; }
   int getWindowHeight() { return _settings.windowHeight; }
@@ -332,6 +334,9 @@ private:
 
   /// The current position of the directory iterator
   PresetIterator * m_presetPos;
+
+  /// Last PresetPost (when randomizing)
+  PresetIterator * m_lastPresetPos;
 
   /// Required by the preset chooser. Manages a loaded preset directory
   PresetLoader * m_presetLoader;


### PR DESCRIPTION
This is based on an end-user experience issue.

The default in SDL is random preset browsing. This should absolutely be the default as you want to see some variety with transitions. The issue is this: you see a preset you really like when suddenly the next preset randomly loads. You use "P" to load the [P]revious preset, but that just loads the presetIndex--. So you don't load the last preset you saw, instead you move alphabetically down the preset index to something very similar (not what you saw last).

This PR is meant to track a history of presets when browsing randomly. So if you move to the [P]revious preset it will actually load what you saw last. If you move backwards in the random preset index you can also move forward to the same random presets you saw with [N]ext. If you reach outside the boundaries of what you saw randomly it will start alphabetically incrementing or decrementing as it was doing before.