### PR TITLE
Fix various warnings

### DIFF
--- a/src/libprojectM/FileScanner.cpp
+++ b/src/libprojectM/FileScanner.cpp
@@ -145,7 +145,7 @@ void FileScanner::scanPosix(ScanCallback cb) {
     fileSystem = fts_open(dirList, FTS_LOGICAL|FTS_NOCHDIR|FTS_NOSTAT, &fts_compare);
     if (fileSystem == NULL) {
         std::string s;
-        for (int i = 0; i < _rootDirs.size(); i++)
+        for (std::size_t i = 0; i < _rootDirs.size(); i++)
             s += _rootDirs[i] + ' ';
         handleDirectoryError(s);
 

--- a/src/libprojectM/KeyHandler.cpp
+++ b/src/libprojectM/KeyHandler.cpp
@@ -154,7 +154,7 @@ void projectM::default_key_handler( projectMEvent event, projectMKeycode keycode
 			if (isTextInputActive()) break; // don't handle this key if search menu is up.
 			if (renderer->showmenu) {
 				int downPreset = m_presetPos->lastIndex() + (renderer->textMenuPageSize / 2.0f); // jump down by page size / 2
-				if (downPreset >= (m_presetLoader->size() - 1)) // handle upper boundary
+				if (static_cast<std::size_t>(downPreset) >= (m_presetLoader->size() - 1)) // handle upper boundary
 					downPreset = 0;
 				selectPreset(downPreset); // jump down menu half a page.
 			}

--- a/src/libprojectM/MilkdropPresetFactory/Expr.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/Expr.cpp
@@ -161,7 +161,7 @@ llvm::Value *PrefunExpr::_llvm(JitContext &jitx)
 class PrefunExprOne : public PrefunExpr
 {
 public:
-    PrefunExprOne(Func *function, Expr **expr_list_) : PrefunExpr(function,expr_list_) {}
+    PrefunExprOne(Func *fun, Expr **expr_list_) : PrefunExpr(fun,expr_list_) {}
     float eval ( int mesh_i, int mesh_j )
     {
         float val = expr_list[0]->eval ( mesh_i, mesh_j );
@@ -260,7 +260,7 @@ public:
 class IfExpr : public PrefunExpr
 {
 public:
-    IfExpr(Func *function, Expr **expr_list_) : PrefunExpr(function,expr_list_) {}
+    IfExpr(Func *fun, Expr **expr_list_) : PrefunExpr(fun,expr_list_) {}
 
     float eval ( int mesh_i, int mesh_j )
 	{
@@ -322,7 +322,7 @@ public:
 class SinExpr : public PrefunExpr
 {
 public:
-    SinExpr(Func *function, Expr **expr_list_) : PrefunExpr(function,expr_list_) {}
+    SinExpr(Func *fun, Expr **expr_list_) : PrefunExpr(fun,expr_list_) {}
     float eval ( int mesh_i, int mesh_j ) override
     {
         float val = expr_list[0]->eval ( mesh_i, mesh_j );
@@ -334,7 +334,7 @@ public:
 class CosExpr : public PrefunExpr
 {
 public:
-    CosExpr(Func *function, Expr **expr_list_) : PrefunExpr(function,expr_list_) {}
+    CosExpr(Func *fun, Expr **expr_list_) : PrefunExpr(fun,expr_list_) {}
     float eval ( int mesh_i, int mesh_j ) override
     {
         float val = expr_list[0]->eval ( mesh_i, mesh_j );
@@ -346,7 +346,7 @@ public:
 class LogExpr : public PrefunExpr
 {
 public:
-    LogExpr(Func *function, Expr **expr_list_) : PrefunExpr(function,expr_list_) {}
+    LogExpr(Func *fun, Expr **expr_list_) : PrefunExpr(fun,expr_list_) {}
     float eval ( int mesh_i, int mesh_j ) override
     {
         float val = expr_list[0]->eval( mesh_i, mesh_j );

--- a/src/libprojectM/Renderer/MilkdropWaveform.cpp
+++ b/src/libprojectM/Renderer/MilkdropWaveform.cpp
@@ -356,7 +356,7 @@ void MilkdropWaveform::WaveformMath(RenderContext &context)
 			break;
 
 		case DoubleLine://dual waveforms
-
+		{
 
 			wave_x_temp=-2*0.4142f*(fabs(fabs(mystery)-.5f)-.5f);
 
@@ -384,6 +384,8 @@ void MilkdropWaveform::WaveformMath(RenderContext &context)
 			}
 
 			break;
-
+		}
+		case last:
+            break;
 	}
 }

--- a/src/libprojectM/Renderer/Renderer.cpp
+++ b/src/libprojectM/Renderer/Renderer.cpp
@@ -389,7 +389,7 @@ void Renderer::RenderTouch(const Pipeline& pipeline, const PipelineContext& pipe
 {
 	Pipeline pipelineTouch;
 	MilkdropWaveform wave;
-	for(int x = 0; x < waveformList.size(); x++){
+	for(std::size_t x = 0; x < waveformList.size(); x++){
 		pipelineTouch.drawables.push_back(&wave);
 		wave = waveformList[x];
 
@@ -701,7 +701,7 @@ bool Renderer::timeCheck(const milliseconds currentTime, const milliseconds last
 }
 
 // If we touched on the renderer where there is an existing waveform.
-bool Renderer::touchedWaveform(float x, float y, int i)
+bool Renderer::touchedWaveform(float x, float y, std::size_t i)
 {
 	if (waveformList[i].x > (x-0.05f) && waveformList[i].x < (x+0.05f) // if x +- 0.5f 
 		&& ((waveformList[i].y > (y-0.05f) && waveformList[i].y < (y+0.05f)) // and y +- 0.5f 
@@ -717,7 +717,7 @@ bool Renderer::touchedWaveform(float x, float y, int i)
 void Renderer::touch(float x, float y, int pressure, int type = 0)
 {
 
-	for (int i = 0; i < waveformList.size(); i++) {
+	for (std::size_t i = 0; i < waveformList.size(); i++) {
 		if (touchedWaveform(x, y, i))
 		{
 			// if we touched an existing waveform with left click, drag it and don't continue with adding another.
@@ -767,7 +767,7 @@ void Renderer::touchDrag(float x, float y, int pressure)
 {
 	// if we left clicked & held in the approximate position of a waveform, snap to it and adjust x / y to simulate dragging.
 	// For lines we don't worry about the x axis.
-	for (int i = 0; i < waveformList.size(); i++) {
+	for (std::size_t i = 0; i < waveformList.size(); i++) {
 		if (touchedWaveform(x, y, i))
 		{
 			waveformList[i].x = x;
@@ -782,7 +782,7 @@ void Renderer::touchDestroy(float x, float y)
 {
 	// if we right clicked approximately on the position of the waveform, then remove it from the waveform list.
 	// For lines we don't worry about the x axis.
-	for (int i = 0; i < waveformList.size(); i++) {
+	for (std::size_t i = 0; i < waveformList.size(); i++) {
 		if (touchedWaveform(x, y, i))
 		{
 			waveformList.erase(waveformList.begin() + i);

--- a/src/libprojectM/Renderer/Renderer.hpp
+++ b/src/libprojectM/Renderer/Renderer.hpp
@@ -170,7 +170,7 @@ public:
   void touchDrag(float x, float y, int pressure);
   void touchDestroy(float x, float y);
   void touchDestroyAll();
-  bool touchedWaveform(float x, float y, int i);
+  bool touchedWaveform(float x, float y, std::size_t i);
   
   void setToastMessage(const std::string& theValue);
   void setSearchText(const std::string& theValue);

--- a/src/libprojectM/event.h
+++ b/src/libprojectM/event.h
@@ -145,6 +145,7 @@ typedef enum {
 
 typedef enum {
     /** Modifiers */
+    PROJECTM_KMOD_NONE = -1,
     PROJECTM_KMOD_LSHIFT,
     PROJECTM_KMOD_RSHIFT,
     PROJECTM_KMOD_CAPS,

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -114,7 +114,7 @@ void projectM::projectM_resetTextures()
 
 
 projectM::projectM ( std::string config_file, int flags) :
-        _pcm(0), beatDetect ( 0 ), renderer ( 0 ), _pipelineContext(new PipelineContext()), _pipelineContext2(new PipelineContext()), m_presetPos(0),
+        renderer ( 0 ), _pcm(0), beatDetect ( 0 ), _pipelineContext(new PipelineContext()), _pipelineContext2(new PipelineContext()), m_presetPos(0),
         timeKeeper(NULL), m_flags(flags), _matcher(NULL), _merger(NULL)
 {
     readConfig(config_file);
@@ -124,7 +124,7 @@ projectM::projectM ( std::string config_file, int flags) :
 }
 
 projectM::projectM(Settings settings, int flags):
-        _pcm(0), beatDetect ( 0 ), renderer ( 0 ), _pipelineContext(new PipelineContext()), _pipelineContext2(new PipelineContext()), m_presetPos(0),
+        renderer ( 0 ), _pcm(0), beatDetect ( 0 ), _pipelineContext(new PipelineContext()), _pipelineContext2(new PipelineContext()), m_presetPos(0),
         timeKeeper(NULL), m_flags(flags), _matcher(NULL), _merger(NULL)
 {
     readSettings(settings);

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -1133,7 +1133,7 @@ void projectM::toggleSearchText()
 }
 
 // get index from search results based on preset name
-const unsigned int projectM::getSearchIndex(std::string &name) const
+unsigned int projectM::getSearchIndex(std::string &name) const
 {
     for (auto& it : renderer->m_presetList) {
         if (it.name == name) return it.id;

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -900,7 +900,7 @@ void projectM::selectPrevious(const bool hardCut) {
             renderer->m_activePresetID--;
             selectPresetByName(renderer->m_presetList[renderer->m_activePresetID-1].name,true);
         }
-    } else if (settings().shuffleEnabled && presetHistory.size() >= 1 && presetHistory.back() != m_presetLoader->size() && !renderer->showmenu) { // if randomly browsing presets, "previous" should return to last random preset not the index--. Avoid returning to size() because that's the idle:// preset.
+    } else if (settings().shuffleEnabled && presetHistory.size() >= 1 && static_cast<std::size_t>(presetHistory.back()) != m_presetLoader->size() && !renderer->showmenu) { // if randomly browsing presets, "previous" should return to last random preset not the index--. Avoid returning to size() because that's the idle:// preset.
         presetFuture.push_back(m_presetPos->lastIndex());
         selectPreset(presetHistory.back());
         presetHistory.pop_back();
@@ -922,7 +922,7 @@ void projectM::selectNext(const bool hardCut) {
     if (isTextInputActive() && renderer->m_presetList.size() >= 1) // if search is active and there are search results
     {
         // if search menu is down, next is based on search terms.
-        if (renderer->m_activePresetID >= renderer->m_presetList.size()) {
+        if (static_cast<std::size_t>(renderer->m_activePresetID) >= renderer->m_presetList.size()) {
             // loop to top of page is at bottom
             renderer->m_activePresetID = 1;
             selectPresetByName(renderer->m_presetList[0].name,true);
@@ -931,7 +931,7 @@ void projectM::selectNext(const bool hardCut) {
             // otherwise move forward 
             selectPresetByName(renderer->m_presetList[renderer->m_activePresetID].name,true);
         }
-    } else if (settings().shuffleEnabled && presetFuture.size() >= 1 && presetFuture.front() != m_presetLoader->size() && !renderer->showmenu) { // if shuffling and we have future presets already stashed then let's go forward rather than truely move randomly.
+    } else if (settings().shuffleEnabled && presetFuture.size() >= 1 && static_cast<std::size_t>(presetFuture.front()) != m_presetLoader->size() && !renderer->showmenu) { // if shuffling and we have future presets already stashed then let's go forward rather than truely move randomly.
         presetHistory.push_back(m_presetPos->lastIndex());
         selectPreset(presetFuture.back());
         presetFuture.pop_back();

--- a/src/libprojectM/projectM.hpp
+++ b/src/libprojectM/projectM.hpp
@@ -294,13 +294,13 @@ public:
   }
 
   /// Occurs when active preset has switched. Switched to index is returned
-  virtual void presetSwitchedEvent(bool isHardCut, size_t index) const {};
-  virtual void shuffleEnabledValueChanged(bool isEnabled) const {};
-  virtual void presetSwitchFailedEvent(bool hardCut, unsigned int index, const std::string & message) const {};
+  virtual void presetSwitchedEvent(bool /*isHardCut*/, size_t /*index*/) const {};
+  virtual void shuffleEnabledValueChanged(bool /*isEnabled*/) const {};
+  virtual void presetSwitchFailedEvent(bool /*hardCut*/, unsigned int /*index*/, const std::string & /*message*/) const {};
 
 
   /// Occurs whenever preset rating has changed via changePresetRating() method
-  virtual void presetRatingChanged(unsigned int index, int rating, PresetRatingType ratingType) const {};
+  virtual void presetRatingChanged(unsigned int /*index*/, int /*rating*/, PresetRatingType /*ratingType*/) const {};
 
 
   inline PCM * pcm() {

--- a/src/libprojectM/projectM.hpp
+++ b/src/libprojectM/projectM.hpp
@@ -315,7 +315,7 @@ public:
   std::vector<int> presetFuture;  
 
   /// Get the preset index given a name
-	const unsigned int getSearchIndex(std::string &name) const;
+  unsigned int getSearchIndex(std::string &name) const;
 
   void selectPrevious(const bool);
   void selectNext(const bool);

--- a/src/projectM-jack/qprojectM-jack.cpp
+++ b/src/projectM-jack/qprojectM-jack.cpp
@@ -89,8 +89,8 @@ std::string read_config()
 {
 
    char num[512];
-   FILE *in;
-   FILE *out;
+   FILE *f_in;
+   FILE *f_out;
 
    char * home;
    char projectM_home[1024];
@@ -111,10 +111,10 @@ std::string read_config()
    projectM_home[strlen(home)+strlen("/.projectM/config.inp")]='\0';
 
 
- if ((in = fopen(projectM_home, "r")) != 0)
+ if ((f_in = fopen(projectM_home, "r")) != 0)
    {
      printf("reading ~/.projectM/config.inp \n");
-     fclose(in);
+     fclose(f_in);
      return std::string(projectM_home);
    }
  else
@@ -130,24 +130,24 @@ std::string read_config()
      strcpy(projectM_home+strlen(home), "/.projectM/config.inp");
      projectM_home[strlen(home)+strlen("/.projectM/config.inp")]='\0';
 
-     if((out = fopen(projectM_home,"w"))!=0)
+     if((f_out = fopen(projectM_home,"w"))!=0)
        {
 
-	 if ((in = fopen(projectM_config, "r")) != 0)
+	 if ((f_in = fopen(projectM_config, "r")) != 0)
 	   {
 
-	     while(fgets(num,80,in)!=NULL)
+	     while(fgets(num,80,f_in)!=NULL)
 	       {
-		 fputs(num,out);
+		 fputs(num,f_out);
 	       }
-	     fclose(in);
-	     fclose(out);
+	     fclose(f_in);
+	     fclose(f_out);
 
 
-	     if ((in = fopen(projectM_home, "r")) != 0)
+	     if ((f_in = fopen(projectM_home, "r")) != 0)
 	       {
 		 printf("created ~/.projectM/config.inp successfully\n");
-		 fclose(in);
+		 fclose(f_in);
 		 return std::string(projectM_home);
 	       }
 	     else{printf("This shouldn't happen, using implementation defaults\n");abort();}
@@ -157,9 +157,9 @@ std::string read_config()
      else
        {
 	 printf("Cannot create ~/.projectM/config.inp, using default config file\n");
-	 if ((in = fopen(projectM_config, "r")) != 0)
+	 if ((f_in = fopen(projectM_config, "r")) != 0)
 	   { printf("Successfully opened default config file\n");
-	     fclose(in);
+	     fclose(f_in);
 	     return std::string(projectM_config);}
 	 else{ printf("Using implementation defaults, your system is really messed up, I'm surprised we even got this far\n");  abort();}
 

--- a/src/projectM-jack/qprojectM-jack.cpp
+++ b/src/projectM-jack/qprojectM-jack.cpp
@@ -88,8 +88,6 @@ class ProjectMApplication : public QApplication {
 std::string read_config()
 {
 
-   int n;
-
    char num[512];
    FILE *in;
    FILE *out;
@@ -176,6 +174,7 @@ std::string read_config()
 int
 process (jack_nframes_t nframes, void *arg)
 {
+	Q_UNUSED(arg);
 
 	jack_default_audio_sample_t *in;
 
@@ -191,6 +190,7 @@ process (jack_nframes_t nframes, void *arg)
 
 void jack_shutdown (void *arg)
 {
+	Q_UNUSED(arg);
 	exit (1);
 }
 
@@ -201,7 +201,6 @@ int main (int argc, char **argv) {
 	jack_options_t options = JackNullOption;
 	jack_status_t status;
 	int i;
-	char projectM_data[1024];
 
 	// Start a new application
 	ProjectMApplication app(argc, argv);

--- a/src/projectM-pulseaudio/QPulseAudioDeviceModel.cpp
+++ b/src/projectM-pulseaudio/QPulseAudioDeviceModel.cpp
@@ -26,17 +26,17 @@
 #include <QMessageBox>
 #include <QHash>
 
-     QPulseAudioDeviceModel::QPulseAudioDeviceModel(const QHash<int, QString> & devices, const QHash<int,QString>::const_iterator & devicePosition, QObject * parent): _devices(devices), _devicePosition(devicePosition) {
-	
-     }
-     
-     void QPulseAudioDeviceModel::updateItemHighlights()
-     {
-	     if ( rowCount() == 0 )
-		     return;
+QPulseAudioDeviceModel::QPulseAudioDeviceModel(const QHash<int, QString> & devices, const QHash<int,QString>::const_iterator & devicePosition, QObject * parent): QAbstractListModel(parent), _devices(devices), _devicePosition(devicePosition) {
 
-	     emit ( dataChanged ( this->index (0), this->index ( rowCount()-1 ) ));			     
-     }
+}
+
+void QPulseAudioDeviceModel::updateItemHighlights()
+{
+	if ( rowCount() == 0 )
+		return;
+
+	emit ( dataChanged ( this->index (0), this->index ( rowCount()-1 ) ));
+}
 
 QVariant QPulseAudioDeviceModel::data ( const QModelIndex & index, int role = Qt::DisplayRole ) const
 {
@@ -82,8 +82,9 @@ QVariant QPulseAudioDeviceModel::data ( const QModelIndex & index, int role = Qt
 
 int QPulseAudioDeviceModel::rowCount ( const QModelIndex & parent) const
 {
-		
-		return _devices.count();
+	Q_UNUSED(parent);
+
+	return _devices.count();
 }
 
 

--- a/src/projectM-pulseaudio/QPulseAudioThread.cpp
+++ b/src/projectM-pulseaudio/QPulseAudioThread.cpp
@@ -714,7 +714,7 @@ void QPulseAudioThread::run()
 		fprintf ( stderr, "io_new() failed.\n" );
 		goto quit;
 	}
-/*
+*/
 	/* Create a new connection context */
 	if ( ! ( context = pa_context_new ( mainloop_api, client_name ) ) )
 	{

--- a/src/projectM-pulseaudio/QPulseAudioThread.cpp
+++ b/src/projectM-pulseaudio/QPulseAudioThread.cpp
@@ -770,8 +770,8 @@ void QPulseAudioThread::initialize_callbacks ( QPulseAudioThread * pulseThread )
 	//pa_context_set_drain
 	pa_context_set_subscribe_callback ( context, subscribe_callback, pulseThread );
 
-	if ( op = pa_context_subscribe ( context, ( enum pa_subscription_mask )
-	                                 PA_SUBSCRIPTION_MASK_SOURCE_OUTPUT, NULL, NULL ) )
+	if ( ( op = pa_context_subscribe ( context, ( enum pa_subscription_mask )
+	                                 PA_SUBSCRIPTION_MASK_SOURCE_OUTPUT, NULL, NULL ) ) )
 	{
 		pa_operation_unref ( op );
 	}

--- a/src/projectM-pulseaudio/QPulseAudioThread.cpp
+++ b/src/projectM-pulseaudio/QPulseAudioThread.cpp
@@ -256,7 +256,10 @@ case PA_STREAM_TERMINATED:// 	The stream has been terminated cleanly.
 
 
 void QPulseAudioThread::pa_stream_success_callback(pa_stream *s, int success, void * data) {
-	
+	Q_UNUSED(s);
+	Q_UNUSED(success);
+	Q_UNUSED(data);
+
 	static bool pausedFlag = true;
 	
 	if (pausedFlag)
@@ -303,6 +306,8 @@ void QPulseAudioThread::pulseQuit ( int ret )
 /* This is called whenever new data may is available */
 void QPulseAudioThread::stream_read_callback ( pa_stream *s, size_t length, void *userdata )
 {
+	Q_UNUSED(userdata);
+
 	const void *data;
 	assert ( s && length );
 
@@ -345,8 +350,8 @@ void QPulseAudioThread::stream_read_callback ( pa_stream *s, size_t length, void
 /* This routine is called whenever the stream state changes */
 void QPulseAudioThread::stream_state_callback ( pa_stream *s, void *userdata )
 {
+	Q_UNUSED(userdata);
 	assert ( s );
-	QPulseAudioThread * thread = (QPulseAudioThread *)userdata;
 
 	switch ( pa_stream_get_state ( s ) )
 	{
@@ -385,6 +390,7 @@ void QPulseAudioThread::stream_state_callback ( pa_stream *s, void *userdata )
 
 void QPulseAudioThread::stream_moved_callback(pa_stream *s, void *userdata) {
     Q_ASSERT(s);
+    Q_ASSERT(userdata);
 
     if (verbose)
         fprintf(stderr, "Stream moved to device %s (%u, %ssuspended).\n", pa_stream_get_device_name(s), pa_stream_get_device_index(s), pa_stream_is_suspended(s) ? "" : "not ");
@@ -404,8 +410,6 @@ void QPulseAudioThread::context_state_callback ( pa_context *c, void *userdata )
 
 		case PA_CONTEXT_READY:
 		{
-			int r;
-		
 			assert ( c && !stream );
 
 			if ( verbose )
@@ -446,13 +450,16 @@ fail:
 /* Connection draining complete */
 void QPulseAudioThread::context_drain_complete ( pa_context*c, void *userdata )
 {
+	Q_UNUSED(userdata);
 	pa_context_disconnect ( c );
 }
 
 /* Some data may be written to STDOUT */
 void QPulseAudioThread::stdout_callback ( pa_mainloop_api*a, pa_io_event *e, int fd, pa_io_event_flags_t f, void *userdata )
 {
-	
+	Q_UNUSED(fd);
+	Q_UNUSED(f);
+
 	assert ( a == mainloop_api && e && stdio_event == e );
 
 	if ( !buffer )
@@ -494,6 +501,11 @@ void QPulseAudioThread::stdout_callback ( pa_mainloop_api*a, pa_io_event *e, int
 /* UNIX signal to quit recieved */
 void QPulseAudioThread::exit_signal_callback ( pa_mainloop_api*m, pa_signal_event *e, int sig, void *userdata )
 {
+	Q_UNUSED(m);
+	Q_UNUSED(e);
+	Q_UNUSED(sig);
+	Q_UNUSED(userdata);
+
 	if ( verbose )
 		fprintf ( stderr, "Got signal, exiting.\n" );
 		
@@ -503,6 +515,8 @@ void QPulseAudioThread::exit_signal_callback ( pa_mainloop_api*m, pa_signal_even
 /* Show the current latency */
 void QPulseAudioThread::stream_update_timing_callback ( pa_stream *s, int success, void *userdata )
 {
+	Q_UNUSED(userdata);
+
 	pa_usec_t latency, usec;
 	int negative = 0;
 
@@ -525,6 +539,10 @@ void QPulseAudioThread::stream_update_timing_callback ( pa_stream *s, int succes
 /* Someone requested that the latency is shown */
 void QPulseAudioThread::sigusr1_signal_callback ( pa_mainloop_api*m, pa_signal_event *e, int sig, void *userdata )
 {
+	Q_UNUSED(m);
+	Q_UNUSED(e);
+	Q_UNUSED(sig);
+	Q_UNUSED(userdata);
 
 	if ( !stream )
 		return;
@@ -534,6 +552,7 @@ void QPulseAudioThread::sigusr1_signal_callback ( pa_mainloop_api*m, pa_signal_e
 
 void QPulseAudioThread::pa_source_info_callback ( pa_context *c, const pa_source_info *i, int eol, void *userdata )
 {
+	Q_UNUSED(c);
 
 	assert ( userdata );
 	QPulseAudioThread * pulseThread = ( QPulseAudioThread* ) userdata;
@@ -558,6 +577,7 @@ void QPulseAudioThread::pa_source_info_callback ( pa_context *c, const pa_source
 
 void QPulseAudioThread::subscribe_callback ( struct pa_context *c, enum pa_subscription_event_type t, uint32_t index, void *userdata )
 {
+	Q_UNUSED(c);
 
 	QPulseAudioThread * thread = static_cast<QPulseAudioThread *>(userdata);
 	switch ( t & PA_SUBSCRIPTION_EVENT_FACILITY_MASK )
@@ -606,6 +626,9 @@ void QPulseAudioThread::subscribe_callback ( struct pa_context *c, enum pa_subsc
 
 void QPulseAudioThread::time_event_callback ( pa_mainloop_api*m, pa_time_event *e, const struct timeval *tv, void *userdata )
 {
+	Q_UNUSED(tv);
+	Q_UNUSED(userdata);
+
 	struct timeval next;
 
 	if ( stream && pa_stream_get_state ( stream ) == PA_STREAM_READY )
@@ -626,10 +649,8 @@ void QPulseAudioThread::time_event_callback ( pa_mainloop_api*m, pa_time_event *
 void QPulseAudioThread::run()
 {
 
-	const char * error = "FOO";
-	int ret = 1, r, c;
+	int r;
 	const char *bn = "projectM";
-	pa_operation * operation ;
 	sample_spec.format = PA_SAMPLE_FLOAT32LE;
 	sample_spec.rate = 44100;
 	sample_spec.channels = 2;

--- a/src/projectM-pulseaudio/QPulseAudioThread.hpp
+++ b/src/projectM-pulseaudio/QPulseAudioThread.hpp
@@ -78,7 +78,6 @@ class QPulseAudioThread : public QThread
 		void threadCleanedUp();
 	private:
 	
-		QProjectM_MainWindow * m_qprojectM_MainWindow;
 		static SourceContainer::const_iterator readSettings();
 
 		static void reconnect(SourceContainer::const_iterator pos);
@@ -107,7 +106,8 @@ class QPulseAudioThread : public QThread
 		static SourceContainer s_sourceList;
 		static SourceContainer::const_iterator s_sourcePosition;
 		int argc;
-		char ** argv;	
+		char ** argv;
+		QProjectM_MainWindow * m_qprojectM_MainWindow;
 		static pa_context *context;
 		static pa_stream *stream;
 		static pa_mainloop_api *mainloop_api;

--- a/src/projectM-pulseaudio/qprojectM-pulseaudio.cpp
+++ b/src/projectM-pulseaudio/qprojectM-pulseaudio.cpp
@@ -111,9 +111,6 @@ int main ( int argc, char*argv[] )
 {
 //	if (!TestRunner::run()) exit(1);
 
-	int i;
-	char projectM_data[1024];
-
 	ProjectMApplication app ( argc, argv );
 
 	std::string config_file;

--- a/src/projectM-qt/qplaylistmodel.cpp
+++ b/src/projectM-qt/qplaylistmodel.cpp
@@ -303,11 +303,12 @@ QVariant QPlaylistModel::headerData ( int section, Qt::Orientation orientation, 
 		return QString ( tr ( "Preset" ) );
 
 	/// @bug hack. this should be formalized like it is in libprojectM.
-	if ( ( section == 1 ) && ( role == Qt::DisplayRole ))
+	if ( ( section == 1 ) && ( role == Qt::DisplayRole )) {
 		if (columnCount() == 2)
 			return QString ( tr ( "Rating" ) );
 		else
 			return QString ( tr ( "Hard Rating" ) );
+    }
 	if ( ( section == 2 ) && ( role == Qt::DisplayRole ) )
 		return QString ( tr ( "Soft Rating" ) );
 

--- a/src/projectM-qt/qplaylistmodel.cpp
+++ b/src/projectM-qt/qplaylistmodel.cpp
@@ -249,44 +249,45 @@ QVariant QPlaylistModel::data ( const QModelIndex & index, int role = Qt::Displa
 		return QVariant();
 	
 	unsigned int pos;
-	
+	const int rowidx = index.row();
+
 	switch ( role )
 	{
 		case Qt::DisplayRole:
 			if ( index.column() == 0 )
-				return QVariant ( QString ( m_projectM.getPresetName ( index.row() ).c_str() ) );
+				return QVariant ( QString ( m_projectM.getPresetName ( rowidx ).c_str() ) );
 			else if (index.column() == 1)
-				return ratingToIcon ( m_projectM.getPresetRating(index.row(), HARD_CUT_RATING_TYPE) );
+				return ratingToIcon ( m_projectM.getPresetRating(rowidx, HARD_CUT_RATING_TYPE) );
 			else
-				return ratingToIcon ( m_projectM.getPresetRating(index.row(), SOFT_CUT_RATING_TYPE) );
+				return ratingToIcon ( m_projectM.getPresetRating(rowidx, SOFT_CUT_RATING_TYPE) );
 		case Qt::ToolTipRole:
 			if ( index.column() == 0 )
-				return QVariant ( QString ( m_projectM.getPresetName ( index.row() ).c_str() ) );
+				return QVariant ( QString ( m_projectM.getPresetName ( rowidx ).c_str() ) );
 			else if (index.column() == 1)
-				return QString ( getSillyRatingToolTip(m_projectM.getPresetRating(index.row(), HARD_CUT_RATING_TYPE)));
-			else return 		getBreedabilityToolTip(m_projectM.getPresetRating(index.row(), SOFT_CUT_RATING_TYPE));
+				return QString ( getSillyRatingToolTip(m_projectM.getPresetRating(rowidx, HARD_CUT_RATING_TYPE)));
+			else return 		getBreedabilityToolTip(m_projectM.getPresetRating(rowidx, SOFT_CUT_RATING_TYPE));
 		case Qt::DecorationRole:
 			if ( index.column() == 1 )
-				return ratingToIcon ( m_projectM.getPresetRating(index.row(), HARD_CUT_RATING_TYPE) );
+				return ratingToIcon ( m_projectM.getPresetRating(rowidx, HARD_CUT_RATING_TYPE) );
 			else if (index.column() == 2)
-				return breedabilityToIcon ( m_projectM.getPresetRating(index.row(), SOFT_CUT_RATING_TYPE) );
+				return breedabilityToIcon ( m_projectM.getPresetRating(rowidx, SOFT_CUT_RATING_TYPE) );
 			else
 				return QVariant();
 		case QPlaylistModel::RatingRole:
-			return QVariant (  m_projectM.getPresetRating(index.row(), HARD_CUT_RATING_TYPE)  );
+			return QVariant (  m_projectM.getPresetRating(rowidx, HARD_CUT_RATING_TYPE)  );
 		case QPlaylistModel::BreedabilityRole:
-			return QVariant (  m_projectM.getPresetRating(index.row(), SOFT_CUT_RATING_TYPE)  );
+			return QVariant (  m_projectM.getPresetRating(rowidx, SOFT_CUT_RATING_TYPE)  );
 		case Qt::BackgroundRole:
 	
 			if (!m_projectM.selectedPresetIndex(pos))
-				return QVariant();						
-			if (m_projectM.isPresetLocked() && ( index.row() == pos ) )
-                return QColor(Qt::red);
-			if (!m_projectM.isPresetLocked() && ( index.row() == pos ) )
-                return QColor(Qt::green);
+				return QVariant();
+			if (m_projectM.isPresetLocked() && rowidx >= 0 && static_cast<unsigned int>(rowidx) == pos )
+				return QColor(Qt::red);
+			if (!m_projectM.isPresetLocked() && rowidx >= 0 && static_cast<unsigned int>(rowidx) == pos )
+				return QColor(Qt::green);
 			return QVariant();
 		case QPlaylistModel::URLInfoRole:
-			return QVariant ( QString ( m_projectM.getPresetURL ( index.row() ).c_str() ) );
+			return QVariant ( QString ( m_projectM.getPresetURL ( rowidx ).c_str() ) );
 		default:
 			
 			return QVariant();

--- a/src/projectM-qt/qplaylistmodel.cpp
+++ b/src/projectM-qt/qplaylistmodel.cpp
@@ -61,6 +61,7 @@ class XmlWriteFunctor {
 		}
 
 		inline bool nextItem(QString & name, QString & url, int & rating, int & breedability) {
+			Q_UNUSED(name);
 
 			if (m_index >= m_model.rowCount())
 				return false;
@@ -131,6 +132,8 @@ Qt::ItemFlags QPlaylistModel::flags(const QModelIndex &index) const
  bool QPlaylistModel::dropMimeData(const QMimeData *data, Qt::DropAction action,
 				int row, int column, const QModelIndex &parent)
 {
+	Q_UNUSED(row);
+	Q_UNUSED(parent);
 	if (!data->hasFormat(PRESET_MIME_TYPE))
 		return false;
 
@@ -312,12 +315,16 @@ QVariant QPlaylistModel::headerData ( int section, Qt::Orientation orientation, 
 
 int QPlaylistModel::rowCount ( const QModelIndex & parent ) const
 {
+	Q_UNUSED(parent);
+
 	return m_projectM.getPlaylistSize();
 }
 
 
 int QPlaylistModel::columnCount ( const QModelIndex & parent ) const
 {
+	Q_UNUSED(parent);
+
 	return softCutRatingsEnabled() ? 3 : 2;
 }
 
@@ -343,6 +350,7 @@ void QPlaylistModel::insertRow (int index, const QString & presetURL, const QStr
 }
 
 bool QPlaylistModel::removeRows ( int row, int count, const QModelIndex & parent)   {
+	Q_UNUSED(parent);
 	
 	beginRemoveRows ( QModelIndex(), row, count);
 
@@ -355,6 +363,8 @@ bool QPlaylistModel::removeRows ( int row, int count, const QModelIndex & parent
 
 bool QPlaylistModel::removeRow ( int index, const QModelIndex & parent)
 {
+	Q_UNUSED(parent);
+
 	beginRemoveRows ( QModelIndex(), index, index );
 	m_projectM.removePreset ( index );	
 	endRemoveRows();

--- a/src/projectM-qt/qplaylisttableview.hpp
+++ b/src/projectM-qt/qplaylisttableview.hpp
@@ -110,7 +110,7 @@ class QPlaylistTableView : public QTableView
 			emit(mousePressed(event, selectedIndexes()));
 		}
 		else
-				;
+		{}
 	 }
 	 
 	inline void keyReleaseEvent(QKeyEvent * event) {

--- a/src/projectM-qt/qplaylisttableview.hpp
+++ b/src/projectM-qt/qplaylisttableview.hpp
@@ -83,6 +83,7 @@ class QPlaylistTableView : public QTableView
     
 	 
 	 void dragLeaveEvent ( QDragLeaveEvent * event )  {
+		Q_UNUSED(event);
 		 //qDebug() << "drag leave";
 	 }
 	 

--- a/src/projectM-qt/qprojectm_mainwindow.cpp
+++ b/src/projectM-qt/qprojectm_mainwindow.cpp
@@ -108,7 +108,7 @@ m_QPlaylistFileDialog( new QPlaylistFileDialog ( this ))
 
 	//connect(this, SIGNAL(dockLocationChanged ( Qt::DockWidgetArea)), SLOT(dockLocationChanged(Qt::DockWidgetArea)));
 	if (!m_QProjectMWidget->isValid()) {
-		int ret = QMessageBox::warning(this, tr("projectM cannot be started."),
+		QMessageBox::warning(this, tr("projectM cannot be started."),
 					       tr("Your graphics driver or configuration is not supported by projectM. Please contact the developers (carmelo.piccione+projectM@gmail.com or psperl+projectM@gmail.com) with your card and driver information so we can help you get it working."),
 			      QMessageBox::Ok);
 		exit(-1);
@@ -659,6 +659,7 @@ void QProjectM_MainWindow::keyReleaseEvent ( QKeyEvent * e )
 
 
 void QProjectM_MainWindow::refreshHeaders(QResizeEvent * event) {
+	Q_UNUSED(event);
 
 
     hHeader->setSectionResizeMode ( 0, QHeaderView::Fixed);
@@ -1292,6 +1293,7 @@ void QProjectM_MainWindow::updateFilteredPlaylist ( const QString & text )
 
 void QProjectM_MainWindow::presetRatingChanged( unsigned int index, int rating, PresetRatingType ratingType)
 {
+	Q_UNUSED(ratingType);
 
 	PlaylistItemVector & lastCache =  *historyHash[previousFilter];
 	const long id = lastCache[index];
@@ -1307,6 +1309,7 @@ void QProjectM_MainWindow::presetRatingChanged( unsigned int index, int rating, 
 
 void QProjectM_MainWindow::handleFailedPresetSwitch(const bool isHardCut, const unsigned int index,
 		const QString & message) {
+	Q_UNUSED(isHardCut);
 
 	qDebug() << "handleFailedPresetSwitch";
 	const QString status = QString("Error switching to preset index %1 (%2)")
@@ -1318,14 +1321,16 @@ void QProjectM_MainWindow::handleFailedPresetSwitch(const bool isHardCut, const 
 
 bool QProjectM_MainWindow::eventFilter(QObject *obj, QEvent *event)
 {
-	    if (event->type() == QEvent::MouseButtonDblClick && ((QMouseEvent*)event)->button() == Qt::LeftButton) {
-			    this->setWindowState ( this->windowState() ^ Qt::WindowFullScreen );
-			    return true;
-		} else if (event->type() == QEvent::MouseButtonPress && ((QMouseEvent*)event)->button() == Qt::RightButton) {
-			    setMenuVisible(!_menuVisible);
-				refreshHeaders();
-				return true;
-		} else {
-			    return false;
-		}
+    Q_UNUSED(obj);
+
+	if (event->type() == QEvent::MouseButtonDblClick && ((QMouseEvent*)event)->button() == Qt::LeftButton) {
+		this->setWindowState ( this->windowState() ^ Qt::WindowFullScreen );
+		return true;
+	} else if (event->type() == QEvent::MouseButtonPress && ((QMouseEvent*)event)->button() == Qt::RightButton) {
+		setMenuVisible(!_menuVisible);
+		refreshHeaders();
+		return true;
+	} else {
+		return false;
+	}
 }

--- a/src/projectM-qt/qprojectm_mainwindow.cpp
+++ b/src/projectM-qt/qprojectm_mainwindow.cpp
@@ -1232,7 +1232,7 @@ void QProjectM_MainWindow::updateFilteredPlaylist ( const QString & text )
 	} else if (presetSelected) {
 		const PlaylistItemVector & oldPlaylistItems = *historyHash.value(previousFilter);
 
-		if ((presetIndexBackup >=0) && (presetIndexBackup < oldPlaylistItems.size())) {
+		if (presetIndexBackup < static_cast<std::size_t>(oldPlaylistItems.size())) {
 			activePresetId = oldPlaylistItems[presetIndexBackup];
 		}
 

--- a/src/projectM-qt/qprojectm_mainwindow.cpp
+++ b/src/projectM-qt/qprojectm_mainwindow.cpp
@@ -74,10 +74,10 @@ class PlaylistWriteFunctor {
 };
 
 QProjectM_MainWindow::QProjectM_MainWindow ( const std::string & config_file, QMutex * audioMutex)
-		:m_QPresetFileDialog ( new QPresetFileDialog ( this ) ), ui(0), m_QPlaylistFileDialog
-		( new QPlaylistFileDialog ( this )), playlistModel(0),
-		configDialog(0), hHeader(0), vHeader(0), _menuVisible(true), _menuAndStatusBarsVisible(true),
-activePresetIndex(new Nullable<long>), playlistItemCounter(0), m_QPresetEditorDialog(0)
+		:playlistItemCounter(0), m_QPresetEditorDialog(0), hHeader(0), vHeader(0), playlistModel(0),
+		ui(0), configDialog(0), activePresetIndex(new Nullable<long>), _menuVisible(true),
+		_menuAndStatusBarsVisible(true), m_QPresetFileDialog ( new QPresetFileDialog ( this ) ),
+m_QPlaylistFileDialog( new QPlaylistFileDialog ( this ))
 {
 	qInitResources();
 

--- a/src/projectM-qt/qprojectm_mainwindow.cpp
+++ b/src/projectM-qt/qprojectm_mainwindow.cpp
@@ -548,6 +548,7 @@ void QProjectM_MainWindow::keyReleaseEvent ( QKeyEvent * e )
 					openPresetEditorDialog(historyHash[previousFilter]->indexOf(activePresetIndex->value()));
 			} else
 				e->ignore();
+			return;
 		case Qt::Key_L:
 
 			if (!(e->modifiers() & Qt::ControlModifier)) {

--- a/src/projectM-qt/qprojectmconfigdialog.cpp
+++ b/src/projectM-qt/qprojectmconfigdialog.cpp
@@ -25,7 +25,7 @@
 #include <QSettings>
 #include "qprojectmwidget.hpp"
 
-QProjectMConfigDialog::QProjectMConfigDialog(const std::string & configFile, QProjectMWidget * qprojectMWidget, QWidget * parent, Qt::WindowFlags f) : QDialog(parent, f), _configFile(configFile), _qprojectMWidget(qprojectMWidget), _settings("projectM", "qprojectM") {
+QProjectMConfigDialog::QProjectMConfigDialog(const std::string & configFile, QProjectMWidget * qprojectMWidget, QWidget * parent, Qt::WindowFlags f) : QDialog(parent, f), _settings("projectM", "qprojectM"), _configFile(configFile), _qprojectMWidget(qprojectMWidget) {
 
 
 	_ui.setupUi(this);

--- a/src/projectM-qt/qprojectmwidget.hpp
+++ b/src/projectM-qt/qprojectmwidget.hpp
@@ -94,6 +94,7 @@ class QProjectMWidget : public QGLWidget
 	protected slots:
 		inline void mouseMoveEvent ( QMouseEvent * event )
 		{
+			Q_UNUSED(event);
 
 			m_mouseTimer->stop();
 			QApplication::restoreOverrideCursor();
@@ -104,6 +105,7 @@ class QProjectMWidget : public QGLWidget
 
 		inline void leaveEvent ( QEvent * event )
 		{
+			Q_UNUSED(event);
 			/// @bug testing if this resolves a bug for ubuntu users
 			QApplication::restoreOverrideCursor();
 		}
@@ -152,6 +154,8 @@ class QProjectMWidget : public QGLWidget
 
 		void mousePressEvent ( QMouseEvent * event )
 		{
+			Q_UNUSED(event);
+
 			this->setFocus();
 		}
 

--- a/src/projectM-qt/qprojectmwidget.hpp
+++ b/src/projectM-qt/qprojectmwidget.hpp
@@ -40,7 +40,7 @@ class QProjectMWidget : public QGLWidget
 	public:
 		static const int MOUSE_VISIBLE_TIMEOUT_MS = 5000;
 		QProjectMWidget ( const std::string & config_file, QWidget * parent, QMutex * audioMutex = 0 )
-				: QGLWidget ( parent ), m_config_file ( config_file ), m_projectM ( 0 ), m_audioMutex ( audioMutex ), m_mouseTimer ( 0 )
+				: QGLWidget ( parent ), m_config_file ( config_file ), m_projectM ( 0 ), m_mouseTimer ( 0 ), m_audioMutex ( audioMutex )
 		{
 
 			m_mouseTimer = new QTimer ( this );

--- a/src/projectM-qt/qprojectmwidget.hpp
+++ b/src/projectM-qt/qprojectmwidget.hpp
@@ -248,7 +248,7 @@ class QProjectMWidget : public QGLWidget
 					e->ignore();
 					return;
 			}
-			projectMModifier modifier;
+			projectMModifier modifier = PROJECTM_KMOD_NONE;
 
 			m_projectM->key_handler ( PROJECTM_KEYDOWN, pkey, modifier );
 			if ( ignore )

--- a/src/projectM-qt/qxmlplaylisthandler.hpp
+++ b/src/projectM-qt/qxmlplaylisthandler.hpp
@@ -103,7 +103,8 @@ template <class ReadFunctor>
 QXmlStreamReader::Error QXmlPlaylistHandler::readPlaylistItem(QXmlStreamReader & reader, ReadFunctor & readFunctor) {
 
 	QString url, name;
-	int rating, breedability;
+	int rating = 3;
+	int breedability = 3;
 
 	while (reader.readNext() != QXmlStreamReader::EndElement)
 		if (reader.name() == "url") {

--- a/src/projectM-qt/qxmlplaylisthandler.hpp
+++ b/src/projectM-qt/qxmlplaylisthandler.hpp
@@ -110,7 +110,7 @@ QXmlStreamReader::Error QXmlPlaylistHandler::readPlaylistItem(QXmlStreamReader &
 			bool repeat;
 			int result;
 
-			while (repeat = (result = reader.readNext()) == QXmlStreamReader::Characters) 	
+			while ((repeat = (result = reader.readNext()) == QXmlStreamReader::Characters))
 				url += reader.text().toString();			
 						
 		} else if (reader.name() == "rating") {
@@ -125,7 +125,7 @@ QXmlStreamReader::Error QXmlPlaylistHandler::readPlaylistItem(QXmlStreamReader &
 			bool repeat;
 			int result;
 
-			while (repeat = (result = reader.readNext()) == QXmlStreamReader::Characters)	
+			while ((repeat = (result = reader.readNext()) == QXmlStreamReader::Characters))
 				name += reader.text().toString();
 		} else {
 			if (reader.name() == "")

--- a/src/projectM-sdl/pmSDL.cpp
+++ b/src/projectM-sdl/pmSDL.cpp
@@ -153,7 +153,6 @@ int projectMSDL::openAudioInput() {
 #endif
     
     // get audio input device
-    unsigned int i;
     NumAudioDevices = SDL_GetNumAudioDevices(true);  // capture, please
 
     CurAudioDevice = 0;
@@ -164,7 +163,7 @@ int projectMSDL::openAudioInput() {
         return 0;
     }
 #ifdef DEBUG
-    for (i = 0; i < NumAudioDevices; i++) {
+    for (unsigned int i = 0; i < NumAudioDevices; i++) {
         SDL_Log("Found audio capture device %d: %s", i, SDL_GetAudioDeviceName(i, true));
     }
 #endif


### PR DESCRIPTION
This fixes almost all warnings in the codebase when compiling on Linux under gcc 9.3.

Only one I couldn't figure out, which is possibly a false compiler warning, is
```
qprojectm_mainwindow.cpp: In member function ‘void QProjectM_MainWindow::updateFilteredPlaylist(const QString&)’:
qprojectm_mainwindow.cpp:1258:68: warning: ‘activePresetId’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 1258 |    if (activePresetId.hasValue() && data.id == activePresetId.value()) {
      |                                                ~~~~~~~~~~~~~~~~~~~~^~
```

It complains about `activePresetId` being uninitialized, however it's a class instance and the default constructor is called.
`activePresetId.value()` above won't be called if it's never been assigned (as `hasValue()` only returns true if `operator=` has been called).