### PR TITLE
Fix blank preset bug

### DIFF
--- a/src/libprojectM/PipelineMerger.cpp
+++ b/src/libprojectM/PipelineMerger.cpp
@@ -5,6 +5,14 @@
 const double PipelineMerger::e(2.71828182845904523536);
 const double PipelineMerger::s(0.5);
 
+void PipelineMerger::ensureAlphaIsNotBlended(const Pipeline & a)
+{
+	for ( std::vector<RenderItem*>::const_iterator pos = a.drawables.begin(); pos != a.drawables.end(); ++pos )
+	{
+		( *pos )->masterAlpha = 1.0;
+	}
+}
+
 void PipelineMerger::mergePipelines(const Pipeline & a, const Pipeline & b, Pipeline & out, RenderItemMatcher::MatchResults & results, RenderItemMergeFunction & mergeFunction, float ratio)
 
 {

--- a/src/libprojectM/PipelineMerger.hpp
+++ b/src/libprojectM/PipelineMerger.hpp
@@ -16,6 +16,7 @@ public:
     
   static void mergePipelines(const Pipeline &a,  const Pipeline &b, Pipeline &out, 
 	RenderItemMatcher::MatchResults & matching, RenderItemMergeFunction & merger, float ratio);
+  static void ensureAlphaIsNotBlended(const Pipeline & a);
 
 private :
 

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -385,6 +385,10 @@ Pipeline * projectM::renderFrameOnlyPass1(Pipeline *pPipeline) /*pPipeline is a 
         }
     }
 
+    if ( !timeKeeper->IsSmoothing() )
+    {
+        PipelineMerger::ensureAlphaIsNotBlended(m_activePreset->pipeline());
+    }
 
     if ( timeKeeper->IsSmoothing() && timeKeeper->SmoothRatio() <= 1.0 && !m_presetChooser->empty() )
     {


### PR DESCRIPTION
I haven't tested this because my only Linux box is headless, but it compiles and is the same fix I applied to the Android branch in Feb 2020.  It makes sure than an interrupted preset blend doesn't accidentally leave the master alpha set to a non-1.0 value.  The fix is not very elegant, but it is quite effective.