### PR TITLE
Toggle stretching

### DIFF
--- a/src/projectM-sdl/pmSDL.cpp
+++ b/src/projectM-sdl/pmSDL.cpp
@@ -249,7 +249,7 @@ void projectMSDL::nextMonitor()
 		std::vector<SDL_Rect> displayBounds;
 		int nextWindow = currentWindowIndex + 1;
 		if (nextWindow >= displayCount) nextWindow = 0;
-
+        
 		for (int i = 0; i < displayCount; i++)
 		{
 			displayBounds.push_back(SDL_Rect());
@@ -302,7 +302,13 @@ void projectMSDL::keyHandler(SDL_Event *sdl_evt) {
 				// command-s: [s]tretch monitors
 				// Stereo requires fullscreen
 #if !STEREOSCOPIC_SBS
-				stretchMonitors();
+                if (!this->strech) {
+                    stretchMonitors();
+                    this->strech = true;
+                } else {
+                    toggleFullScreen();
+                    this->strech = false;
+                }
 #endif
 				return; // handled
 			}
@@ -314,6 +320,7 @@ void projectMSDL::keyHandler(SDL_Event *sdl_evt) {
 #if !STEREOSCOPIC_SBS
 				nextMonitor();
 #endif
+                this->strech = false;
 				return; // handled
 			}
         case SDLK_f:
@@ -323,6 +330,7 @@ void projectMSDL::keyHandler(SDL_Event *sdl_evt) {
 #if !STEREOSCOPIC_SBS
 				toggleFullScreen();
 #endif
+                this->strech = false;
                 return; // handled
             }
             break;

--- a/src/projectM-sdl/pmSDL.cpp
+++ b/src/projectM-sdl/pmSDL.cpp
@@ -302,12 +302,12 @@ void projectMSDL::keyHandler(SDL_Event *sdl_evt) {
 				// command-s: [s]tretch monitors
 				// Stereo requires fullscreen
 #if !STEREOSCOPIC_SBS
-                if (!this->strech) {
+                if (!this->stretch) { // if stretching is not already enabled, enable it.
                     stretchMonitors();
-                    this->strech = true;
+                    this->stretch = true;
                 } else {
-                    toggleFullScreen();
-                    this->strech = false;
+                    toggleFullScreen(); // else, just toggle full screen so we leave stretch mode.
+                    this->stretch = false;
                 }
 #endif
 				return; // handled
@@ -320,7 +320,7 @@ void projectMSDL::keyHandler(SDL_Event *sdl_evt) {
 #if !STEREOSCOPIC_SBS
 				nextMonitor();
 #endif
-                this->strech = false;
+                this->stretch = false; // if we are switching monitors, ensure we disable monitor stretching.
 				return; // handled
 			}
         case SDLK_f:
@@ -330,7 +330,7 @@ void projectMSDL::keyHandler(SDL_Event *sdl_evt) {
 #if !STEREOSCOPIC_SBS
 				toggleFullScreen();
 #endif
-                this->strech = false;
+                this->stretch = false; // if we are toggling fullscreen, ensure we disable monitor stretching.
                 return; // handled
             }
             break;

--- a/src/projectM-sdl/pmSDL.hpp
+++ b/src/projectM-sdl/pmSDL.hpp
@@ -90,7 +90,7 @@ public:
     bool done;
     bool wasapi = false; // Used to track if wasapi is currently active. This bool will allow us to run a WASAPI app and still toggle to microphone inputs.
     bool fakeAudio = false; // Used to track fake audio, so we can turn it off and on.
-    bool strech = false;
+    bool stretch = false; // used for toggling stretch mode
     projectMSDL(Settings settings, int flags);
     projectMSDL(std::string config_file, int flags);
     void init(SDL_Window *window, SDL_GLContext *glCtx, const bool renderToTexture = false);

--- a/src/projectM-sdl/pmSDL.hpp
+++ b/src/projectM-sdl/pmSDL.hpp
@@ -90,6 +90,7 @@ public:
     bool done;
     bool wasapi = false; // Used to track if wasapi is currently active. This bool will allow us to run a WASAPI app and still toggle to microphone inputs.
     bool fakeAudio = false; // Used to track fake audio, so we can turn it off and on.
+    bool strech = false;
     projectMSDL(Settings settings, int flags);
     projectMSDL(std::string config_file, int flags);
     void init(SDL_Window *window, SDL_GLContext *glCtx, const bool renderToTexture = false);


### PR DESCRIPTION
Ctrl+S stretches monitors. But if you do Ctrl+S again it does nothing. This minor PR makes it so you can toggle stretching on and off. 