### PR TITLE
Added missing return statement in processLoopbackFrame() of the projectM SDL app.

### DIFF
--- a/src/projectM-sdl/loopback.cpp
+++ b/src/projectM-sdl/loopback.cpp
@@ -224,5 +224,6 @@ bool processLoopbackFrame(projectMSDL *app) {
         }
     }
 #endif /** WASAPI_LOOPBACK */
-    
+
+    return true;
 }


### PR DESCRIPTION
The missing return leads to a stack corruption, in turn crashing the SDL visualizer on some platforms in optimized builds.

The crashes have great similarity to those reported in issue #427 (segfault/aborts in std::string destructors), yet this issue was opened before the refactoring that possibly introduced the error, so might have a different reason.