### PR TITLE
More toasts... and one more little thing

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ See [BUILDING.md](BUILDING.md)
 * Down: decrease beat sensitivity (min 0)
 * Y: toggle shuffle enabled
 * R: jump to random preset
-* N: next preset
-* P: previous preset
-* Shift-N: next preset with hard cut
-* Shift-P: previous preset with hard cut
+* N: next preset (hard cut)
+* P: previous preset (hard cut)
+* Shift-N: next preset
+* Shift-P: previous preset
 * L: lock current preset
 
 * H or F1: show help (if supported)

--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ See [BUILDING.md](BUILDING.md)
 * Down: decrease beat sensitivity (min 0)
 * Y: toggle shuffle enabled
 * R: jump to random preset
-* N: next preset (hard cut)
-* P: previous preset (hard cut)
-* Shift-N: next preset
-* Shift-P: previous preset
+* N: next preset (hard transition)
+* P: previous preset (hard transition)
+* Shift-N: next preset (soft transition)
+* Shift-P: previous preset (soft transition)
 * L: lock current preset
 
 * H or F1: show help (if supported)

--- a/src/libprojectM/KeyHandler.cpp
+++ b/src/libprojectM/KeyHandler.cpp
@@ -41,6 +41,13 @@ void selectRandom(const bool hardCut);
 void selectNext(const bool hardCut);
 void selectPrevious(const bool hardCut);
 
+std::string round_float(float number)
+{
+    std::string num_text = std::to_string(number);
+    std::string rounded = num_text.substr(0, num_text.find(".")+3);
+	return rounded;
+}
+
 void refreshConsole() {
 
   switch (current_interface) {
@@ -115,10 +122,12 @@ void projectM::default_key_handler( projectMEvent event, projectMKeycode keycode
 	    case PROJECTM_K_UP:
             beatDetect->beatSensitivity += 0.25;
 			if (beatDetect->beatSensitivity > 5.0) beatDetect->beatSensitivity = 5.0;
+			renderer->setToastMessage("Beat Sensitivity: "+round_float(beatDetect->beatSensitivity));
 	      break;
 	    case PROJECTM_K_DOWN:
             beatDetect->beatSensitivity -= 0.25;
 			if (beatDetect->beatSensitivity < 0) beatDetect->beatSensitivity = 0;
+			renderer->setToastMessage("Beat Sensitivity: "+round_float(beatDetect->beatSensitivity));
 	      break;
 		case PROJECTM_K_h:
  		  renderer->showhelp = !renderer->showhelp;
@@ -129,6 +138,12 @@ void projectM::default_key_handler( projectMEvent event, projectMKeycode keycode
 	      break;
 	    case PROJECTM_K_y:
 		this->setShuffleEnabled(!this->isShuffleEnabled());
+		if (this->isShuffleEnabled()) {
+			renderer->setToastMessage("Shuffle Enabled");
+		}
+		else {
+			renderer->setToastMessage("Shuffle Disabled");
+		}
 		 break;
 
 	    case PROJECTM_K_F5:

--- a/src/libprojectM/sdltoprojectM.h
+++ b/src/libprojectM/sdltoprojectM.h
@@ -58,7 +58,7 @@ inline projectMEvent sdl2pmEvent( SDL_Event *event ) { \
       } \
   } \
 
-inline projectMKeycode sdl2pmKeycode( SDL_Keycode keycode ) { \
+inline projectMKeycode sdl2pmKeycode( SDL_Keycode keycode , SDL_Keymod mod ) { \
     switch ( keycode ) { \
         case SDLK_F1: \
             return PROJECTM_K_F1; \
@@ -87,56 +87,108 @@ inline projectMKeycode sdl2pmKeycode( SDL_Keycode keycode ) { \
 	  case SDLK_ESCAPE: \
 	    return PROJECTM_K_ESCAPE; 
     case SDLK_a:
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_A;
       return PROJECTM_K_a;
     case SDLK_b:
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_B;
       return PROJECTM_K_b;
     case SDLK_c:  
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_C;
       return PROJECTM_K_c;
-    case SDLK_d: 
+    case SDLK_d:
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_D;
       return PROJECTM_K_d; 
     case SDLK_e:
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_E;
       return PROJECTM_K_e; 
     case SDLK_f: 
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_F;
       return PROJECTM_K_f; 
     case SDLK_g: 
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_G;
       return PROJECTM_K_g; 
     case SDLK_h: 
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_H;
       return PROJECTM_K_h; 
-    case SDLK_i: 
+    case SDLK_i:
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_I;
       return PROJECTM_K_i; 
     case SDLK_j:
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_J;
       return PROJECTM_K_j;
     case SDLK_k:
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_K;
       return PROJECTM_K_k;
-    case SDLK_l:  
+    case SDLK_l:
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_L;
       return PROJECTM_K_l;
-    case SDLK_m: 
+    case SDLK_m:
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_M;
       return PROJECTM_K_m; 
     case SDLK_n:
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_N;
       return PROJECTM_K_n; 
-    case SDLK_o: 
+    case SDLK_o:
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_O;
       return PROJECTM_K_o; 
     case SDLK_p: 
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_P;
       return PROJECTM_K_p; 
-    case SDLK_q: 
+    case SDLK_q:
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_Q;
       return PROJECTM_K_q; 
     case SDLK_r: 
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_R;
       return PROJECTM_K_r; 
     case SDLK_s: 
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_S;
       return PROJECTM_K_s; 
     case SDLK_t:
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_T;
       return PROJECTM_K_t; 
-    case SDLK_u: 
+    case SDLK_u:
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_U;
       return PROJECTM_K_u; 
     case SDLK_v: 
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_V;
       return PROJECTM_K_v; 
     case SDLK_w: 
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_W;
       return PROJECTM_K_w; 
     case SDLK_x: 
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_X;
       return PROJECTM_K_x; 
     case SDLK_y: 
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_Y;
       return PROJECTM_K_y; 
     case SDLK_z: 
+      if (mod & KMOD_SHIFT)
+        return PROJECTM_K_Z;
       return PROJECTM_K_z; 
     case SDLK_UP:
       return PROJECTM_K_UP;

--- a/src/projectM-sdl/pmSDL.cpp
+++ b/src/projectM-sdl/pmSDL.cpp
@@ -372,8 +372,8 @@ void projectMSDL::keyHandler(SDL_Event *sdl_evt) {
 
     // translate into projectM codes and perform default projectM handler
     evt = sdl2pmEvent(sdl_evt);
-    key = sdl2pmKeycode(sdl_keycode);
     mod = sdl2pmModifier(sdl_mod);
+    key = sdl2pmKeycode(sdl_keycode,sdl_mod);
     key_handler(evt, key, mod);
 }
 


### PR DESCRIPTION
I never noticed the Y key can enable/disable the shuffle setting, so I added a toast notification for a better user-experience. I separately added toast messages for manipulating beat sensitivity.

In my documentation review I noticed that N/P (a/k/a lowercase) are reported to load next/previous presets with soft-cut transitions, and SHIFT+N/P are supposed to be hard-cut transitions. Currently SDL treats lowercase and SHIFT+N/P the same: they are hard cut transitions.

I think I fixed this up and changed the documentation (it was wrong as lowercase should be hard cut and SHIFT should be soft cut).