### PR TITLE
This work fixes a problem where GL 3.30 was being chosen for

### DIFF
--- a/src/libprojectM/Renderer/StaticGlShaders.h
+++ b/src/libprojectM/Renderer/StaticGlShaders.h
@@ -16,7 +16,6 @@ class StaticGlShaders {
 
         static std::shared_ptr<StaticGlShaders> instance(
             new StaticGlShaders(use_gles));
-
         return instance;
     }
 
@@ -44,14 +43,17 @@ class StaticGlShaders {
         int major, minor;
     };
 
-    // Constructs a StaticGlShaders, overriding the version to GLES3 if
-    // `use_gles` is true.
-    StaticGlShaders(bool use_gles);
-
     // Queries the system GLSL version using
     // `glGetString(GL_SHADING_LANGUAGE_VERSION)` and returns the major and
     // minor numbers.
     GlslVersion QueryGlslVersion();
+
+    // Constructs a StaticGlShaders, overriding the version to GLES3 if
+    // `use_gles` is true.
+    // Note - this happens after GlslVersion is called, because it uses the 
+    // version to determine things.
+    StaticGlShaders(bool use_gles);
+
 
     // Prepends a string of the form "#version <number>\n" to the provided
     // shader text, where <number> is derived from the queried GLSL version (or

--- a/src/libprojectM/Renderer/hlslparser/src/GLSLGenerator.cpp
+++ b/src/libprojectM/Renderer/hlslparser/src/GLSLGenerator.cpp
@@ -114,7 +114,12 @@ GLSLGenerator::GLSLGenerator() :
     m_tree                      = NULL;
     m_entryName                 = NULL;
     m_target                    = Target_VertexShader;
+#ifdef USE_GLES
+    m_version                   = Version_300_ES;
+#else
     m_version                   = Version_330;
+#endif
+	
     m_versionLegacy             = false;
     m_inAttribPrefix            = NULL;
     m_outAttribPrefix           = NULL;
@@ -233,7 +238,7 @@ bool GLSLGenerator::Generate(HLSLTree* tree, Target target, Version version, con
         m_writer.WriteLine(0, "precision highp float;");
     }
     else if (m_version == Version_300_ES)
-    {
+    {  
         m_writer.WriteLine(0, "#version 300 es");
         m_writer.WriteLine(0, "precision highp float;");
         m_writer.WriteLine(0, "precision highp sampler3D;");


### PR DESCRIPTION
GLES 2.0 mode. GLES needs Version 3.00 ES.

This was done by switching the order of how a StaticGl Shader is constructed,
And there is additional code that properly sets up the GLSLGenerator for GLES mode.

My hardware hat had the problem GL stats:GL_VERSION  : OpenGL ES 3.1 Mesa 20.2.6

GL_RENDERER : Mesa DRI Intel(R) HD Graphics 4600 (HSW GT2)

g1

GPU: Vendor:   Intel Open Source Technology Center
GPU: Renderer: Mesa DRI Intel(R) HD Graphics 4600 (HSW GT2)
GPU: Version:  OpenGL ES 3.1 Mesa 20.2.6
GPU: GLSL:     OpenGL ES GLSL ES 3.10
[EXTENSION] VAO extension not found, VAO usage not supported
[EXTENSION] NPOT textures extension detected, full NPOT textures supported
[EXTENSION] DXT compressed textures supported
[EXTENSION] ETC1 compressed textures supported
[EXTENSION] Anisotropic textures filtering supported (max: 16X)
[CPU] Default buffers initialized successfully quads)
[VBO ID 1][VBO ID 2][VBO ID 3][VBO ID 4] Default buffers VBOs initialized successfully (quads)
OpenGL default states initialized successfully



It caused errors comiling 3.30 GL, because it needed 3.00 GLES.
