### PR TITLE
Made it possible to do decimal duration times between transitions.

### DIFF
--- a/src/libprojectM/TimeKeeper.hpp
+++ b/src/libprojectM/TimeKeeper.hpp
@@ -42,6 +42,8 @@ public:
 
   void ChangeHardcutDuration(int seconds) { _hardcutDuration = seconds; }
   void ChangePresetDuration(int seconds) { _presetDuration = seconds; }
+  void ChangeHardcutDuration(double seconds) { _hardcutDuration = seconds; }
+  void ChangePresetDuration(double seconds) { _presetDuration = seconds; }
 
 #ifndef WIN32
   /* The first ticks value of the application */

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -175,9 +175,9 @@ void projectM::readConfig (const std::string & configFile)
     _settings.fps = config.read<int> ( "FPS", 35 );
     _settings.windowWidth  = config.read<int> ( "Window Width", 512 );
     _settings.windowHeight = config.read<int> ( "Window Height", 512 );
-    _settings.smoothPresetDuration =  config.read<int>
+    _settings.smoothPresetDuration =  config.read<double>
             ( "Smooth Preset Duration", config.read<int>("Smooth Transition Duration", 10));
-    _settings.presetDuration = config.read<int> ( "Preset Duration", 15 );
+    _settings.presetDuration = config.read<double> ( "Preset Duration", 15 );
 
 #ifdef __unix__
     _settings.presetURL = config.read<string> ( "Preset Path", "/usr/local/share/projectM/presets" );
@@ -223,7 +223,7 @@ void projectM::readConfig (const std::string & configFile)
     // Hard Cuts are preset transitions that occur when your music becomes louder. They only occur after a hard cut duration threshold has passed.
     _settings.hardcutEnabled = config.read<bool> ( "Hard Cuts Enabled", false );
     // Hard Cut duration is the number of seconds before you become eligible for a hard cut.
-    _settings.hardcutDuration = config.read<int> ( "Hard Cut Duration", 60 );
+    _settings.hardcutDuration = config.read<double> ( "Hard Cut Duration", 60 );
     // Hard Cut sensitivity is the volume difference before a "hard cut" is triggered.
     _settings.hardcutSensitivity = config.read<float> ( "Hard Cut Sensitivity", 1.0 );
     
@@ -1116,10 +1116,18 @@ void projectM::changeTextureSize(int size) {
                             _settings.titleFontURL, _settings.menuFontURL,
                             _settings.datadir);
 }
+
 void projectM::changeHardcutDuration(int seconds) {
     timeKeeper->ChangeHardcutDuration(seconds);
 }
 void projectM::changePresetDuration(int seconds) {
+    timeKeeper->ChangePresetDuration(seconds);
+}
+
+void projectM::changeHardcutDuration(double seconds) {
+    timeKeeper->ChangeHardcutDuration(seconds);
+}
+void projectM::changePresetDuration(double seconds) {
     timeKeeper->ChangePresetDuration(seconds);
 }
 void projectM::getMeshSize(int *w, int *h)	{

--- a/src/libprojectM/projectM.hpp
+++ b/src/libprojectM/projectM.hpp
@@ -133,8 +133,8 @@ public:
         std::string titleFontURL;
         std::string menuFontURL;
         std::string datadir;
-        int smoothPresetDuration;
-        int presetDuration;
+        double smoothPresetDuration;
+        double presetDuration;
         bool hardcutEnabled;
         int hardcutDuration;
         float hardcutSensitivity;
@@ -151,8 +151,8 @@ public:
             textureSize(512),
             windowWidth(512),
             windowHeight(512),
-            smoothPresetDuration(10),
-            presetDuration(15),
+            smoothPresetDuration(10.0),
+            presetDuration(15.0),
             hardcutEnabled(false),
             hardcutDuration(60),
             hardcutSensitivity(2.0),
@@ -181,7 +181,9 @@ public:
 
   void changeTextureSize(int size);
   void changeHardcutDuration(int seconds);
+  void changeHardcutDuration(double seconds);
   void changePresetDuration(int seconds);
+  void changePresetDuration(double seconds);
   void getMeshSize(int *w, int *h);
   void touch(float x, float y, int pressure, int touchtype);
   void touchDrag(float x, float y, int pressure);


### PR DESCRIPTION
…Duration

to be Double precision numbers instead of /as well as integers.
This will allow more complex transitions, such as transitions on measure
detect or 4 beat detects for example.
Forsing this to generte youtube videos, it would be good for the transitions to happen precisely when measures or stances in the music change.