### PR TITLE
#378 Fix aligned alloc on macOS when building without XCode

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([projectM], [3.1.5], [mischa@mvstg.biz], [projectM], [https://github.com/projectM-visualizer/projectm/])
+AC_INIT([projectM], [3.1.6], [me@mish.dev], [projectM], [https://github.com/projectM-visualizer/projectm/])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects tar-pax])
 
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
@@ -241,6 +241,7 @@ my_CFLAGS="-Wall -Wchar-subscripts -Wformat-security -Wpointer-arith -Wshadow -W
 #my_CFLAGS+="-fsanitize=address -fno-omit-frame-pointer "
 my_CFLAGS="${my_CFLAGS} -DDATADIR_PATH=\\\"\"\$(pkgdatadir)\\\"\""
 my_CFLAGS="${my_CFLAGS} -I\$(top_srcdir)/vendor"
+my_CFLAGS="${my_CFLAGS} -DGL_SILENCE_DEPRECATION"
 AC_SUBST([my_CFLAGS])
 
 

--- a/src/libprojectM/wipemalloc.cpp
+++ b/src/libprojectM/wipemalloc.cpp
@@ -55,7 +55,7 @@ void *wipe_aligned_alloc( size_t align, size_t size )
 {
     void *mem = NULL;
 
-#if HAVE_ALIGNED_ALLOC==1
+#if HAVE_ALIGNED_ALLOC==1 && !__APPLE__
 
     mem = aligned_alloc( align, size );
 


### PR DESCRIPTION
Makes normal `make` build flow work; we don't have `aligned_alloc` on macOS.