### PR TITLE
Crash fix when using multiple renderers (do not use static Renderer::currentPipe)

### DIFF
--- a/src/libprojectM/Renderer/Renderer.cpp
+++ b/src/libprojectM/Renderer/Renderer.cpp
@@ -16,8 +16,6 @@
 #include <chrono>
 #include <ctime>
 
-Pipeline* Renderer::currentPipe;
-
 using namespace std::chrono;
 
 class Preset;
@@ -482,7 +480,11 @@ void Renderer::Interpolation(const Pipeline& pipeline, const PipelineContext& pi
 	else
 	{
 		mesh.Reset();
-		omptl::transform(mesh.p.begin(), mesh.p.end(), mesh.identity.begin(), mesh.p.begin(), &Renderer::PerPixel);
+		Pipeline *cp = currentPipe;
+		omptl::transform(mesh.p.begin(), mesh.p.end(), mesh.identity.begin(), mesh.p.begin(),
+			[cp](PixelPoint p, PerPixelContext &context) {
+				return cp->PerPixel(p, context);
+			});
 
 		for (int j = 0; j < mesh.height - 1; j++)
 		{

--- a/src/libprojectM/Renderer/Renderer.hpp
+++ b/src/libprojectM/Renderer/Renderer.hpp
@@ -136,7 +136,7 @@ private:
   PerPixelMesh mesh;
   BeatDetect *beatDetect;
   TextureManager *textureManager;
-  static Pipeline* currentPipe;
+  Pipeline* currentPipe;
   TimeKeeper *timeKeeperFPS;
   TimeKeeper *timeKeeperToast;
 
@@ -195,11 +195,6 @@ private:
   void Pass2 (const Pipeline &pipeline, const PipelineContext &pipelineContext);
   void CompositeShaderOutput(const Pipeline &pipeline, const PipelineContext &pipelineContext);
   void CompositeOutput(const Pipeline &pipeline, const PipelineContext &pipelineContext);
-
-  inline static PixelPoint PerPixel(PixelPoint p, PerPixelContext &context)
-  {
-	  return currentPipe->PerPixel(p,context);
-  }
 
   void rescale_per_pixel_matrices();
 


### PR DESCRIPTION
When creating 2 or more renderers, deleting one of them, then switching presets crash occurs because of using deleted currentPipe from deleted another renderer.