### PR TITLE
parse completely empty line

### DIFF
--- a/src/libprojectM/MilkdropPresetFactory/Parser.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/Parser.cpp
@@ -844,14 +844,13 @@ Expr * Parser::_parse_gen_expr ( std::istream &  fs, TreeExpr * tree_expr, Milkd
     if (*string == 0)
     {
       if (PARSE_DEBUG) printf("parse_gen_expr: empty string coupled with terminal (LINE %d) \n", line_count);
-			if (nullptr == tree_expr )
-			{
-				// we will get here if we have a completely empty line e.g. "shape_1_per_frame1=shpt ="
-				// should we return 0 or generate an error?
-				return Expr::const_to_expr(0.0f);
-			}
+      if (nullptr == tree_expr && (token==tEOF||token==tEOL))
+      {
+        // we will get here if we have a completely empty line e.g. "shape_1_per_frame1=shpt ="
+        // we return 0 because returning NULL would indicate an error
+        return Expr::const_to_expr(0.0f);
+      }
       return parse_infix_op(fs, token, tree_expr, preset);
-
     }
 
   default:
@@ -2674,8 +2673,16 @@ public:
         TEST(eval_expr(-1.0f, "-(1.0)"));         // unary`
         TEST(eval_expr(0.5f, "5/10.000"));        // binary
         TEST(eval_expr(1.0f, "sin(3.14159/2)"));
-        preset->presetOutputs().rot = 0.99f;
+				// emtpy expression evals to 0, NULL usually means error in this parser
+				TEST(eval_expr(0.0f, ""));
+				TEST(eval_expr(0.0f, " "));
+				TEST(eval_expr(0.0f, "\n"));
+				TEST(eval_expr(0.0f, " \n"));
+				preset->presetOutputs().rot = 0.99f;
         TEST(eval_expr(0.99f, "rot"));
+
+				// random other stuff to parse
+				Parser::parse_gen_expr(ss("0.5 + 0.5*sin(q8*0.613 + 1);"),nullptr,preset);
         return true;
     }
 

--- a/src/libprojectM/MilkdropPresetFactory/Parser.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/Parser.cpp
@@ -844,6 +844,12 @@ Expr * Parser::_parse_gen_expr ( std::istream &  fs, TreeExpr * tree_expr, Milkd
     if (*string == 0)
     {
       if (PARSE_DEBUG) printf("parse_gen_expr: empty string coupled with terminal (LINE %d) \n", line_count);
+			if (nullptr == tree_expr )
+			{
+				// we will get here if we have a completely empty line e.g. "shape_1_per_frame1=shpt ="
+				// should we return 0 or generate an error?
+				return Expr::const_to_expr(0.0f);
+			}
       return parse_infix_op(fs, token, tree_expr, preset);
 
     }


### PR DESCRIPTION
parse completely empty line e.g.

```shape_1_per_frame1=shpt =```

seems to address https://github.com/projectM-visualizer/projectm/issues/407