### PR TITLE
Fixed a few memory management issues with presets.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,65 +1,66 @@
----
-Language:        Cpp
-# BasedOnStyle:  LLVM
-AccessModifierOffset: -2
-AlignAfterOpenBracket: false
-AlignEscapedNewlinesLeft: true
-AlignOperands:   true
-AlignTrailingComments: true
-AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: false
-AllowShortCaseLabelsOnASingleLine: true
-AllowShortIfStatementsOnASingleLine: true
+# Generated from CLion C/C++ Code Style settings
+BasedOnStyle: LLVM
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: None
+AlignOperands: Align
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Always
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
 AllowShortLoopsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: Inline
-AlwaysBreakAfterDefinitionReturnType: false
-AlwaysBreakTemplateDeclarations: true
-AlwaysBreakBeforeMultilineStrings: true
-BreakBeforeBinaryOperators: NonAssignment
+AlwaysBreakAfterReturnType: None
+AlwaysBreakTemplateDeclarations: Yes
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: false
+  AfterUnion: true
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+BreakBeforeBinaryOperators: None
 BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
-BinPackParameters: true
-BinPackArguments: true
-ColumnLimit:     100
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
-ConstructorInitializerIndentWidth: 4
-DerivePointerAlignment: false
-ExperimentalAutoDetectBinPacking: false
+BreakConstructorInitializers: BeforeComma
+BreakInheritanceList: BeforeColon
+ColumnLimit: 0
+CompactNamespaces: false
+ContinuationIndentWidth: 4
 IndentCaseLabels: true
-IndentWrappedFunctionNames: false
-IndentFunctionDeclarationAfterType: false
-MaxEmptyLinesToKeep: 1
+IndentPPDirectives: None
+IndentWidth: 4
 KeepEmptyLinesAtTheStartOfBlocks: true
+MaxEmptyLinesToKeep: 2
 NamespaceIndentation: None
-ObjCBlockIndentWidth: 2
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
-PenaltyBreakBeforeFirstCallParameter: 19
-PenaltyBreakComment: 300
-PenaltyBreakString: 1000
-PenaltyBreakFirstLessLess: 120
-PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 60
-PointerAlignment: Right
-SpacesBeforeTrailingComments: 1
-Cpp11BracedListStyle: true
-Standard:        Cpp11
-IndentWidth:     2
-TabWidth:        2
-UseTab:          Always
-BreakBeforeBraces: Allman
+PointerAlignment: Left
+ReflowComments: false
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 0
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-SpacesInAngles:  false
-SpaceInEmptyParentheses: false
-SpacesInCStyleCastParentheses: false
-SpaceAfterCStyleCast: false
-SpacesInContainerLiterals: true
-SpaceBeforeAssignmentOperators: true
-ContinuationIndentWidth: 2
-CommentPragmas:  '^ IWYU pragma:'
-ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
-SpaceBeforeParens: ControlStatements
-DisableFormat:   false
-SortIncludes: false
-...
+TabWidth: 4
+UseTab: Never

--- a/src/libprojectM/MilkdropPresetFactory/BuiltinParams.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/BuiltinParams.cpp
@@ -13,10 +13,10 @@ BuiltinParams::BuiltinParams()
 {
 }
 
-BuiltinParams::BuiltinParams(PresetInputs& presetInputs, PresetOutputs& presetOutputs)
+BuiltinParams::BuiltinParams(PresetInputs& presetInputs, PresetOutputs* presetOutputs)
 {
 
-    presetInputs.Initialize(presetOutputs.gx, presetOutputs.gy);
+    presetInputs.Initialize(presetOutputs->gx, presetOutputs->gy);
 
     int ret;
     if ((ret = init_builtin_param_db(presetInputs, presetOutputs)) != PROJECTM_SUCCESS)
@@ -267,7 +267,7 @@ int BuiltinParams::insert_builtin_param(Param* param)
 
 /* Initialize the builtin parameter database.
    Should only be necessary once */
-int BuiltinParams::init_builtin_param_db(const PresetInputs& presetInputs, PresetOutputs& presetOutputs)
+int BuiltinParams::init_builtin_param_db(const PresetInputs& presetInputs, PresetOutputs* presetOutputs)
 {
 
     if (BUILTIN_PARAMS_DEBUG)
@@ -297,120 +297,121 @@ int BuiltinParams::init_builtin_param_db(const PresetInputs& presetInputs, Prese
 
 
 /* Loads all builtin parameters, limits are also defined here */
-int BuiltinParams::load_all_builtin_param(const PresetInputs& presetInputs, PresetOutputs& presetOutputs)
+int BuiltinParams::load_all_builtin_param(const PresetInputs& presetInputs, PresetOutputs* presetOutputs)
 {
 
-    load_builtin_param_float("frating", (void*) &presetOutputs.fRating, NULL, P_FLAG_NONE, 0.0, 5.0, 0.0, "");
+    load_builtin_param_float("frating", (void*) &presetOutputs->fRating, NULL, P_FLAG_NONE, 0.0, 5.0, 0.0, "");
     // 0 will turn off all waviness in our waves... 1 seems better
-    load_builtin_param_float("fwavescale", (void*) &presetOutputs.wave.scale, NULL, P_FLAG_NONE, 1.0, MAX_DOUBLE_SIZE,
+    load_builtin_param_float("fwavescale", (void*) &presetOutputs->wave.scale, NULL, P_FLAG_NONE, 1.0, MAX_DOUBLE_SIZE,
                              -MAX_DOUBLE_SIZE, "");
-    load_builtin_param_float("gamma", (void*) &presetOutputs.fGammaAdj, NULL, P_FLAG_NONE, 0.0, MAX_DOUBLE_SIZE, 0,
+    load_builtin_param_float("gamma", (void*) &presetOutputs->fGammaAdj, NULL, P_FLAG_NONE, 0.0, MAX_DOUBLE_SIZE, 0,
                              "fGammaAdj");
-    load_builtin_param_float("echo_zoom", (void*) &presetOutputs.videoEcho.zoom, NULL, P_FLAG_NONE, 0.0,
+    load_builtin_param_float("echo_zoom", (void*) &presetOutputs->videoEcho.zoom, NULL, P_FLAG_NONE, 0.0,
                              MAX_DOUBLE_SIZE, 0, "fVideoEchoZoom");
-    load_builtin_param_float("echo_alpha", (void*) &presetOutputs.videoEcho.a, NULL, P_FLAG_NONE, 0.0, MAX_DOUBLE_SIZE,
+    load_builtin_param_float("echo_alpha", (void*) &presetOutputs->videoEcho.a, NULL, P_FLAG_NONE, 0.0, MAX_DOUBLE_SIZE,
                              0, "fvideoechoalpha");
-    load_builtin_param_float("wave_a", (void*) &presetOutputs.wave.a, NULL, P_FLAG_NONE, 1.0, 1.0, 0, "fwavealpha");
-    load_builtin_param_float("fwavesmoothing", (void*) &presetOutputs.wave.smoothing, NULL, P_FLAG_NONE, 0.0, 1.0, -1.0,
-                             "");
-    load_builtin_param_float("fmodwavealphastart", (void*) &presetOutputs.wave.modOpacityStart, NULL, P_FLAG_NONE, 0.0,
-                             1.0, -1.0, "");
-    load_builtin_param_float("fmodwavealphaend", (void*) &presetOutputs.wave.modOpacityEnd, NULL, P_FLAG_NONE, 0.0, 1.0,
+    load_builtin_param_float("wave_a", (void*) &presetOutputs->wave.a, NULL, P_FLAG_NONE, 1.0, 1.0, 0, "fwavealpha");
+    load_builtin_param_float("fwavesmoothing", (void*) &presetOutputs->wave.smoothing, NULL, P_FLAG_NONE, 0.0, 1.0,
                              -1.0, "");
-    load_builtin_param_float("fWarpAnimSpeed", (void*) &presetOutputs.fWarpAnimSpeed, NULL, P_FLAG_NONE, 1.0, 1.0, -1.0,
-                             "");
-    load_builtin_param_float("fWarpScale", (void*) &presetOutputs.fWarpScale, NULL, P_FLAG_NONE, 1.0, 1.0, -1.0, "");
+    load_builtin_param_float("fmodwavealphastart", (void*) &presetOutputs->wave.modOpacityStart, NULL, P_FLAG_NONE, 0.0,
+                             1.0, -1.0, "");
+    load_builtin_param_float("fmodwavealphaend", (void*) &presetOutputs->wave.modOpacityEnd, NULL, P_FLAG_NONE, 0.0,
+                             1.0, -1.0, "");
+    load_builtin_param_float("fWarpAnimSpeed", (void*) &presetOutputs->fWarpAnimSpeed, NULL, P_FLAG_NONE, 1.0, 1.0,
+                             -1.0, "");
+    load_builtin_param_float("fWarpScale", (void*) &presetOutputs->fWarpScale, NULL, P_FLAG_NONE, 1.0, 1.0, -1.0, "");
 
-    load_builtin_param_float("fshader", (void*) &presetOutputs.fShader, NULL, P_FLAG_NONE, 0.0, 1.0, -1.0, "");
+    load_builtin_param_float("fshader", (void*) &presetOutputs->fShader, NULL, P_FLAG_NONE, 0.0, 1.0, -1.0, "");
     // 0.98 seems close to milkdrop2 default
-    load_builtin_param_float("decay", (void*) &presetOutputs.screenDecay, NULL, P_FLAG_NONE, 0.98, 1.0, 0, "fdecay");
+    load_builtin_param_float("decay", (void*) &presetOutputs->screenDecay, NULL, P_FLAG_NONE, 0.98, 1.0, 0, "fdecay");
 
-    load_builtin_param_int("echo_orient", (void*) &presetOutputs.videoEcho.orientation, P_FLAG_NONE, 0, 3, 0,
+    load_builtin_param_int("echo_orient", (void*) &presetOutputs->videoEcho.orientation, P_FLAG_NONE, 0, 3, 0,
                            "nVideoEchoOrientation");
-    load_builtin_param_int("wave_mode", (void*) &presetOutputs.wave.mode, P_FLAG_NONE, 0, 7, 0, "nwavemode");
+    load_builtin_param_int("wave_mode", (void*) &presetOutputs->wave.mode, P_FLAG_NONE, 0, 7, 0, "nwavemode");
 
-    load_builtin_param_bool("wave_additive", (void*) &presetOutputs.wave.additive, P_FLAG_NONE, false,
+    load_builtin_param_bool("wave_additive", (void*) &presetOutputs->wave.additive, P_FLAG_NONE, false,
                             "bAdditiveWaves");
-    load_builtin_param_bool("bmodwavealphabyvolume", (void*) &presetOutputs.wave.modulateAlphaByVolume, P_FLAG_NONE,
+    load_builtin_param_bool("bmodwavealphabyvolume", (void*) &presetOutputs->wave.modulateAlphaByVolume, P_FLAG_NONE,
                             false, "");
-    load_builtin_param_bool("wave_brighten", (void*) &presetOutputs.wave.maximizeColors, P_FLAG_NONE, false,
+    load_builtin_param_bool("wave_brighten", (void*) &presetOutputs->wave.maximizeColors, P_FLAG_NONE, false,
                             "bMaximizeWaveColor");
-    load_builtin_param_bool("wrap", (void*) &presetOutputs.textureWrap, P_FLAG_NONE, true, "btexwrap");
-    load_builtin_param_bool("darken_center", (void*) &presetOutputs.bDarkenCenter, P_FLAG_NONE, false, "bdarkencenter");
-    load_builtin_param_bool("bredbluestereo", (void*) &presetOutputs.bRedBlueStereo, P_FLAG_NONE, false, "");
-    load_builtin_param_bool("brighten", (void*) &presetOutputs.bBrighten, P_FLAG_NONE, false, "bbrighten");
-    load_builtin_param_bool("darken", (void*) &presetOutputs.bDarken, P_FLAG_NONE, false, "bdarken");
-    load_builtin_param_bool("solarize", (void*) &presetOutputs.bSolarize, P_FLAG_NONE, false, "bsolarize");
-    load_builtin_param_bool("invert", (void*) &presetOutputs.bInvert, P_FLAG_NONE, false, "binvert");
-    load_builtin_param_bool("bmotionvectorson", (void*) &presetOutputs.bMotionVectorsOn, P_FLAG_NONE, false, "");
-    load_builtin_param_bool("wave_dots", (void*) &presetOutputs.wave.dots, P_FLAG_NONE, false, "bwavedots");
-    load_builtin_param_bool("wave_thick", (void*) &presetOutputs.wave.thick, P_FLAG_NONE, false, "bwavethick");
+    load_builtin_param_bool("wrap", (void*) &presetOutputs->textureWrap, P_FLAG_NONE, true, "btexwrap");
+    load_builtin_param_bool("darken_center", (void*) &presetOutputs->bDarkenCenter, P_FLAG_NONE, false,
+                            "bdarkencenter");
+    load_builtin_param_bool("bredbluestereo", (void*) &presetOutputs->bRedBlueStereo, P_FLAG_NONE, false, "");
+    load_builtin_param_bool("brighten", (void*) &presetOutputs->bBrighten, P_FLAG_NONE, false, "bbrighten");
+    load_builtin_param_bool("darken", (void*) &presetOutputs->bDarken, P_FLAG_NONE, false, "bdarken");
+    load_builtin_param_bool("solarize", (void*) &presetOutputs->bSolarize, P_FLAG_NONE, false, "bsolarize");
+    load_builtin_param_bool("invert", (void*) &presetOutputs->bInvert, P_FLAG_NONE, false, "binvert");
+    load_builtin_param_bool("bmotionvectorson", (void*) &presetOutputs->bMotionVectorsOn, P_FLAG_NONE, false, "");
+    load_builtin_param_bool("wave_dots", (void*) &presetOutputs->wave.dots, P_FLAG_NONE, false, "bwavedots");
+    load_builtin_param_bool("wave_thick", (void*) &presetOutputs->wave.thick, P_FLAG_NONE, false, "bwavethick");
     // warp is turned on by default in milkdrop2
-    load_builtin_param_float("warp", (void*) &presetOutputs.warp, presetOutputs.warp_mesh,
+    load_builtin_param_float("warp", (void*) &presetOutputs->warp, presetOutputs->warp_mesh,
                              P_FLAG_PER_PIXEL | P_FLAG_NONE, 1.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
     // zoom=1 is the 'do nothing' value, 0 causes Inf values in PresetOutputs::PerPixelMath()
-    load_builtin_param_float("zoom", (void*) &presetOutputs.zoom, presetOutputs.zoom_mesh,
+    load_builtin_param_float("zoom", (void*) &presetOutputs->zoom, presetOutputs->zoom_mesh,
                              P_FLAG_PER_PIXEL | P_FLAG_NONE, 1.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
-    load_builtin_param_float("rot", (void*) &presetOutputs.rot, presetOutputs.rot_mesh, P_FLAG_PER_PIXEL | P_FLAG_NONE,
-                             0.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
+    load_builtin_param_float("rot", (void*) &presetOutputs->rot, presetOutputs->rot_mesh,
+                             P_FLAG_PER_PIXEL | P_FLAG_NONE, 0.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
     // zoomexp=1 is the 'do nothing' value, 0 effectively forces zoom=1
-    load_builtin_param_float("zoomexp", (void*) &presetOutputs.zoomexp, presetOutputs.zoomexp_mesh,
+    load_builtin_param_float("zoomexp", (void*) &presetOutputs->zoomexp, presetOutputs->zoomexp_mesh,
                              P_FLAG_PER_PIXEL | P_FLAG_NONE, 1.0, MAX_DOUBLE_SIZE, 0, "fzoomexponent");
 
-    load_builtin_param_float("cx", (void*) &presetOutputs.cx, presetOutputs.cx_mesh, P_FLAG_PER_PIXEL | P_FLAG_NONE,
+    load_builtin_param_float("cx", (void*) &presetOutputs->cx, presetOutputs->cx_mesh, P_FLAG_PER_PIXEL | P_FLAG_NONE,
                              0.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
-    load_builtin_param_float("cy", (void*) &presetOutputs.cy, presetOutputs.cy_mesh, P_FLAG_PER_PIXEL | P_FLAG_NONE,
+    load_builtin_param_float("cy", (void*) &presetOutputs->cy, presetOutputs->cy_mesh, P_FLAG_PER_PIXEL | P_FLAG_NONE,
                              0.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
-    load_builtin_param_float("dx", (void*) &presetOutputs.dx, presetOutputs.dx_mesh, P_FLAG_PER_PIXEL | P_FLAG_NONE,
+    load_builtin_param_float("dx", (void*) &presetOutputs->dx, presetOutputs->dx_mesh, P_FLAG_PER_PIXEL | P_FLAG_NONE,
                              0.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
-    load_builtin_param_float("dy", (void*) &presetOutputs.dy, presetOutputs.dy_mesh, P_FLAG_PER_PIXEL | P_FLAG_NONE,
+    load_builtin_param_float("dy", (void*) &presetOutputs->dy, presetOutputs->dy_mesh, P_FLAG_PER_PIXEL | P_FLAG_NONE,
                              0.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
     // sx=1 and sy=1 are the 'do nothing' values, 0 causes Inf values in PresetOutputs::PerPixelMath()
-    load_builtin_param_float("sx", (void*) &presetOutputs.sx, presetOutputs.sx_mesh, P_FLAG_PER_PIXEL | P_FLAG_NONE,
+    load_builtin_param_float("sx", (void*) &presetOutputs->sx, presetOutputs->sx_mesh, P_FLAG_PER_PIXEL | P_FLAG_NONE,
                              1.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
-    load_builtin_param_float("sy", (void*) &presetOutputs.sy, presetOutputs.sy_mesh, P_FLAG_PER_PIXEL | P_FLAG_NONE,
+    load_builtin_param_float("sy", (void*) &presetOutputs->sy, presetOutputs->sy_mesh, P_FLAG_PER_PIXEL | P_FLAG_NONE,
                              1.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
 
 
-    load_builtin_param_float("b1n", (void*) &presetOutputs.blur1n, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-    load_builtin_param_float("b2n", (void*) &presetOutputs.blur2n, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-    load_builtin_param_float("b3n", (void*) &presetOutputs.blur3n, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-    load_builtin_param_float("b1x", (void*) &presetOutputs.blur1x, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-    load_builtin_param_float("b2x", (void*) &presetOutputs.blur2x, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-    load_builtin_param_float("b3x", (void*) &presetOutputs.blur3x, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-    load_builtin_param_float("b1ed", (void*) &presetOutputs.blur1ed, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("b1n", (void*) &presetOutputs->blur1n, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("b2n", (void*) &presetOutputs->blur2n, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("b3n", (void*) &presetOutputs->blur3n, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("b1x", (void*) &presetOutputs->blur1x, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("b2x", (void*) &presetOutputs->blur2x, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("b3x", (void*) &presetOutputs->blur3x, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("b1ed", (void*) &presetOutputs->blur1ed, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
 
-    load_builtin_param_float("wave_r", (void*) &presetOutputs.wave.r, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-    load_builtin_param_float("wave_g", (void*) &presetOutputs.wave.g, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-    load_builtin_param_float("wave_b", (void*) &presetOutputs.wave.b, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-    load_builtin_param_float("wave_x", (void*) &presetOutputs.wave.x, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-    load_builtin_param_float("wave_y", (void*) &presetOutputs.wave.y, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-    load_builtin_param_float("wave_mystery", (void*) &presetOutputs.wave.mystery, NULL, P_FLAG_NONE, 0.0, 1.0, -1.0,
+    load_builtin_param_float("wave_r", (void*) &presetOutputs->wave.r, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("wave_g", (void*) &presetOutputs->wave.g, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("wave_b", (void*) &presetOutputs->wave.b, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("wave_x", (void*) &presetOutputs->wave.x, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("wave_y", (void*) &presetOutputs->wave.y, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("wave_mystery", (void*) &presetOutputs->wave.mystery, NULL, P_FLAG_NONE, 0.0, 1.0, -1.0,
                              "fWaveParam");
 
-    load_builtin_param_float("ob_size", (void*) &presetOutputs.border.outer_size, NULL, P_FLAG_NONE, 0.0, 0.5, 0, "");
-    load_builtin_param_float("ob_r", (void*) &presetOutputs.border.outer_r, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-    load_builtin_param_float("ob_g", (void*) &presetOutputs.border.outer_g, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-    load_builtin_param_float("ob_b", (void*) &presetOutputs.border.outer_b, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-    load_builtin_param_float("ob_a", (void*) &presetOutputs.border.outer_a, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("ob_size", (void*) &presetOutputs->border.outer_size, NULL, P_FLAG_NONE, 0.0, 0.5, 0, "");
+    load_builtin_param_float("ob_r", (void*) &presetOutputs->border.outer_r, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("ob_g", (void*) &presetOutputs->border.outer_g, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("ob_b", (void*) &presetOutputs->border.outer_b, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("ob_a", (void*) &presetOutputs->border.outer_a, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
 
-    load_builtin_param_float("ib_size", (void*) &presetOutputs.border.inner_size, NULL, P_FLAG_NONE, 0.0, .5, 0.0, "");
-    load_builtin_param_float("ib_r", (void*) &presetOutputs.border.inner_r, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-    load_builtin_param_float("ib_g", (void*) &presetOutputs.border.inner_g, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-    load_builtin_param_float("ib_b", (void*) &presetOutputs.border.inner_b, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-    load_builtin_param_float("ib_a", (void*) &presetOutputs.border.inner_a, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("ib_size", (void*) &presetOutputs->border.inner_size, NULL, P_FLAG_NONE, 0.0, .5, 0.0, "");
+    load_builtin_param_float("ib_r", (void*) &presetOutputs->border.inner_r, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("ib_g", (void*) &presetOutputs->border.inner_g, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("ib_b", (void*) &presetOutputs->border.inner_b, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("ib_a", (void*) &presetOutputs->border.inner_a, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
 
-    load_builtin_param_float("mv_r", (void*) &presetOutputs.mv.r, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-    load_builtin_param_float("mv_g", (void*) &presetOutputs.mv.g, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-    load_builtin_param_float("mv_b", (void*) &presetOutputs.mv.b, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-    load_builtin_param_float("mv_x", (void*) &presetOutputs.mv.x_num, NULL, P_FLAG_NONE, 0.0, 64.0, 0.0,
+    load_builtin_param_float("mv_r", (void*) &presetOutputs->mv.r, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("mv_g", (void*) &presetOutputs->mv.g, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("mv_b", (void*) &presetOutputs->mv.b, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("mv_x", (void*) &presetOutputs->mv.x_num, NULL, P_FLAG_NONE, 0.0, 64.0, 0.0,
                              "nmotionvectorsx");
-    load_builtin_param_float("mv_y", (void*) &presetOutputs.mv.y_num, NULL, P_FLAG_NONE, 0.0, 48.0, 0.0,
+    load_builtin_param_float("mv_y", (void*) &presetOutputs->mv.y_num, NULL, P_FLAG_NONE, 0.0, 48.0, 0.0,
                              "nmotionvectorsy");
-    load_builtin_param_float("mv_l", (void*) &presetOutputs.mv.length, NULL, P_FLAG_NONE, 0.0, 5.0, 0.0, "");
-    load_builtin_param_float("mv_dx", (void*) &presetOutputs.mv.x_offset, NULL, P_FLAG_NONE, 0.0, 1.0, -1.0, "");
-    load_builtin_param_float("mv_dy", (void*) &presetOutputs.mv.y_offset, NULL, P_FLAG_NONE, 0.0, 1.0, -1.0, "");
-    load_builtin_param_float("mv_a", (void*) &presetOutputs.mv.a, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("mv_l", (void*) &presetOutputs->mv.length, NULL, P_FLAG_NONE, 0.0, 5.0, 0.0, "");
+    load_builtin_param_float("mv_dx", (void*) &presetOutputs->mv.x_offset, NULL, P_FLAG_NONE, 0.0, 1.0, -1.0, "");
+    load_builtin_param_float("mv_dy", (void*) &presetOutputs->mv.y_offset, NULL, P_FLAG_NONE, 0.0, 1.0, -1.0, "");
+    load_builtin_param_float("mv_a", (void*) &presetOutputs->mv.a, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
 
     load_builtin_param_float("time", (void*) &presetInputs.time, NULL, P_FLAG_READONLY, 0.0, MAX_DOUBLE_SIZE, 0.0, "");
     load_builtin_param_float("bass", (void*) &presetInputs.bass, NULL, P_FLAG_READONLY, 0.0, MAX_DOUBLE_SIZE, 0.0, "");
@@ -446,7 +447,7 @@ int BuiltinParams::load_all_builtin_param(const PresetInputs& presetInputs, Pres
     {
         std::ostringstream os;
         os << "q" << i + 1;
-        load_builtin_param_float(os.str().c_str(), (void*) &presetOutputs.q[i], NULL, P_FLAG_QVAR, 0, MAX_DOUBLE_SIZE,
+        load_builtin_param_float(os.str().c_str(), (void*) &presetOutputs->q[i], NULL, P_FLAG_QVAR, 0, MAX_DOUBLE_SIZE,
                                  -MAX_DOUBLE_SIZE, "");
 
     }

--- a/src/libprojectM/MilkdropPresetFactory/BuiltinParams.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/BuiltinParams.cpp
@@ -9,97 +9,102 @@
 #include <stdio.h>
 #include "Common.hpp"
 
-BuiltinParams::BuiltinParams() {}
+BuiltinParams::BuiltinParams()
+{
+}
 
-BuiltinParams::BuiltinParams(PresetInputs & presetInputs, PresetOutputs & presetOutputs)
+BuiltinParams::BuiltinParams(PresetInputs& presetInputs, PresetOutputs& presetOutputs)
 {
 
-  presetInputs.Initialize(presetOutputs.gx, presetOutputs.gy);
+    presetInputs.Initialize(presetOutputs.gx, presetOutputs.gy);
 
-  int ret;
-  if ((ret = init_builtin_param_db(presetInputs, presetOutputs)) != PROJECTM_SUCCESS)
-  {
-	std::cout << "failed to allocate builtin parameter database with error " << ret << std::endl;;
+    int ret;
+    if ((ret = init_builtin_param_db(presetInputs, presetOutputs)) != PROJECTM_SUCCESS)
+    {
+        std::cout << "failed to allocate builtin parameter database with error " << ret << std::endl;;
         throw ret;
-  }
+    }
 
 }
 
 BuiltinParams::~BuiltinParams()
 {
-  destroy_builtin_param_db();
+    destroy_builtin_param_db();
 }
 
 /* Loads a float parameter into the builtin database */
-int BuiltinParams::load_builtin_param_float(const std::string & name, void * engine_val, void * matrix, short int flags,
-    float init_val, float upper_bound, float lower_bound, const std::string & alt_name)
+int BuiltinParams::load_builtin_param_float(const std::string& name, void* engine_val, void* matrix, short int flags,
+                                            float init_val, float upper_bound, float lower_bound,
+                                            const std::string& alt_name)
 {
 
-  Param * param = NULL;
-  CValue iv, ub, lb;
+    Param* param = NULL;
+    CValue iv, ub, lb;
 
-  iv.float_val = init_val;
-  ub.float_val = upper_bound;
-  lb.float_val = lower_bound;
+    iv.float_val = init_val;
+    ub.float_val = upper_bound;
+    lb.float_val = lower_bound;
 
-  /* Create new parameter of type float */
-  if (BUILTIN_PARAMS_DEBUG == 2)
-  {
-    printf("load_builtin_param_float: (name \"%s\") (alt_name = \"%s\") ", name.c_str(), alt_name.c_str());
-    fflush(stdout);
-  }
+    /* Create new parameter of type float */
+    if (BUILTIN_PARAMS_DEBUG == 2)
+    {
+        printf("load_builtin_param_float: (name \"%s\") (alt_name = \"%s\") ", name.c_str(), alt_name.c_str());
+        fflush(stdout);
+    }
 
-std::string lowerName(name);
-std::transform(lowerName.begin(), lowerName.end(), lowerName.begin(), tolower);
+    std::string lowerName(name);
+    std::transform(lowerName.begin(), lowerName.end(), lowerName.begin(), tolower);
 
-  if ((param = Param::create(lowerName, P_TYPE_DOUBLE, flags, engine_val, matrix, iv, ub, lb)) == NULL)
-  {
-    return PROJECTM_OUTOFMEM_ERROR;
-  }
-
-  if (BUILTIN_PARAMS_DEBUG == 2)
-  {
-    printf("created...");
-    fflush(stdout);
-  }
-
-  /* Insert the paremeter into the database */
-
-  if (insert_builtin_param( param ) < 0)
-  {
-    delete param;
-    return PROJECTM_ERROR;
-  }
-
-  if (BUILTIN_PARAMS_DEBUG == 2)
-  {
-    printf("inserted...");
-    fflush(stdout);
-  }
-
-  /* If this parameter has an alternate name, insert it into the database as link */
-
-  if (alt_name != "")
-  {
-    std::string alt_lower_name(alt_name);
-    std::transform(alt_lower_name.begin(), alt_lower_name.end(), alt_lower_name.begin(), tolower);
-    insert_param_alt_name(param,alt_lower_name);
+    if ((param = Param::create(lowerName, P_TYPE_DOUBLE, flags, engine_val, matrix, iv, ub, lb)) == NULL)
+    {
+        return PROJECTM_OUTOFMEM_ERROR;
+    }
 
     if (BUILTIN_PARAMS_DEBUG == 2)
     {
-      printf("alt_name inserted...");
-      fflush(stdout);
+        printf("created...");
+        fflush(stdout);
     }
 
+    /* Insert the paremeter into the database */
 
-  }
+    if (insert_builtin_param(param) < 0)
+    {
+        delete param;
+        return PROJECTM_ERROR;
+    }
 
-  if (BUILTIN_PARAMS_DEBUG == 2) printf("finished\n");
+    if (BUILTIN_PARAMS_DEBUG == 2)
+    {
+        printf("inserted...");
+        fflush(stdout);
+    }
 
-  /* Finished, return success */
-  return PROJECTM_SUCCESS;
+    /* If this parameter has an alternate name, insert it into the database as link */
+
+    if (alt_name != "")
+    {
+        std::string alt_lower_name(alt_name);
+        std::transform(alt_lower_name.begin(), alt_lower_name.end(), alt_lower_name.begin(), tolower);
+        insert_param_alt_name(param, alt_lower_name);
+
+        if (BUILTIN_PARAMS_DEBUG == 2)
+        {
+            printf("alt_name inserted...");
+            fflush(stdout);
+        }
+
+
+    }
+
+    if (BUILTIN_PARAMS_DEBUG == 2)
+    {
+        printf("finished\n");
+    }
+
+    /* Finished, return success */
+    return PROJECTM_SUCCESS;
 }
-
 
 
 /* Destroy the builtin parameter database.
@@ -107,309 +112,350 @@ std::transform(lowerName.begin(), lowerName.end(), lowerName.begin(), tolower);
 int BuiltinParams::destroy_builtin_param_db()
 {
 
-  traverse<TraverseFunctors::Delete<Param> >(builtin_param_tree);
-  return PROJECTM_SUCCESS;
+    traverse<TraverseFunctors::Delete<Param> >(builtin_param_tree);
+    return PROJECTM_SUCCESS;
 }
 
 
 /* Insert a parameter into the database with an alternate name */
-int BuiltinParams::insert_param_alt_name(Param * param, const std::string & alt_name)
+int BuiltinParams::insert_param_alt_name(Param* param, const std::string& alt_name)
 {
 
-  assert(param);
+    assert(param);
 
-  aliasMap.insert(std::make_pair(alt_name, param->name));
+    aliasMap.insert(std::make_pair(alt_name, param->name));
 
-  return PROJECTM_SUCCESS;
+    return PROJECTM_SUCCESS;
 }
 
-Param * BuiltinParams::find_builtin_param(const std::string & name)
+Param* BuiltinParams::find_builtin_param(const std::string& name)
 {
 
 
+    AliasMap::iterator pos = aliasMap.find(name);
+    Param* param = 0;
+    //std::cerr << "[BuiltinParams] find_builtin_param: name is " << name << std::endl;
+    if (pos == aliasMap.end())
+    {
+        std::map<std::string, Param*>::iterator builtinPos = builtin_param_tree.find(name);
 
-  AliasMap::iterator pos = aliasMap.find(name);
-  Param * param = 0;
-  //std::cerr << "[BuiltinParams] find_builtin_param: name is " << name << std::endl;
-  if (pos == aliasMap.end())
-  {
-    std::map<std::string, Param*>::iterator builtinPos = builtin_param_tree.find(name);
+        if (builtinPos != builtin_param_tree.end())
+        {
+            //  std::cerr << "[BuiltinParams] find_builtin_param: found it directly." << std::endl;
+            param = builtinPos->second;
+        }
+    }
+    else
+    {
 
-    if (builtinPos != builtin_param_tree.end()) {
-    //  std::cerr << "[BuiltinParams] find_builtin_param: found it directly." << std::endl;
-      param = builtinPos->second;
-     }
-  }
-  else
-  {
+        std::map<std::string, Param*>::iterator builtinPos = builtin_param_tree.find(pos->second);
 
-    std::map<std::string, Param*>::iterator builtinPos = builtin_param_tree.find(pos->second);
+        if (builtinPos != builtin_param_tree.end())
+        {
+            //std::cerr << "[BuiltinParams] find_builtin_param: found it indirectly." << std::endl;
+            param = builtinPos->second;
 
-    if (builtinPos != builtin_param_tree.end()) {
-      //std::cerr << "[BuiltinParams] find_builtin_param: found it indirectly." << std::endl;
-      param = builtinPos->second;
-
-}
-  }
-  return param;
+        }
+    }
+    return param;
 }
 
 
 /* Loads a integer parameter into the builtin database */
-int BuiltinParams::load_builtin_param_int(const std::string & name, void * engine_val, short int flags,
-    int init_val, int upper_bound, int lower_bound, const std::string &alt_name)
+int BuiltinParams::load_builtin_param_int(const std::string& name, void* engine_val, short int flags,
+                                          int init_val, int upper_bound, int lower_bound, const std::string& alt_name)
 {
 
-  Param * param;
-  CValue iv, ub, lb;
+    Param* param;
+    CValue iv, ub, lb;
 
-  iv.int_val = init_val;
-  ub.int_val = upper_bound;
-  lb.int_val = lower_bound;
+    iv.int_val = init_val;
+    ub.int_val = upper_bound;
+    lb.int_val = lower_bound;
 
-  // normalize to lower case as milkdrop scripts depend on this
-  std::string lowerName(name);
-  std::transform(lowerName.begin(), lowerName.end(), lowerName.begin(), tolower);
+    // normalize to lower case as milkdrop scripts depend on this
+    std::string lowerName(name);
+    std::transform(lowerName.begin(), lowerName.end(), lowerName.begin(), tolower);
 
-  param = Param::create(lowerName, P_TYPE_INT, flags, engine_val, NULL, iv, ub, lb);
+    param = Param::create(lowerName, P_TYPE_INT, flags, engine_val, NULL, iv, ub, lb);
 
-  if (param == NULL)
-  {
-    return PROJECTM_OUTOFMEM_ERROR;
-  }
+    if (param == NULL)
+    {
+        return PROJECTM_OUTOFMEM_ERROR;
+    }
 
-  if (insert_builtin_param( param ) < 0)
-  {
-    delete param;
-    return PROJECTM_ERROR;
-  }
+    if (insert_builtin_param(param) < 0)
+    {
+        delete param;
+        return PROJECTM_ERROR;
+    }
 
-  if (alt_name != "")
-  {
-    std::string alt_lower_name(alt_name);
-    std::transform(alt_lower_name.begin(), alt_lower_name.end(), alt_lower_name.begin(), tolower);
-    insert_param_alt_name(param,alt_lower_name);
+    if (alt_name != "")
+    {
+        std::string alt_lower_name(alt_name);
+        std::transform(alt_lower_name.begin(), alt_lower_name.end(), alt_lower_name.begin(), tolower);
+        insert_param_alt_name(param, alt_lower_name);
 
-  }
+    }
 
-  return PROJECTM_SUCCESS;
+    return PROJECTM_SUCCESS;
 
 }
 
-int BuiltinParams::load_builtin_param_string( const std::string & name, std::string * engine_val, short int flags) {
+int BuiltinParams::load_builtin_param_string(const std::string& name, std::string* engine_val, short int flags)
+{
 
-	/* Creates a new parameter of type string */
-	Param * param = Param::new_param_string(name.c_str(), flags, engine_val);
+    /* Creates a new parameter of type string */
+    Param* param = Param::new_param_string(name.c_str(), flags, engine_val);
 
-	if (insert_builtin_param( param ) < 0)
-	{
-		delete param;
-		return PROJECTM_ERROR;
-	}
-	return PROJECTM_SUCCESS;
+    if (insert_builtin_param(param) < 0)
+    {
+        delete param;
+        return PROJECTM_ERROR;
+    }
+    return PROJECTM_SUCCESS;
 }
 
 /* Loads a boolean parameter */
-int BuiltinParams::load_builtin_param_bool(const std:: string & name, void * engine_val, short int flags,
-    int init_val, const std::string &alt_name)
+int BuiltinParams::load_builtin_param_bool(const std::string& name, void* engine_val, short int flags,
+                                           int init_val, const std::string& alt_name)
 {
 
-  Param * param;
-  CValue iv, ub, lb;
+    Param* param;
+    CValue iv, ub, lb;
 
-  iv.int_val = init_val;
-  ub.int_val = TRUE;
-  lb.int_val = false;
+    iv.int_val = init_val;
+    ub.int_val = TRUE;
+    lb.int_val = false;
 
-std::string lowerName(name);
-std::transform(lowerName.begin(), lowerName.end(), lowerName.begin(), tolower);
+    std::string lowerName(name);
+    std::transform(lowerName.begin(), lowerName.end(), lowerName.begin(), tolower);
 
-  param = Param::create(lowerName, P_TYPE_BOOL, flags, engine_val, NULL, iv, ub, lb);
+    param = Param::create(lowerName, P_TYPE_BOOL, flags, engine_val, NULL, iv, ub, lb);
 
-  if (param == NULL)
-  {
-    return PROJECTM_OUTOFMEM_ERROR;
-  }
+    if (param == NULL)
+    {
+        return PROJECTM_OUTOFMEM_ERROR;
+    }
 
-  if (insert_builtin_param(param) < 0)
-  {
-    delete param;
-    return PROJECTM_ERROR;
-  }
+    if (insert_builtin_param(param) < 0)
+    {
+        delete param;
+        return PROJECTM_ERROR;
+    }
 
-  if (alt_name != "")
-  {
-    std::string alt_lower_name(alt_name);
-    std::transform(alt_lower_name.begin(), alt_lower_name.end(), alt_lower_name.begin(), tolower);
-    insert_param_alt_name(param,alt_lower_name);
-  }
+    if (alt_name != "")
+    {
+        std::string alt_lower_name(alt_name);
+        std::transform(alt_lower_name.begin(), alt_lower_name.end(), alt_lower_name.begin(), tolower);
+        insert_param_alt_name(param, alt_lower_name);
+    }
 
-  return PROJECTM_SUCCESS;
+    return PROJECTM_SUCCESS;
 
 }
 
 /* Inserts a parameter into the builtin database */
-int BuiltinParams::insert_builtin_param( Param *param )
+int BuiltinParams::insert_builtin_param(Param* param)
 {
-  std::pair<std::map<std::string, Param*>::iterator, bool> inserteePos = builtin_param_tree.insert(std::make_pair(param->name, param));
+    std::pair<std::map<std::string, Param*>::iterator, bool> inserteePos = builtin_param_tree.insert(
+        std::make_pair(param->name, param));
 
-  return inserteePos.second;
+    return inserteePos.second;
 }
-
 
 
 /* Initialize the builtin parameter database.
    Should only be necessary once */
-int BuiltinParams::init_builtin_param_db(const PresetInputs & presetInputs, PresetOutputs & presetOutputs)
+int BuiltinParams::init_builtin_param_db(const PresetInputs& presetInputs, PresetOutputs& presetOutputs)
 {
 
-  if (BUILTIN_PARAMS_DEBUG)
-  {
-    printf("init_builtin_param: loading database...");
-    fflush(stdout);
-  }
+    if (BUILTIN_PARAMS_DEBUG)
+    {
+        printf("init_builtin_param: loading database...");
+        fflush(stdout);
+    }
 
-  /* Loads all builtin parameters into the database */
-  if (load_all_builtin_param(presetInputs, presetOutputs) < 0)
-  {
-    if (BUILTIN_PARAMS_DEBUG) printf("failed loading builtin parameters (FATAL)\n");
-    return PROJECTM_ERROR;
-  }
+    /* Loads all builtin parameters into the database */
+    if (load_all_builtin_param(presetInputs, presetOutputs) < 0)
+    {
+        if (BUILTIN_PARAMS_DEBUG)
+        {
+            printf("failed loading builtin parameters (FATAL)\n");
+        }
+        return PROJECTM_ERROR;
+    }
 
-  if (BUILTIN_PARAMS_DEBUG) printf("success!\n");
+    if (BUILTIN_PARAMS_DEBUG)
+    {
+        printf("success!\n");
+    }
 
-  /* Finished, no errors */
-  return PROJECTM_SUCCESS;
+    /* Finished, no errors */
+    return PROJECTM_SUCCESS;
 }
 
 
-
 /* Loads all builtin parameters, limits are also defined here */
-int BuiltinParams::load_all_builtin_param(const PresetInputs & presetInputs, PresetOutputs & presetOutputs)
+int BuiltinParams::load_all_builtin_param(const PresetInputs& presetInputs, PresetOutputs& presetOutputs)
 {
 
-  load_builtin_param_float("frating", (void*)&presetOutputs.fRating, NULL, P_FLAG_NONE, 0.0 , 5.0, 0.0, "");
-  // 0 will turn off all waviness in our waves... 1 seems better
-  load_builtin_param_float("fwavescale", (void*)&presetOutputs.wave.scale, NULL, P_FLAG_NONE, 1.0, MAX_DOUBLE_SIZE, -MAX_DOUBLE_SIZE, "");
-  load_builtin_param_float("gamma", (void*)&presetOutputs.fGammaAdj, NULL, P_FLAG_NONE, 0.0, MAX_DOUBLE_SIZE, 0, "fGammaAdj");
-  load_builtin_param_float("echo_zoom", (void*)&presetOutputs.videoEcho.zoom, NULL, P_FLAG_NONE, 0.0, MAX_DOUBLE_SIZE, 0, "fVideoEchoZoom");
-  load_builtin_param_float("echo_alpha", (void*)&presetOutputs.videoEcho.a, NULL, P_FLAG_NONE, 0.0, MAX_DOUBLE_SIZE, 0, "fvideoechoalpha");
-  load_builtin_param_float("wave_a", (void*)&presetOutputs.wave.a, NULL, P_FLAG_NONE, 1.0, 1.0, 0, "fwavealpha");
-  load_builtin_param_float("fwavesmoothing", (void*)&presetOutputs.wave.smoothing, NULL, P_FLAG_NONE, 0.0, 1.0, -1.0, "");
-  load_builtin_param_float("fmodwavealphastart", (void*)&presetOutputs.wave.modOpacityStart, NULL, P_FLAG_NONE, 0.0, 1.0, -1.0, "");
-  load_builtin_param_float("fmodwavealphaend", (void*)&presetOutputs.wave.modOpacityEnd, NULL, P_FLAG_NONE, 0.0, 1.0, -1.0, "");
-  load_builtin_param_float("fWarpAnimSpeed",  (void*)&presetOutputs.fWarpAnimSpeed, NULL, P_FLAG_NONE, 1.0, 1.0, -1.0, "");
-  load_builtin_param_float("fWarpScale",  (void*)&presetOutputs.fWarpScale, NULL, P_FLAG_NONE, 1.0, 1.0, -1.0, "");
+    load_builtin_param_float("frating", (void*) &presetOutputs.fRating, NULL, P_FLAG_NONE, 0.0, 5.0, 0.0, "");
+    // 0 will turn off all waviness in our waves... 1 seems better
+    load_builtin_param_float("fwavescale", (void*) &presetOutputs.wave.scale, NULL, P_FLAG_NONE, 1.0, MAX_DOUBLE_SIZE,
+                             -MAX_DOUBLE_SIZE, "");
+    load_builtin_param_float("gamma", (void*) &presetOutputs.fGammaAdj, NULL, P_FLAG_NONE, 0.0, MAX_DOUBLE_SIZE, 0,
+                             "fGammaAdj");
+    load_builtin_param_float("echo_zoom", (void*) &presetOutputs.videoEcho.zoom, NULL, P_FLAG_NONE, 0.0,
+                             MAX_DOUBLE_SIZE, 0, "fVideoEchoZoom");
+    load_builtin_param_float("echo_alpha", (void*) &presetOutputs.videoEcho.a, NULL, P_FLAG_NONE, 0.0, MAX_DOUBLE_SIZE,
+                             0, "fvideoechoalpha");
+    load_builtin_param_float("wave_a", (void*) &presetOutputs.wave.a, NULL, P_FLAG_NONE, 1.0, 1.0, 0, "fwavealpha");
+    load_builtin_param_float("fwavesmoothing", (void*) &presetOutputs.wave.smoothing, NULL, P_FLAG_NONE, 0.0, 1.0, -1.0,
+                             "");
+    load_builtin_param_float("fmodwavealphastart", (void*) &presetOutputs.wave.modOpacityStart, NULL, P_FLAG_NONE, 0.0,
+                             1.0, -1.0, "");
+    load_builtin_param_float("fmodwavealphaend", (void*) &presetOutputs.wave.modOpacityEnd, NULL, P_FLAG_NONE, 0.0, 1.0,
+                             -1.0, "");
+    load_builtin_param_float("fWarpAnimSpeed", (void*) &presetOutputs.fWarpAnimSpeed, NULL, P_FLAG_NONE, 1.0, 1.0, -1.0,
+                             "");
+    load_builtin_param_float("fWarpScale", (void*) &presetOutputs.fWarpScale, NULL, P_FLAG_NONE, 1.0, 1.0, -1.0, "");
 
-  load_builtin_param_float("fshader", (void*)&presetOutputs.fShader, NULL, P_FLAG_NONE, 0.0, 1.0, -1.0, "");
-  // 0.98 seems close to milkdrop2 default
-  load_builtin_param_float("decay", (void*)&presetOutputs.screenDecay, NULL, P_FLAG_NONE, 0.98, 1.0, 0, "fdecay");
+    load_builtin_param_float("fshader", (void*) &presetOutputs.fShader, NULL, P_FLAG_NONE, 0.0, 1.0, -1.0, "");
+    // 0.98 seems close to milkdrop2 default
+    load_builtin_param_float("decay", (void*) &presetOutputs.screenDecay, NULL, P_FLAG_NONE, 0.98, 1.0, 0, "fdecay");
 
-  load_builtin_param_int("echo_orient", (void*)&presetOutputs.videoEcho.orientation, P_FLAG_NONE, 0, 3, 0, "nVideoEchoOrientation");
-  load_builtin_param_int("wave_mode", (void*)&presetOutputs.wave.mode, P_FLAG_NONE, 0, 7, 0, "nwavemode");
+    load_builtin_param_int("echo_orient", (void*) &presetOutputs.videoEcho.orientation, P_FLAG_NONE, 0, 3, 0,
+                           "nVideoEchoOrientation");
+    load_builtin_param_int("wave_mode", (void*) &presetOutputs.wave.mode, P_FLAG_NONE, 0, 7, 0, "nwavemode");
 
-  load_builtin_param_bool("wave_additive", (void*)&presetOutputs.wave.additive, P_FLAG_NONE, false, "bAdditiveWaves");
-  load_builtin_param_bool("bmodwavealphabyvolume", (void*)&presetOutputs.wave.modulateAlphaByVolume, P_FLAG_NONE, false, "");
-  load_builtin_param_bool("wave_brighten", (void*)&presetOutputs.wave.maximizeColors, P_FLAG_NONE, false, "bMaximizeWaveColor");
-  load_builtin_param_bool("wrap", (void*)&presetOutputs.textureWrap, P_FLAG_NONE, true, "btexwrap");
-  load_builtin_param_bool("darken_center", (void*)&presetOutputs.bDarkenCenter, P_FLAG_NONE, false, "bdarkencenter");
-  load_builtin_param_bool("bredbluestereo", (void*)&presetOutputs.bRedBlueStereo, P_FLAG_NONE, false, "");
-  load_builtin_param_bool("brighten", (void*)&presetOutputs.bBrighten, P_FLAG_NONE, false, "bbrighten");
-  load_builtin_param_bool("darken", (void*)&presetOutputs.bDarken, P_FLAG_NONE, false, "bdarken");
-  load_builtin_param_bool("solarize", (void*)&presetOutputs.bSolarize, P_FLAG_NONE, false, "bsolarize");
-  load_builtin_param_bool("invert", (void*)&presetOutputs.bInvert, P_FLAG_NONE, false, "binvert");
-  load_builtin_param_bool("bmotionvectorson", (void*)&presetOutputs.bMotionVectorsOn, P_FLAG_NONE, false, "");
-  load_builtin_param_bool("wave_dots", (void*)&presetOutputs.wave.dots, P_FLAG_NONE, false, "bwavedots");
-  load_builtin_param_bool("wave_thick", (void*)&presetOutputs.wave.thick, P_FLAG_NONE, false, "bwavethick");
-  // warp is turned on by default in milkdrop2
-  load_builtin_param_float("warp", (void*)&presetOutputs.warp, presetOutputs.warp_mesh,  P_FLAG_PER_PIXEL |P_FLAG_NONE, 1.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
-  // zoom=1 is the 'do nothing' value, 0 causes Inf values in PresetOutputs::PerPixelMath()
-  load_builtin_param_float("zoom", (void*)&presetOutputs.zoom, presetOutputs.zoom_mesh,  P_FLAG_PER_PIXEL |P_FLAG_NONE, 1.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
-  load_builtin_param_float("rot", (void*)&presetOutputs.rot, presetOutputs.rot_mesh,  P_FLAG_PER_PIXEL |P_FLAG_NONE, 0.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
-  // zoomexp=1 is the 'do nothing' value, 0 effectively forces zoom=1
-  load_builtin_param_float("zoomexp", (void*)&presetOutputs.zoomexp, presetOutputs.zoomexp_mesh,  P_FLAG_PER_PIXEL |P_FLAG_NONE , 1.0, MAX_DOUBLE_SIZE, 0, "fzoomexponent");
+    load_builtin_param_bool("wave_additive", (void*) &presetOutputs.wave.additive, P_FLAG_NONE, false,
+                            "bAdditiveWaves");
+    load_builtin_param_bool("bmodwavealphabyvolume", (void*) &presetOutputs.wave.modulateAlphaByVolume, P_FLAG_NONE,
+                            false, "");
+    load_builtin_param_bool("wave_brighten", (void*) &presetOutputs.wave.maximizeColors, P_FLAG_NONE, false,
+                            "bMaximizeWaveColor");
+    load_builtin_param_bool("wrap", (void*) &presetOutputs.textureWrap, P_FLAG_NONE, true, "btexwrap");
+    load_builtin_param_bool("darken_center", (void*) &presetOutputs.bDarkenCenter, P_FLAG_NONE, false, "bdarkencenter");
+    load_builtin_param_bool("bredbluestereo", (void*) &presetOutputs.bRedBlueStereo, P_FLAG_NONE, false, "");
+    load_builtin_param_bool("brighten", (void*) &presetOutputs.bBrighten, P_FLAG_NONE, false, "bbrighten");
+    load_builtin_param_bool("darken", (void*) &presetOutputs.bDarken, P_FLAG_NONE, false, "bdarken");
+    load_builtin_param_bool("solarize", (void*) &presetOutputs.bSolarize, P_FLAG_NONE, false, "bsolarize");
+    load_builtin_param_bool("invert", (void*) &presetOutputs.bInvert, P_FLAG_NONE, false, "binvert");
+    load_builtin_param_bool("bmotionvectorson", (void*) &presetOutputs.bMotionVectorsOn, P_FLAG_NONE, false, "");
+    load_builtin_param_bool("wave_dots", (void*) &presetOutputs.wave.dots, P_FLAG_NONE, false, "bwavedots");
+    load_builtin_param_bool("wave_thick", (void*) &presetOutputs.wave.thick, P_FLAG_NONE, false, "bwavethick");
+    // warp is turned on by default in milkdrop2
+    load_builtin_param_float("warp", (void*) &presetOutputs.warp, presetOutputs.warp_mesh,
+                             P_FLAG_PER_PIXEL | P_FLAG_NONE, 1.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
+    // zoom=1 is the 'do nothing' value, 0 causes Inf values in PresetOutputs::PerPixelMath()
+    load_builtin_param_float("zoom", (void*) &presetOutputs.zoom, presetOutputs.zoom_mesh,
+                             P_FLAG_PER_PIXEL | P_FLAG_NONE, 1.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
+    load_builtin_param_float("rot", (void*) &presetOutputs.rot, presetOutputs.rot_mesh, P_FLAG_PER_PIXEL | P_FLAG_NONE,
+                             0.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
+    // zoomexp=1 is the 'do nothing' value, 0 effectively forces zoom=1
+    load_builtin_param_float("zoomexp", (void*) &presetOutputs.zoomexp, presetOutputs.zoomexp_mesh,
+                             P_FLAG_PER_PIXEL | P_FLAG_NONE, 1.0, MAX_DOUBLE_SIZE, 0, "fzoomexponent");
 
-  load_builtin_param_float("cx", (void*)&presetOutputs.cx, presetOutputs.cx_mesh, P_FLAG_PER_PIXEL | P_FLAG_NONE, 0.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
-  load_builtin_param_float("cy", (void*)&presetOutputs.cy, presetOutputs.cy_mesh, P_FLAG_PER_PIXEL | P_FLAG_NONE, 0.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
-  load_builtin_param_float("dx", (void*)&presetOutputs.dx, presetOutputs.dx_mesh,  P_FLAG_PER_PIXEL | P_FLAG_NONE, 0.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
-  load_builtin_param_float("dy", (void*)&presetOutputs.dy, presetOutputs.dy_mesh,  P_FLAG_PER_PIXEL |P_FLAG_NONE, 0.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
-  // sx=1 and sy=1 are the 'do nothing' values, 0 causes Inf values in PresetOutputs::PerPixelMath()
-  load_builtin_param_float("sx", (void*)&presetOutputs.sx, presetOutputs.sx_mesh,  P_FLAG_PER_PIXEL |P_FLAG_NONE, 1.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
-  load_builtin_param_float("sy", (void*)&presetOutputs.sy, presetOutputs.sy_mesh,  P_FLAG_PER_PIXEL |P_FLAG_NONE, 1.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
-
-
-  load_builtin_param_float("b1n", (void*)&presetOutputs.blur1n, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-  load_builtin_param_float("b2n", (void*)&presetOutputs.blur2n, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-  load_builtin_param_float("b3n", (void*)&presetOutputs.blur3n, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-  load_builtin_param_float("b1x", (void*)&presetOutputs.blur1x, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-  load_builtin_param_float("b2x", (void*)&presetOutputs.blur2x, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-  load_builtin_param_float("b3x", (void*)&presetOutputs.blur3x, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-  load_builtin_param_float("b1ed", (void*)&presetOutputs.blur1ed, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-
-  load_builtin_param_float("wave_r", (void*)&presetOutputs.wave.r, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-  load_builtin_param_float("wave_g", (void*)&presetOutputs.wave.g, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-  load_builtin_param_float("wave_b", (void*)&presetOutputs.wave.b, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-  load_builtin_param_float("wave_x", (void*)&presetOutputs.wave.x, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-  load_builtin_param_float("wave_y", (void*)&presetOutputs.wave.y, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-  load_builtin_param_float("wave_mystery", (void*)&presetOutputs.wave.mystery, NULL, P_FLAG_NONE, 0.0, 1.0, -1.0, "fWaveParam");
-
-  load_builtin_param_float("ob_size", (void*)&presetOutputs.border.outer_size, NULL, P_FLAG_NONE, 0.0, 0.5, 0, "");
-  load_builtin_param_float("ob_r", (void*)&presetOutputs.border.outer_r, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-  load_builtin_param_float("ob_g", (void*)&presetOutputs.border.outer_g, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-  load_builtin_param_float("ob_b", (void*)&presetOutputs.border.outer_b, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-  load_builtin_param_float("ob_a", (void*)&presetOutputs.border.outer_a, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-
-  load_builtin_param_float("ib_size", (void*)&presetOutputs.border.inner_size,  NULL,P_FLAG_NONE, 0.0, .5, 0.0, "");
-  load_builtin_param_float("ib_r", (void*)&presetOutputs.border.inner_r,  NULL,P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-  load_builtin_param_float("ib_g", (void*)&presetOutputs.border.inner_g,  NULL,P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-  load_builtin_param_float("ib_b", (void*)&presetOutputs.border.inner_b,  NULL,P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-  load_builtin_param_float("ib_a", (void*)&presetOutputs.border.inner_a,  NULL,P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-
-  load_builtin_param_float("mv_r", (void*)&presetOutputs.mv.r,  NULL,P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-  load_builtin_param_float("mv_g", (void*)&presetOutputs.mv.g,  NULL,P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-  load_builtin_param_float("mv_b", (void*)&presetOutputs.mv.b,  NULL,P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-  load_builtin_param_float("mv_x", (void*)&presetOutputs.mv.x_num,  NULL,P_FLAG_NONE, 0.0, 64.0, 0.0, "nmotionvectorsx");
-  load_builtin_param_float("mv_y", (void*)&presetOutputs.mv.y_num,  NULL,P_FLAG_NONE, 0.0, 48.0, 0.0, "nmotionvectorsy");
-  load_builtin_param_float("mv_l", (void*)&presetOutputs.mv.length,  NULL,P_FLAG_NONE, 0.0, 5.0, 0.0, "");
-  load_builtin_param_float("mv_dx", (void*)&presetOutputs.mv.x_offset, NULL, P_FLAG_NONE, 0.0, 1.0, -1.0, "");
-  load_builtin_param_float("mv_dy", (void*)&presetOutputs.mv.y_offset,  NULL,P_FLAG_NONE, 0.0, 1.0, -1.0, "");
-  load_builtin_param_float("mv_a", (void*)&presetOutputs.mv.a,  NULL,P_FLAG_NONE, 0.0, 1.0, 0.0, "");
-
-  load_builtin_param_float("time", (void*)&presetInputs.time,  NULL,P_FLAG_READONLY, 0.0, MAX_DOUBLE_SIZE, 0.0, "");
-  load_builtin_param_float("bass", (void*)&presetInputs.bass,  NULL,P_FLAG_READONLY, 0.0, MAX_DOUBLE_SIZE, 0.0, "");
-  load_builtin_param_float("mid", (void*)&presetInputs.mid,  NULL,P_FLAG_READONLY, 0.0, MAX_DOUBLE_SIZE, 0, "");
-
-  load_builtin_param_float("treb", (void*)&presetInputs.treb,  NULL,P_FLAG_READONLY, 0.0, MAX_DOUBLE_SIZE, 0, "");
+    load_builtin_param_float("cx", (void*) &presetOutputs.cx, presetOutputs.cx_mesh, P_FLAG_PER_PIXEL | P_FLAG_NONE,
+                             0.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
+    load_builtin_param_float("cy", (void*) &presetOutputs.cy, presetOutputs.cy_mesh, P_FLAG_PER_PIXEL | P_FLAG_NONE,
+                             0.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
+    load_builtin_param_float("dx", (void*) &presetOutputs.dx, presetOutputs.dx_mesh, P_FLAG_PER_PIXEL | P_FLAG_NONE,
+                             0.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
+    load_builtin_param_float("dy", (void*) &presetOutputs.dy, presetOutputs.dy_mesh, P_FLAG_PER_PIXEL | P_FLAG_NONE,
+                             0.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
+    // sx=1 and sy=1 are the 'do nothing' values, 0 causes Inf values in PresetOutputs::PerPixelMath()
+    load_builtin_param_float("sx", (void*) &presetOutputs.sx, presetOutputs.sx_mesh, P_FLAG_PER_PIXEL | P_FLAG_NONE,
+                             1.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
+    load_builtin_param_float("sy", (void*) &presetOutputs.sy, presetOutputs.sy_mesh, P_FLAG_PER_PIXEL | P_FLAG_NONE,
+                             1.0, MAX_DOUBLE_SIZE, MIN_DOUBLE_SIZE, "");
 
 
-  load_builtin_param_float("bass_att", (void*)&presetInputs.bass_att,  NULL,P_FLAG_READONLY, 0.0, MAX_DOUBLE_SIZE, 0, "");
-  load_builtin_param_float("mid_att", (void*)&presetInputs.mid_att,  NULL, P_FLAG_READONLY, 0.0, MAX_DOUBLE_SIZE, 0, "");
-  load_builtin_param_float("treb_att", (void*)&presetInputs.treb_att,  NULL, P_FLAG_READONLY, 0.0, MAX_DOUBLE_SIZE, 0, "");
-  load_builtin_param_int("frame", (void*)&presetInputs.frame, P_FLAG_READONLY, 0, MAX_INT_SIZE, 0, "");
-  load_builtin_param_float("progress", (void*)&presetInputs.progress,  NULL,P_FLAG_READONLY, 0.0, 1, 0, "");
-  load_builtin_param_int("fps", (void*)&presetInputs.fps, P_FLAG_READONLY, 15, MAX_INT_SIZE, 0, "");
+    load_builtin_param_float("b1n", (void*) &presetOutputs.blur1n, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("b2n", (void*) &presetOutputs.blur2n, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("b3n", (void*) &presetOutputs.blur3n, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("b1x", (void*) &presetOutputs.blur1x, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("b2x", (void*) &presetOutputs.blur2x, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("b3x", (void*) &presetOutputs.blur3x, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("b1ed", (void*) &presetOutputs.blur1ed, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
 
-  load_builtin_param_float("x", (void*)&presetInputs.x_per_pixel, presetInputs.origx,  P_FLAG_PER_PIXEL |P_FLAG_ALWAYS_MATRIX | P_FLAG_READONLY | P_FLAG_NONE,
-                           0, MAX_DOUBLE_SIZE, -MAX_DOUBLE_SIZE, "");
-  load_builtin_param_float("y", (void*)&presetInputs.y_per_pixel, presetInputs.origy,  P_FLAG_PER_PIXEL |P_FLAG_ALWAYS_MATRIX |P_FLAG_READONLY | P_FLAG_NONE,
-                           0, MAX_DOUBLE_SIZE, -MAX_DOUBLE_SIZE, "");
-  load_builtin_param_float("ang", (void*)&presetInputs.ang_per_pixel, presetInputs.origtheta,  P_FLAG_PER_PIXEL |P_FLAG_ALWAYS_MATRIX | P_FLAG_READONLY | P_FLAG_NONE,
-                           0, MAX_DOUBLE_SIZE, -MAX_DOUBLE_SIZE, "");
-  load_builtin_param_float("rad", (void*)&presetInputs.rad_per_pixel, presetInputs.origrad,  P_FLAG_PER_PIXEL |P_FLAG_ALWAYS_MATRIX | P_FLAG_READONLY | P_FLAG_NONE,
-                           0, MAX_DOUBLE_SIZE, -MAX_DOUBLE_SIZE, "");
+    load_builtin_param_float("wave_r", (void*) &presetOutputs.wave.r, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("wave_g", (void*) &presetOutputs.wave.g, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("wave_b", (void*) &presetOutputs.wave.b, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("wave_x", (void*) &presetOutputs.wave.x, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("wave_y", (void*) &presetOutputs.wave.y, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("wave_mystery", (void*) &presetOutputs.wave.mystery, NULL, P_FLAG_NONE, 0.0, 1.0, -1.0,
+                             "fWaveParam");
 
-  for (unsigned int i = 0; i < NUM_Q_VARIABLES;i++) {
-	std::ostringstream os;
-	os << "q" << i+1;
-	load_builtin_param_float(os.str().c_str(), (void*)&presetOutputs.q[i],  NULL, P_FLAG_QVAR, 0, MAX_DOUBLE_SIZE, -MAX_DOUBLE_SIZE, "");
+    load_builtin_param_float("ob_size", (void*) &presetOutputs.border.outer_size, NULL, P_FLAG_NONE, 0.0, 0.5, 0, "");
+    load_builtin_param_float("ob_r", (void*) &presetOutputs.border.outer_r, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("ob_g", (void*) &presetOutputs.border.outer_g, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("ob_b", (void*) &presetOutputs.border.outer_b, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("ob_a", (void*) &presetOutputs.border.outer_a, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
 
-  }
+    load_builtin_param_float("ib_size", (void*) &presetOutputs.border.inner_size, NULL, P_FLAG_NONE, 0.0, .5, 0.0, "");
+    load_builtin_param_float("ib_r", (void*) &presetOutputs.border.inner_r, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("ib_g", (void*) &presetOutputs.border.inner_g, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("ib_b", (void*) &presetOutputs.border.inner_b, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("ib_a", (void*) &presetOutputs.border.inner_a, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
 
-  /* variables added in 1.04 */
-  load_builtin_param_int("meshx", (void*)&presetInputs.gx, P_FLAG_READONLY, 32, 96, 8, "");
-  load_builtin_param_int("meshy", (void*)&presetInputs.gy, P_FLAG_READONLY, 24, 72, 6, "");
+    load_builtin_param_float("mv_r", (void*) &presetOutputs.mv.r, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("mv_g", (void*) &presetOutputs.mv.g, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("mv_b", (void*) &presetOutputs.mv.b, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
+    load_builtin_param_float("mv_x", (void*) &presetOutputs.mv.x_num, NULL, P_FLAG_NONE, 0.0, 64.0, 0.0,
+                             "nmotionvectorsx");
+    load_builtin_param_float("mv_y", (void*) &presetOutputs.mv.y_num, NULL, P_FLAG_NONE, 0.0, 48.0, 0.0,
+                             "nmotionvectorsy");
+    load_builtin_param_float("mv_l", (void*) &presetOutputs.mv.length, NULL, P_FLAG_NONE, 0.0, 5.0, 0.0, "");
+    load_builtin_param_float("mv_dx", (void*) &presetOutputs.mv.x_offset, NULL, P_FLAG_NONE, 0.0, 1.0, -1.0, "");
+    load_builtin_param_float("mv_dy", (void*) &presetOutputs.mv.y_offset, NULL, P_FLAG_NONE, 0.0, 1.0, -1.0, "");
+    load_builtin_param_float("mv_a", (void*) &presetOutputs.mv.a, NULL, P_FLAG_NONE, 0.0, 1.0, 0.0, "");
 
-  return PROJECTM_SUCCESS;
+    load_builtin_param_float("time", (void*) &presetInputs.time, NULL, P_FLAG_READONLY, 0.0, MAX_DOUBLE_SIZE, 0.0, "");
+    load_builtin_param_float("bass", (void*) &presetInputs.bass, NULL, P_FLAG_READONLY, 0.0, MAX_DOUBLE_SIZE, 0.0, "");
+    load_builtin_param_float("mid", (void*) &presetInputs.mid, NULL, P_FLAG_READONLY, 0.0, MAX_DOUBLE_SIZE, 0, "");
+
+    load_builtin_param_float("treb", (void*) &presetInputs.treb, NULL, P_FLAG_READONLY, 0.0, MAX_DOUBLE_SIZE, 0, "");
+
+
+    load_builtin_param_float("bass_att", (void*) &presetInputs.bass_att, NULL, P_FLAG_READONLY, 0.0, MAX_DOUBLE_SIZE, 0,
+                             "");
+    load_builtin_param_float("mid_att", (void*) &presetInputs.mid_att, NULL, P_FLAG_READONLY, 0.0, MAX_DOUBLE_SIZE, 0,
+                             "");
+    load_builtin_param_float("treb_att", (void*) &presetInputs.treb_att, NULL, P_FLAG_READONLY, 0.0, MAX_DOUBLE_SIZE, 0,
+                             "");
+    load_builtin_param_int("frame", (void*) &presetInputs.frame, P_FLAG_READONLY, 0, MAX_INT_SIZE, 0, "");
+    load_builtin_param_float("progress", (void*) &presetInputs.progress, NULL, P_FLAG_READONLY, 0.0, 1, 0, "");
+    load_builtin_param_int("fps", (void*) &presetInputs.fps, P_FLAG_READONLY, 15, MAX_INT_SIZE, 0, "");
+
+    load_builtin_param_float("x", (void*) &presetInputs.x_per_pixel, presetInputs.origx,
+                             P_FLAG_PER_PIXEL | P_FLAG_ALWAYS_MATRIX | P_FLAG_READONLY | P_FLAG_NONE,
+                             0, MAX_DOUBLE_SIZE, -MAX_DOUBLE_SIZE, "");
+    load_builtin_param_float("y", (void*) &presetInputs.y_per_pixel, presetInputs.origy,
+                             P_FLAG_PER_PIXEL | P_FLAG_ALWAYS_MATRIX | P_FLAG_READONLY | P_FLAG_NONE,
+                             0, MAX_DOUBLE_SIZE, -MAX_DOUBLE_SIZE, "");
+    load_builtin_param_float("ang", (void*) &presetInputs.ang_per_pixel, presetInputs.origtheta,
+                             P_FLAG_PER_PIXEL | P_FLAG_ALWAYS_MATRIX | P_FLAG_READONLY | P_FLAG_NONE,
+                             0, MAX_DOUBLE_SIZE, -MAX_DOUBLE_SIZE, "");
+    load_builtin_param_float("rad", (void*) &presetInputs.rad_per_pixel, presetInputs.origrad,
+                             P_FLAG_PER_PIXEL | P_FLAG_ALWAYS_MATRIX | P_FLAG_READONLY | P_FLAG_NONE,
+                             0, MAX_DOUBLE_SIZE, -MAX_DOUBLE_SIZE, "");
+
+    for (unsigned int i = 0; i < NUM_Q_VARIABLES; i++)
+    {
+        std::ostringstream os;
+        os << "q" << i + 1;
+        load_builtin_param_float(os.str().c_str(), (void*) &presetOutputs.q[i], NULL, P_FLAG_QVAR, 0, MAX_DOUBLE_SIZE,
+                                 -MAX_DOUBLE_SIZE, "");
+
+    }
+
+    /* variables added in 1.04 */
+    load_builtin_param_int("meshx", (void*) &presetInputs.gx, P_FLAG_READONLY, 32, 96, 8, "");
+    load_builtin_param_int("meshy", (void*) &presetInputs.gy, P_FLAG_READONLY, 24, 72, 6, "");
+
+    return PROJECTM_SUCCESS;
 
 }
 

--- a/src/libprojectM/MilkdropPresetFactory/BuiltinParams.hpp
+++ b/src/libprojectM/MilkdropPresetFactory/BuiltinParams.hpp
@@ -44,16 +44,9 @@ public:
 
     /** Construct a new builtin parameter database with variables references given by
      * the preset input and output structures */
-    BuiltinParams(PresetInputs& presetInputs, PresetOutputs& presetOutputs);
+    BuiltinParams(PresetInputs& presetInputs, PresetOutputs* presetOutputs);
 
     ~BuiltinParams();
-
-    /** Param database initalizer / destructor functions */
-    int init_builtin_param_db(const PresetInputs& presetInputs, PresetOutputs& presetOutputs);
-
-    int load_all_builtin_param(const PresetInputs& presetInputs, PresetOutputs& presetOutputs);
-
-    int destroy_builtin_param_db();
 
     int insert_param_alt_name(Param* param, const std::string& salt_name);
 
@@ -81,6 +74,14 @@ public:
         traverse(builtin_param_tree, fun);
     }
 
+
+protected:
+    /** Param database initalizer / destructor functions */
+    int init_builtin_param_db(const PresetInputs& presetInputs, PresetOutputs* presetOutputs);
+
+    int load_all_builtin_param(const PresetInputs& presetInputs, PresetOutputs* presetOutputs);
+
+    int destroy_builtin_param_db();
 
 private:
     static const bool BUILTIN_PARAMS_DEBUG = false;

--- a/src/libprojectM/MilkdropPresetFactory/BuiltinParams.hpp
+++ b/src/libprojectM/MilkdropPresetFactory/BuiltinParams.hpp
@@ -33,44 +33,52 @@
 #include <map>
 #include <cstdio>
 
-class BuiltinParams {
+class BuiltinParams
+{
 
 public:
-   typedef std::map<std::string, std::string> AliasMap;
+    typedef std::map<std::string, std::string> AliasMap;
 
     /** Default constructor leaves database in an uninitialized state.  */
     BuiltinParams();
 
     /** Construct a new builtin parameter database with variables references given by
      * the preset input and output structures */
-     BuiltinParams(PresetInputs &  presetInputs, PresetOutputs & presetOutputs);
+    BuiltinParams(PresetInputs& presetInputs, PresetOutputs& presetOutputs);
 
     ~BuiltinParams();
 
     /** Param database initalizer / destructor functions */
-    int init_builtin_param_db(const PresetInputs & presetInputs, PresetOutputs & presetOutputs);
-    int load_all_builtin_param(const PresetInputs & presetInputs, PresetOutputs & presetOutputs);
+    int init_builtin_param_db(const PresetInputs& presetInputs, PresetOutputs& presetOutputs);
+
+    int load_all_builtin_param(const PresetInputs& presetInputs, PresetOutputs& presetOutputs);
+
     int destroy_builtin_param_db();
 
-    int insert_param_alt_name( Param *param, const std::string& salt_name );
-    Param *find_builtin_param( const std::string & name );
-    int load_builtin_param_float( const std::string & name, void *engine_val, void *matrix,
-                                  short int flags,
-                                  float init_val, float upper_bound,
-                                  float lower_bound, const std::string & alt_name );
-    int load_builtin_param_int( const std::string & name, void *engine_val, short int flags,
-                                int init_val, int upper_bound,
-                                int lower_bound, const std::string & alt_name );
-    int load_builtin_param_bool( const std::string & name, void *engine_val, short int flags,
-                                int init_val, const std::string & alt_name );
+    int insert_param_alt_name(Param* param, const std::string& salt_name);
 
-    int load_builtin_param_string( const std::string & name, std::string * engine_val, short int flags);
+    Param* find_builtin_param(const std::string& name);
 
-    int insert_builtin_param( Param *param );
+    int load_builtin_param_float(const std::string& name, void* engine_val, void* matrix,
+                                 short int flags,
+                                 float init_val, float upper_bound,
+                                 float lower_bound, const std::string& alt_name);
 
-    template <class Fun>
-    void apply(Fun & fun) {
-	traverse(builtin_param_tree, fun);
+    int load_builtin_param_int(const std::string& name, void* engine_val, short int flags,
+                               int init_val, int upper_bound,
+                               int lower_bound, const std::string& alt_name);
+
+    int load_builtin_param_bool(const std::string& name, void* engine_val, short int flags,
+                                int init_val, const std::string& alt_name);
+
+    int load_builtin_param_string(const std::string& name, std::string* engine_val, short int flags);
+
+    int insert_builtin_param(Param* param);
+
+    template<class Fun>
+    void apply(Fun& fun)
+    {
+        traverse(builtin_param_tree, fun);
     }
 
 
@@ -81,6 +89,7 @@ private:
     AliasMap aliasMap;
 
     // Internal datastructure to store the parameters
-    std::map<std::string,Param*> builtin_param_tree;
+    std::map<std::string, Param*> builtin_param_tree;
 };
+
 #endif

--- a/src/libprojectM/MilkdropPresetFactory/IdlePreset.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/IdlePreset.cpp
@@ -2,209 +2,218 @@
 #include <sstream>
 #include <string>
 #include "MilkdropPreset.hpp"
+
 const std::string IdlePresets::IDLE_PRESET_NAME
-	("Geiss & Sperl - Feedback (projectM idle HDR mix).milk");
+    ("Geiss & Sperl - Feedback (projectM idle HDR mix).milk");
 
-std::string IdlePresets::presetText() {
+std::string IdlePresets::presetText()
+{
 
-std::ostringstream out;
+    std::ostringstream out;
 
-out << "[preset00]\n" <<
-"fRating=2.000000\n" <<
-"fGammaAdj=1.700000\n" <<
-"fDecay=0.940000\n" <<
-"fVideoEchoZoom=1.000000\n" <<
-"fVideoEchoAlpha=0.000000\n" <<
-"nVideoEchoOrientation=0\n" <<
-"nWaveMode=0\n" <<
-"bAdditiveWaves=1\n" <<
-"bWaveDots=0\n" <<
-"bWaveThick=0\n" <<
-"bModWaveAlphaByVolume=0\n" <<
-"bMaximizeWaveColor=0\n" <<
-"bTexWrap=1\n" <<
-"bDarkenCenter=0\n" <<
-"bRedBlueStereo=0\n" <<
-"bBrighten=0\n" <<
-"bDarken=0\n" <<
-"bSolarize=0\n" <<
-"bInvert=0\n" <<
-"fWaveAlpha=0.001000\n" <<
-"fWaveScale=0.010000\n" <<
-"fWaveSmoothing=0.630000\n" <<
-"fWaveParam=-1.000000\n" <<
-"fModWaveAlphaStart=0.710000\n" <<
-"fModWaveAlphaEnd=1.300000\n" <<
-"fWarpAnimSpeed=1.000000\n" <<
-"fWarpScale=1.331000\n" <<
-"fZoomExponent=1.000000\n" <<
-"fShader=0.000000\n" <<
-"zoom=13.290894\n" <<
-"rot=-0.020000\n" <<
-"cx=0.500000\n" <<
-"cy=0.500000\n" <<
-"dx=-0.280000\n" <<
-"dy=-0.320000\n" <<
-"warp=0.010000\n" <<
-"sx=1.000000\n" <<
-"sy=1.000000\n" <<
-"wave_r=0.650000\n" <<
-"wave_g=0.650000\n" <<
-"wave_b=0.650000\n" <<
-"wave_x=0.500000\n" <<
-"wave_y=0.500000\n" <<
-"ob_size=0.000000\n" <<
-"ob_r=0.010000\n" <<
-"ob_g=0.000000\n" <<
-"ob_b=0.000000\n" <<
-"ob_a=1.000000\n" <<
-"ib_size=0.000000\n" <<
-"ib_r=0.950000\n" <<
-"ib_g=0.850000\n" <<
-"ib_b=0.650000\n" <<
-"ib_a=1.000000\n" <<
-"nMotionVectorsX=64.000000\n" <<
-"nMotionVectorsY=0.000000\n" <<
-"mv_dx=0.000000\n" <<
-"mv_dy=0.000000\n" <<
-"mv_l=0.900000\n" <<
-"mv_r=1.000000\n" <<
-"mv_g=1.000000\n" <<
-"mv_b=1.000000\n" <<
-"mv_a=0.000000\n" <<
-"shapecode_3_enabled=1\n" <<
-"shapecode_3_sides=20\n" <<
-"shapecode_3_additive=0\n" <<
-"shapecode_3_thickOutline=0\n" <<
-"shapecode_3_textured=1\n" <<
-"shapecode_3_ImageURL=M.tga\n" <<
-"shapecode_3_x=0.68\n" <<
-"shapecode_3_y=0.5\n" <<
-"shapecode_3_rad=0.41222\n" <<
-"shapecode_3_ang=0\n" <<
-"shapecode_3_tex_ang=0\n" <<
-"shapecode_3_tex_zoom=0.71\n" <<
-"shapecode_3_r=1\n" <<
-"shapecode_3_g=1\n" <<
-"shapecode_3_b=1\n" <<
-"shapecode_3_a=1\n" <<
-"shapecode_3_r2=1\n" <<
-"shapecode_3_g2=1\n" <<
-"shapecode_3_b2=1\n" <<
-"shapecode_3_a2=1\n" <<
-"shapecode_3_border_r=0\n" <<
-"shapecode_3_border_g=0\n" <<
-"shapecode_3_border_b=0\n" <<
-"shapecode_3_border_a=0\n" <<
-"shape_3_per_frame1=x = x + q1;\n" <<
-"shape_3_per_frame2=y = y + q2;\n" <<
-"shape_3_per_frame3=r =0.5 + 0.5*sin(q8*0.613 + 1);\n" <<
-"shape_3_per_frame4=g = 0.5 + 0.5*sin(q8*0.763 + 2);\n" <<
-"shape_3_per_frame5=b = 0.5 + 0.5*sin(q8*0.771 + 5);\n" <<
-"shape_3_per_frame6=r2 = 0.5 + 0.5*sin(q8*0.635 + 4);\n" <<
-"shape_3_per_frame7=g2 = 0.5 + 0.5*sin(q8*0.616+ 1);\n" <<
-"shape_3_per_frame8=b2 = 0.5 + 0.5*sin(q8*0.538 + 3);\n" <<
-"shapecode_4_enabled=1\n" <<
-"shapecode_4_sides=4\n" <<
-"shapecode_4_additive=0\n" <<
-"shapecode_4_thickOutline=0\n" <<
-"shapecode_4_textured=1\n" <<
-"shapecode_4_ImageURL=headphones.tga\n" <<
-"shapecode_4_x=0.68\n" <<
-"shapecode_4_y=0.58\n" <<
-"shapecode_4_rad=0.6\n" <<
-"shapecode_4_ang=0\n" <<
-"shapecode_4_tex_ang=0\n" <<
-"shapecode_4_tex_zoom=0.71\n" <<
-"shapecode_4_r=1\n" <<
-"shapecode_4_g=1\n" <<
-"shapecode_4_b=1\n" <<
-"shapecode_4_a=1\n" <<
-"shapecode_4_r2=1\n" <<
-"shapecode_4_g2=1\n" <<
-"shapecode_4_b2=1\n" <<
-"shapecode_4_a2=1\n" <<
-"shapecode_4_border_r=0\n" <<
-"shapecode_4_border_g=0\n" <<
-"shapecode_4_border_b=0\n" <<
-"shapecode_4_border_a=0\n" <<
-"shape_4_per_frame1=x = x + q1;\n" <<
-"shape_4_per_frame2=y = y + q2;\n" <<
-"shape_4_per_frame3=rad = rad + bass * 0.1;\n" <<
-"shape_4_per_frame4=a = q3;\n" <<
-"shape_4_per_frame5=a2 = q3;\n" <<
-// disabling projectM logo thingey
-// "shapecode_6_enabled=1\n" <<
-// "shapecode_6_sides=4\n" <<
-// "shapecode_6_additive=0\n" <<
-// "shapecode_6_thickOutline=0\n" <<
-// "shapecode_6_textured=1\n" <<
-// "shapecode_6_ImageURL=project.tga\n" <<
-// "shapecode_6_x=0.38\n" <<
-// "shapecode_6_y=0.435\n" <<
-// "shapecode_6_rad=0.8\n" <<
-// "shapecode_6_ang=0\n" <<
-// "shapecode_6_tex_ang=0\n" <<
-// "shapecode_6_tex_zoom=0.71\n" <<
-// "shapecode_6_r=1\n" <<
-// "shapecode_6_g=1\n" <<
-// "shapecode_6_b=1\n" <<
-// "shapecode_6_a=1\n" <<
-// "shapecode_6_r2=1\n" <<
-// "shapecode_6_g2=1\n" <<
-// "shapecode_6_b2=1\n" <<
-// "shapecode_6_a2=1\n" <<
-// "shapecode_6_border_r=0\n" <<
-// "shapecode_6_border_g=0\n" <<
-// "shapecode_6_border_b=0\n" <<
-// "shapecode_6_border_a=0\n" <<
-// "shape_6_per_frame1=x = x + q1;\n" <<
-// "shape_6_per_frame2=y = y + q2;\n" <<
-// "shape_6_per_frame3=a = q3;\n" <<
-// "shape_6_per_frame4=a2 = q3;\n" <<
-"per_frame_1=ob_r = 0.5 + 0.4*sin(time*1.324);\n" <<
-"per_frame_2=ob_g = 0.5 + 0.4*cos(time*1.371);\n" <<
-"per_frame_3=ob_b = 0.5+0.4*sin(2.332*time);\n" <<
-"per_frame_4=ib_r = 0.5 + 0.25*sin(time*1.424);\n" <<
-"per_frame_5=ib_g = 0.25 + 0.25*cos(time*1.871);\n" <<
-"per_frame_6=ib_b = 1-ob_b;\n" <<
-"per_frame_7=volume = 0.15*(bass+bass_att+treb+treb_att+mid+mid_att);\n" <<
-"per_frame_8=xamptarg = if(equal(frame%15,0),min(0.5*volume*bass_att,0.5),xamptarg);\n" <<
-"per_frame_9=xamp = xamp + 0.5*(xamptarg-xamp);\n" <<
-"per_frame_10=xdir = if(above(abs(xpos),xamp),-sign(xpos),if(below(abs(xspeed),0.1),2*above(xpos,0)-1,xdir));\n" <<
-"per_frame_11=xaccel = xdir*xamp - xpos - xspeed*0.055*below(abs(xpos),xamp);\n" <<
-"per_frame_12=xspeed = xspeed + xdir*xamp - xpos - xspeed*0.055*below(abs(xpos),xamp);\n" <<
-"per_frame_13=xpos = xpos + 0.001*xspeed;\n" <<
-"per_frame_14=dx = xpos*0.05;\n" <<
-"per_frame_15=yamptarg = if(equal(frame%15,0),min(0.3*volume*treb_att,0.5),yamptarg);\n" <<
-"per_frame_16=yamp = yamp + 0.5*(yamptarg-yamp);\n" <<
-"per_frame_17=ydir = if(above(abs(ypos),yamp),-sign(ypos),if(below(abs(yspeed),0.1),2*above(ypos,0)-1,ydir));\n" <<
-"per_frame_18=yaccel = ydir*yamp - ypos - yspeed*0.055*below(abs(ypos),yamp);\n" <<
-"per_frame_19=yspeed = yspeed + ydir*yamp - ypos - yspeed*0.055*below(abs(ypos),yamp);\n" <<
-"per_frame_20=ypos = ypos + 0.001*yspeed;\n" <<
-"per_frame_21=dy = ypos*0.05;\n" <<
-"per_frame_22=wave_a = 0;\n" <<
-"per_frame_23=q8 = oldq8 + 0.0003*(pow(1+1.2*bass+0.4*bass_att+0.1*treb+0.1*treb_att+0.1*mid+0.1*mid_att,6)/fps);\n" <<
-"per_frame_24=oldq8 = q8;\n" <<
-"per_frame_25=q7 = 0.003*(pow(1+1.2*bass+0.4*bass_att+0.1*treb+0.1*treb_att+0.1*mid+0.1*mid_att,6)/fps);\n" <<
-"per_frame_26=rot = 0.4 + 1.5*sin(time*0.273) + 0.4*sin(time*0.379+3);\n" <<
-"per_frame_27=q1 = 0.05*sin(time*1.14);\n" <<
-"per_frame_28=q2 = 0.03*sin(time*0.93+2);\n" <<
-"per_frame_29=q3 = if(above(frame,60),1, frame/60.0);\n" <<
-"per_frame_30=oldq8 = if(above(oldq8,1000),0,oldq8);\n" <<
-"per_pixel_1=zoom =( log(sqrt(2)-rad) -0.24)*1;\n";
+    out << "[preset00]\n" <<
+        "fRating=2.000000\n" <<
+        "fGammaAdj=1.700000\n" <<
+        "fDecay=0.940000\n" <<
+        "fVideoEchoZoom=1.000000\n" <<
+        "fVideoEchoAlpha=0.000000\n" <<
+        "nVideoEchoOrientation=0\n" <<
+        "nWaveMode=0\n" <<
+        "bAdditiveWaves=1\n" <<
+        "bWaveDots=0\n" <<
+        "bWaveThick=0\n" <<
+        "bModWaveAlphaByVolume=0\n" <<
+        "bMaximizeWaveColor=0\n" <<
+        "bTexWrap=1\n" <<
+        "bDarkenCenter=0\n" <<
+        "bRedBlueStereo=0\n" <<
+        "bBrighten=0\n" <<
+        "bDarken=0\n" <<
+        "bSolarize=0\n" <<
+        "bInvert=0\n" <<
+        "fWaveAlpha=0.001000\n" <<
+        "fWaveScale=0.010000\n" <<
+        "fWaveSmoothing=0.630000\n" <<
+        "fWaveParam=-1.000000\n" <<
+        "fModWaveAlphaStart=0.710000\n" <<
+        "fModWaveAlphaEnd=1.300000\n" <<
+        "fWarpAnimSpeed=1.000000\n" <<
+        "fWarpScale=1.331000\n" <<
+        "fZoomExponent=1.000000\n" <<
+        "fShader=0.000000\n" <<
+        "zoom=13.290894\n" <<
+        "rot=-0.020000\n" <<
+        "cx=0.500000\n" <<
+        "cy=0.500000\n" <<
+        "dx=-0.280000\n" <<
+        "dy=-0.320000\n" <<
+        "warp=0.010000\n" <<
+        "sx=1.000000\n" <<
+        "sy=1.000000\n" <<
+        "wave_r=0.650000\n" <<
+        "wave_g=0.650000\n" <<
+        "wave_b=0.650000\n" <<
+        "wave_x=0.500000\n" <<
+        "wave_y=0.500000\n" <<
+        "ob_size=0.000000\n" <<
+        "ob_r=0.010000\n" <<
+        "ob_g=0.000000\n" <<
+        "ob_b=0.000000\n" <<
+        "ob_a=1.000000\n" <<
+        "ib_size=0.000000\n" <<
+        "ib_r=0.950000\n" <<
+        "ib_g=0.850000\n" <<
+        "ib_b=0.650000\n" <<
+        "ib_a=1.000000\n" <<
+        "nMotionVectorsX=64.000000\n" <<
+        "nMotionVectorsY=0.000000\n" <<
+        "mv_dx=0.000000\n" <<
+        "mv_dy=0.000000\n" <<
+        "mv_l=0.900000\n" <<
+        "mv_r=1.000000\n" <<
+        "mv_g=1.000000\n" <<
+        "mv_b=1.000000\n" <<
+        "mv_a=0.000000\n" <<
+        "shapecode_3_enabled=1\n" <<
+        "shapecode_3_sides=20\n" <<
+        "shapecode_3_additive=0\n" <<
+        "shapecode_3_thickOutline=0\n" <<
+        "shapecode_3_textured=1\n" <<
+        "shapecode_3_ImageURL=M.tga\n" <<
+        "shapecode_3_x=0.68\n" <<
+        "shapecode_3_y=0.5\n" <<
+        "shapecode_3_rad=0.41222\n" <<
+        "shapecode_3_ang=0\n" <<
+        "shapecode_3_tex_ang=0\n" <<
+        "shapecode_3_tex_zoom=0.71\n" <<
+        "shapecode_3_r=1\n" <<
+        "shapecode_3_g=1\n" <<
+        "shapecode_3_b=1\n" <<
+        "shapecode_3_a=1\n" <<
+        "shapecode_3_r2=1\n" <<
+        "shapecode_3_g2=1\n" <<
+        "shapecode_3_b2=1\n" <<
+        "shapecode_3_a2=1\n" <<
+        "shapecode_3_border_r=0\n" <<
+        "shapecode_3_border_g=0\n" <<
+        "shapecode_3_border_b=0\n" <<
+        "shapecode_3_border_a=0\n" <<
+        "shape_3_per_frame1=x = x + q1;\n" <<
+        "shape_3_per_frame2=y = y + q2;\n" <<
+        "shape_3_per_frame3=r =0.5 + 0.5*sin(q8*0.613 + 1);\n" <<
+        "shape_3_per_frame4=g = 0.5 + 0.5*sin(q8*0.763 + 2);\n" <<
+        "shape_3_per_frame5=b = 0.5 + 0.5*sin(q8*0.771 + 5);\n" <<
+        "shape_3_per_frame6=r2 = 0.5 + 0.5*sin(q8*0.635 + 4);\n" <<
+        "shape_3_per_frame7=g2 = 0.5 + 0.5*sin(q8*0.616+ 1);\n" <<
+        "shape_3_per_frame8=b2 = 0.5 + 0.5*sin(q8*0.538 + 3);\n" <<
+        "shapecode_4_enabled=1\n" <<
+        "shapecode_4_sides=4\n" <<
+        "shapecode_4_additive=0\n" <<
+        "shapecode_4_thickOutline=0\n" <<
+        "shapecode_4_textured=1\n" <<
+        "shapecode_4_ImageURL=headphones.tga\n" <<
+        "shapecode_4_x=0.68\n" <<
+        "shapecode_4_y=0.58\n" <<
+        "shapecode_4_rad=0.6\n" <<
+        "shapecode_4_ang=0\n" <<
+        "shapecode_4_tex_ang=0\n" <<
+        "shapecode_4_tex_zoom=0.71\n" <<
+        "shapecode_4_r=1\n" <<
+        "shapecode_4_g=1\n" <<
+        "shapecode_4_b=1\n" <<
+        "shapecode_4_a=1\n" <<
+        "shapecode_4_r2=1\n" <<
+        "shapecode_4_g2=1\n" <<
+        "shapecode_4_b2=1\n" <<
+        "shapecode_4_a2=1\n" <<
+        "shapecode_4_border_r=0\n" <<
+        "shapecode_4_border_g=0\n" <<
+        "shapecode_4_border_b=0\n" <<
+        "shapecode_4_border_a=0\n" <<
+        "shape_4_per_frame1=x = x + q1;\n" <<
+        "shape_4_per_frame2=y = y + q2;\n" <<
+        "shape_4_per_frame3=rad = rad + bass * 0.1;\n" <<
+        "shape_4_per_frame4=a = q3;\n" <<
+        "shape_4_per_frame5=a2 = q3;\n" <<
+        // disabling projectM logo thingey
+        // "shapecode_6_enabled=1\n" <<
+        // "shapecode_6_sides=4\n" <<
+        // "shapecode_6_additive=0\n" <<
+        // "shapecode_6_thickOutline=0\n" <<
+        // "shapecode_6_textured=1\n" <<
+        // "shapecode_6_ImageURL=project.tga\n" <<
+        // "shapecode_6_x=0.38\n" <<
+        // "shapecode_6_y=0.435\n" <<
+        // "shapecode_6_rad=0.8\n" <<
+        // "shapecode_6_ang=0\n" <<
+        // "shapecode_6_tex_ang=0\n" <<
+        // "shapecode_6_tex_zoom=0.71\n" <<
+        // "shapecode_6_r=1\n" <<
+        // "shapecode_6_g=1\n" <<
+        // "shapecode_6_b=1\n" <<
+        // "shapecode_6_a=1\n" <<
+        // "shapecode_6_r2=1\n" <<
+        // "shapecode_6_g2=1\n" <<
+        // "shapecode_6_b2=1\n" <<
+        // "shapecode_6_a2=1\n" <<
+        // "shapecode_6_border_r=0\n" <<
+        // "shapecode_6_border_g=0\n" <<
+        // "shapecode_6_border_b=0\n" <<
+        // "shapecode_6_border_a=0\n" <<
+        // "shape_6_per_frame1=x = x + q1;\n" <<
+        // "shape_6_per_frame2=y = y + q2;\n" <<
+        // "shape_6_per_frame3=a = q3;\n" <<
+        // "shape_6_per_frame4=a2 = q3;\n" <<
+        "per_frame_1=ob_r = 0.5 + 0.4*sin(time*1.324);\n" <<
+        "per_frame_2=ob_g = 0.5 + 0.4*cos(time*1.371);\n" <<
+        "per_frame_3=ob_b = 0.5+0.4*sin(2.332*time);\n" <<
+        "per_frame_4=ib_r = 0.5 + 0.25*sin(time*1.424);\n" <<
+        "per_frame_5=ib_g = 0.25 + 0.25*cos(time*1.871);\n" <<
+        "per_frame_6=ib_b = 1-ob_b;\n" <<
+        "per_frame_7=volume = 0.15*(bass+bass_att+treb+treb_att+mid+mid_att);\n" <<
+        "per_frame_8=xamptarg = if(equal(frame%15,0),min(0.5*volume*bass_att,0.5),xamptarg);\n" <<
+        "per_frame_9=xamp = xamp + 0.5*(xamptarg-xamp);\n" <<
+        "per_frame_10=xdir = if(above(abs(xpos),xamp),-sign(xpos),if(below(abs(xspeed),0.1),2*above(xpos,0)-1,xdir));\n"
+        <<
+        "per_frame_11=xaccel = xdir*xamp - xpos - xspeed*0.055*below(abs(xpos),xamp);\n" <<
+        "per_frame_12=xspeed = xspeed + xdir*xamp - xpos - xspeed*0.055*below(abs(xpos),xamp);\n" <<
+        "per_frame_13=xpos = xpos + 0.001*xspeed;\n" <<
+        "per_frame_14=dx = xpos*0.05;\n" <<
+        "per_frame_15=yamptarg = if(equal(frame%15,0),min(0.3*volume*treb_att,0.5),yamptarg);\n" <<
+        "per_frame_16=yamp = yamp + 0.5*(yamptarg-yamp);\n" <<
+        "per_frame_17=ydir = if(above(abs(ypos),yamp),-sign(ypos),if(below(abs(yspeed),0.1),2*above(ypos,0)-1,ydir));\n"
+        <<
+        "per_frame_18=yaccel = ydir*yamp - ypos - yspeed*0.055*below(abs(ypos),yamp);\n" <<
+        "per_frame_19=yspeed = yspeed + ydir*yamp - ypos - yspeed*0.055*below(abs(ypos),yamp);\n" <<
+        "per_frame_20=ypos = ypos + 0.001*yspeed;\n" <<
+        "per_frame_21=dy = ypos*0.05;\n" <<
+        "per_frame_22=wave_a = 0;\n" <<
+        "per_frame_23=q8 = oldq8 + 0.0003*(pow(1+1.2*bass+0.4*bass_att+0.1*treb+0.1*treb_att+0.1*mid+0.1*mid_att,6)/fps);\n"
+        <<
+        "per_frame_24=oldq8 = q8;\n" <<
+        "per_frame_25=q7 = 0.003*(pow(1+1.2*bass+0.4*bass_att+0.1*treb+0.1*treb_att+0.1*mid+0.1*mid_att,6)/fps);\n" <<
+        "per_frame_26=rot = 0.4 + 1.5*sin(time*0.273) + 0.4*sin(time*0.379+3);\n" <<
+        "per_frame_27=q1 = 0.05*sin(time*1.14);\n" <<
+        "per_frame_28=q2 = 0.03*sin(time*0.93+2);\n" <<
+        "per_frame_29=q3 = if(above(frame,60),1, frame/60.0);\n" <<
+        "per_frame_30=oldq8 = if(above(oldq8,1000),0,oldq8);\n" <<
+        "per_pixel_1=zoom =( log(sqrt(2)-rad) -0.24)*1;\n";
 
-return out.str();
+    return out.str();
 
 }
 
-std::unique_ptr<Preset> IdlePresets::allocate(MilkdropPresetFactory *factory, const std::string & name, PresetOutputs & presetOutputs)
+std::unique_ptr<Preset>
+IdlePresets::allocate(MilkdropPresetFactory* factory, const std::string& name, PresetOutputs& presetOutputs)
 {
 
-  if (name == IDLE_PRESET_NAME) {
-  	std::istringstream in(presetText());
-  	return std::unique_ptr<Preset>(new MilkdropPreset(factory, in, IDLE_PRESET_NAME, presetOutputs));
-  }
-  else
-    return std::unique_ptr<Preset>();
+    if (name == IDLE_PRESET_NAME)
+    {
+        std::istringstream in(presetText());
+        return std::unique_ptr<Preset>(new MilkdropPreset(factory, in, IDLE_PRESET_NAME, presetOutputs));
+    }
+    else
+    {
+        return std::unique_ptr<Preset>();
+    }
 }

--- a/src/libprojectM/MilkdropPresetFactory/IdlePreset.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/IdlePreset.cpp
@@ -204,7 +204,7 @@ std::string IdlePresets::presetText()
 }
 
 std::unique_ptr<Preset>
-IdlePresets::allocate(MilkdropPresetFactory* factory, const std::string& name, PresetOutputs& presetOutputs)
+IdlePresets::allocate(MilkdropPresetFactory* factory, const std::string& name, PresetOutputs* presetOutputs)
 {
 
     if (name == IDLE_PRESET_NAME)

--- a/src/libprojectM/MilkdropPresetFactory/IdlePreset.hpp
+++ b/src/libprojectM/MilkdropPresetFactory/IdlePreset.hpp
@@ -1,22 +1,30 @@
 #ifndef IDLE_PRESET_HPP
 #define IDLE_PRESET_HPP
+
 #include <memory>
 #include <string>
 
 class MilkdropPresetFactory;
+
 class PresetOutputs;
+
 class Preset;
 
 /// A preset that does not depend on the file system to be loaded. This allows projectM to render
 /// something (ie. self indulgent project advertising) even when no valid preset directory is found.
-class IdlePresets {
+class IdlePresets
+{
 
-  public:
-	/// Allocate a new idle preset instance
-	/// \returns a newly allocated auto pointer of an idle preset instance
-	static std::unique_ptr<Preset> allocate(MilkdropPresetFactory *factory, const std::string & path, PresetOutputs & outputs);
-  private:
-	static std::string presetText();
-	static const std::string IDLE_PRESET_NAME;
+public:
+    /// Allocate a new idle preset instance
+    /// \returns a newly allocated auto pointer of an idle preset instance
+    static std::unique_ptr<Preset>
+    allocate(MilkdropPresetFactory* factory, const std::string& path, PresetOutputs& outputs);
+
+private:
+    static std::string presetText();
+
+    static const std::string IDLE_PRESET_NAME;
 };
+
 #endif

--- a/src/libprojectM/MilkdropPresetFactory/IdlePreset.hpp
+++ b/src/libprojectM/MilkdropPresetFactory/IdlePreset.hpp
@@ -19,7 +19,7 @@ public:
     /// Allocate a new idle preset instance
     /// \returns a newly allocated auto pointer of an idle preset instance
     static std::unique_ptr<Preset>
-    allocate(MilkdropPresetFactory* factory, const std::string& path, PresetOutputs& outputs);
+    allocate(MilkdropPresetFactory* factory, const std::string& path, PresetOutputs* outputs);
 
 private:
     static std::string presetText();

--- a/src/libprojectM/MilkdropPresetFactory/MilkdropPreset.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/MilkdropPreset.cpp
@@ -26,8 +26,11 @@
 #ifdef WIN32
 #include "dirent.h"
 #else
+
 #include <dirent.h>
+
 #endif /** WIN32 */
+
 #include <time.h>
 
 #include "MilkdropPreset.hpp"
@@ -45,230 +48,257 @@
 #include "MilkdropPresetFactory.hpp"
 
 #ifdef __SSE2__
+
 #include <immintrin.h>
+
 #endif
 
 
-MilkdropPreset::MilkdropPreset(MilkdropPresetFactory *factory, std::istream & in, const std::string & presetName,  PresetOutputs & presetOutputs):
-	Preset(presetName),
-    builtinParams(_presetInputs, presetOutputs),
-    per_pixel_program(nullptr),
-    _factory(factory),
-    _presetOutputs(presetOutputs)
+MilkdropPreset::MilkdropPreset(MilkdropPresetFactory* factory, std::istream& in, const std::string& presetName,
+                               PresetOutputs& presetOutputs)
+    :
+    Preset(presetName)
+    , builtinParams(_presetInputs, presetOutputs)
+    , per_pixel_program(nullptr)
+    , _factory(factory)
+    , _presetOutputs(presetOutputs)
 {
-  initialize(in);
+    initialize(in);
 }
 
 
-MilkdropPreset::MilkdropPreset(MilkdropPresetFactory *factory, const std::string & absoluteFilePath, const std::string & presetName, PresetOutputs & presetOutputs):
-	Preset(presetName),
-    builtinParams(_presetInputs, presetOutputs),
-    per_pixel_program(nullptr),
-    _filename(parseFilename(absoluteFilePath)),
-    _absoluteFilePath(absoluteFilePath),
-    _factory(factory),
-    _presetOutputs(presetOutputs)
+MilkdropPreset::MilkdropPreset(MilkdropPresetFactory* factory, const std::string& absoluteFilePath,
+                               const std::string& presetName, PresetOutputs& presetOutputs)
+    :
+    Preset(presetName)
+    , builtinParams(_presetInputs, presetOutputs)
+    , per_pixel_program(nullptr)
+    , _filename(parseFilename(absoluteFilePath))
+    , _absoluteFilePath(absoluteFilePath)
+    , _factory(factory)
+    , _presetOutputs(presetOutputs)
 {
 
-  initialize(absoluteFilePath);
+    initialize(absoluteFilePath);
 }
 
 
 MilkdropPreset::~MilkdropPreset()
 {
 
-  traverse<TraverseFunctors::Delete<InitCond> >(init_cond_tree);
+    traverse<TraverseFunctors::Delete<InitCond> >(init_cond_tree);
 
-  traverse<TraverseFunctors::Delete<InitCond> >(per_frame_init_eqn_tree);
+    traverse<TraverseFunctors::Delete<InitCond> >(per_frame_init_eqn_tree);
 
-  traverse<TraverseFunctors::Delete<PerPixelEqn> >(per_pixel_eqn_tree);
-  Expr::delete_expr(per_pixel_program);
+    traverse<TraverseFunctors::Delete<PerPixelEqn> >(per_pixel_eqn_tree);
+    Expr::delete_expr(per_pixel_program);
 
-  traverseVector<TraverseFunctors::Delete<PerFrameEqn> >(per_frame_eqn_tree);
+    traverseVector<TraverseFunctors::Delete<PerFrameEqn> >(per_frame_eqn_tree);
 
-  traverse<TraverseFunctors::Delete<Param> >(user_param_tree);
+    traverse<TraverseFunctors::Delete<Param> >(user_param_tree);
 
-  /// Testing deletion of render items by the preset. would be nice if it worked, 
-  /// and seems to be working if you use a mutex on the preset switching.
-  
-  for (PresetOutputs::cwave_container::iterator pos = customWaves.begin(); 
-        pos != customWaves.end(); ++pos ) {
-  //  __android_log_print(ANDROID_LOG_ERROR, "projectM", "not freeing wave %x", *pos);
-    delete(*pos);
-  }
+    /// Testing deletion of render items by the preset. would be nice if it worked,
+    /// and seems to be working if you use a mutex on the preset switching.
 
-  for (PresetOutputs::cshape_container::iterator pos = customShapes.begin(); 
-        pos != customShapes.end(); ++pos ) {
+    for (PresetOutputs::cwave_container::iterator pos = customWaves.begin();
+         pos != customWaves.end(); ++pos)
+    {
+        //  __android_log_print(ANDROID_LOG_ERROR, "projectM", "not freeing wave %x", *pos);
+        delete (*pos);
+    }
+
+    for (PresetOutputs::cshape_container::iterator pos = customShapes.begin();
+         pos != customShapes.end(); ++pos)
+    {
 //__android_log_print(ANDROID_LOG_ERROR, "projectM", "not freeing shape %x", *pos);
 
-        delete(*pos);
-  }
-  customWaves.clear();
-  customShapes.clear();
+        delete (*pos);
+    }
+    customWaves.clear();
+    customShapes.clear();
 
-  if (nullptr != _factory)
-      _factory->releasePreset(this);
+    if (nullptr != _factory)
+    {
+        _factory->releasePreset(this);
+    }
 }
 
 /* Adds a per pixel equation according to its string name. This
    will be used only by the parser */
 
-int MilkdropPreset::add_per_pixel_eqn(char * name, Expr * gen_expr)
+int MilkdropPreset::add_per_pixel_eqn(char* name, Expr* gen_expr)
 {
-  PerPixelEqn * per_pixel_eqn = NULL;
-  Param * param = NULL;
+    PerPixelEqn* per_pixel_eqn = NULL;
+    Param* param = NULL;
 
-  assert(gen_expr);
-  assert(name);
+    assert(gen_expr);
+    assert(name);
 
-  if (PER_PIXEL_EQN_DEBUG) printf("add_per_pixel_eqn: per pixel equation (name = \"%s\")\n", name);
+    if (PER_PIXEL_EQN_DEBUG)
+    {
+        printf("add_per_pixel_eqn: per pixel equation (name = \"%s\")\n", name);
+    }
 
-  /* Search for the parameter so we know what matrix the per pixel equation is referencing */
+    /* Search for the parameter so we know what matrix the per pixel equation is referencing */
 
-  param = ParamUtils::find(name, &this->builtinParams, &this->user_param_tree);
-  if ( !param )
-  {
-    if (PER_PIXEL_EQN_DEBUG) printf("add_per_pixel_eqn: failed to allocate a new parameter!\n");
-    return PROJECTM_FAILURE;
-  }
+    param = ParamUtils::find(name, &this->builtinParams, &this->user_param_tree);
+    if (!param)
+    {
+        if (PER_PIXEL_EQN_DEBUG)
+        {
+            printf("add_per_pixel_eqn: failed to allocate a new parameter!\n");
+        }
+        return PROJECTM_FAILURE;
+    }
 
-  auto index = per_pixel_eqn_tree.size();
+    auto index = per_pixel_eqn_tree.size();
 
-  /* Create the per pixel equation given the index, parameter, and general expression */
-  if ((per_pixel_eqn = new PerPixelEqn(index, param, gen_expr)) == NULL)
-  {
-    if (PER_PIXEL_EQN_DEBUG) printf("add_per_pixel_eqn: failed to create new per pixel equation!\n");
-    return PROJECTM_FAILURE;
-  }
+    /* Create the per pixel equation given the index, parameter, and general expression */
+    if ((per_pixel_eqn = new PerPixelEqn(index, param, gen_expr)) == NULL)
+    {
+        if (PER_PIXEL_EQN_DEBUG)
+        {
+            printf("add_per_pixel_eqn: failed to create new per pixel equation!\n");
+        }
+        return PROJECTM_FAILURE;
+    }
 
-  /* Insert the per pixel equation into the preset per pixel database */
-  std::pair<std::map<int, PerPixelEqn*>::iterator, bool> inserteeOption = per_pixel_eqn_tree.insert
-      (std::make_pair(per_pixel_eqn->index, per_pixel_eqn));
+    /* Insert the per pixel equation into the preset per pixel database */
+    std::pair<std::map<int, PerPixelEqn*>::iterator, bool> inserteeOption = per_pixel_eqn_tree.insert
+        (std::make_pair(per_pixel_eqn->index, per_pixel_eqn));
 
-  if (!inserteeOption.second)
-  {
-    printf("failed to add per pixel eqn!\n");
-    delete(per_pixel_eqn);
-    return PROJECTM_FAILURE;
-  }
+    if (!inserteeOption.second)
+    {
+        printf("failed to add per pixel eqn!\n");
+        delete (per_pixel_eqn);
+        return PROJECTM_FAILURE;
+    }
 
-  /* Done */
-  return PROJECTM_SUCCESS;
+    /* Done */
+    return PROJECTM_SUCCESS;
 }
 
 void MilkdropPreset::evalCustomShapeInitConditions()
 {
 
-  for (PresetOutputs::cshape_container::iterator pos = customShapes.begin(); pos != customShapes.end(); ++pos) {
-    assert(*pos);
-    (*pos)->evalInitConds();
-  }
+    for (PresetOutputs::cshape_container::iterator pos = customShapes.begin(); pos != customShapes.end(); ++pos)
+    {
+        assert(*pos);
+        (*pos)->evalInitConds();
+    }
 }
 
 
 void MilkdropPreset::evalCustomWaveInitConditions()
 {
 
-  for (PresetOutputs::cwave_container::iterator pos = customWaves.begin(); pos != customWaves.end(); ++pos) {
-    assert(*pos);
-   (*pos)->evalInitConds();
-}
+    for (PresetOutputs::cwave_container::iterator pos = customWaves.begin(); pos != customWaves.end(); ++pos)
+    {
+        assert(*pos);
+        (*pos)->evalInitConds();
+    }
 }
 
 
 void MilkdropPreset::evalCustomWavePerFrameEquations()
 {
 
-  for (PresetOutputs::cwave_container::iterator pos = customWaves.begin(); pos != customWaves.end(); ++pos)
-  {
-
-    std::map<std::string, InitCond*> & init_cond_tree2 = (*pos)->init_cond_tree;
-    for (std::map<std::string, InitCond*>::iterator _pos = init_cond_tree2.begin(); _pos != init_cond_tree2.end(); ++_pos)
+    for (PresetOutputs::cwave_container::iterator pos = customWaves.begin(); pos != customWaves.end(); ++pos)
     {
-      assert(_pos->second);
-      _pos->second->evaluate();
-    }
 
-    std::vector<PerFrameEqn*> & per_frame_eqn_tree2 = (*pos)->per_frame_eqn_tree;
-    for (std::vector<PerFrameEqn*>::iterator _pos = per_frame_eqn_tree2.begin(); _pos != per_frame_eqn_tree2.end(); ++_pos)
-    {
-      (*_pos)->evaluate();
+        std::map<std::string, InitCond*>& init_cond_tree2 = (*pos)->init_cond_tree;
+        for (std::map<std::string, InitCond*>::iterator _pos = init_cond_tree2.begin();
+             _pos != init_cond_tree2.end(); ++_pos)
+        {
+            assert(_pos->second);
+            _pos->second->evaluate();
+        }
+
+        std::vector<PerFrameEqn*>& per_frame_eqn_tree2 = (*pos)->per_frame_eqn_tree;
+        for (std::vector<PerFrameEqn*>::iterator _pos = per_frame_eqn_tree2.begin();
+             _pos != per_frame_eqn_tree2.end(); ++_pos)
+        {
+            (*_pos)->evaluate();
+        }
     }
-  }
 
 }
 
 void MilkdropPreset::evalCustomShapePerFrameEquations()
 {
 
-  for (PresetOutputs::cshape_container::iterator pos = customShapes.begin(); pos != customShapes.end(); ++pos)
-  {
-
-    std::map<std::string, InitCond*> & init_cond_tree2 = (*pos)->init_cond_tree;
-    for (std::map<std::string, InitCond*>::iterator _pos = init_cond_tree2.begin(); _pos != init_cond_tree2.end(); ++_pos)
+    for (PresetOutputs::cshape_container::iterator pos = customShapes.begin(); pos != customShapes.end(); ++pos)
     {
-      assert(_pos->second);
-      _pos->second->evaluate();
-    }
 
-    std::vector<PerFrameEqn*> & per_frame_eqn_tree2 = (*pos)->per_frame_eqn_tree;
-    for (std::vector<PerFrameEqn*>::iterator _pos = per_frame_eqn_tree2.begin(); _pos != per_frame_eqn_tree2.end(); ++_pos)
-    {
-      (*_pos)->evaluate();
+        std::map<std::string, InitCond*>& init_cond_tree2 = (*pos)->init_cond_tree;
+        for (std::map<std::string, InitCond*>::iterator _pos = init_cond_tree2.begin();
+             _pos != init_cond_tree2.end(); ++_pos)
+        {
+            assert(_pos->second);
+            _pos->second->evaluate();
+        }
+
+        std::vector<PerFrameEqn*>& per_frame_eqn_tree2 = (*pos)->per_frame_eqn_tree;
+        for (std::vector<PerFrameEqn*>::iterator _pos = per_frame_eqn_tree2.begin();
+             _pos != per_frame_eqn_tree2.end(); ++_pos)
+        {
+            (*_pos)->evaluate();
+        }
     }
-  }
 
 }
 
 void MilkdropPreset::evalPerFrameInitEquations()
 {
 
-  for (std::map<std::string, InitCond*>::iterator pos = per_frame_init_eqn_tree.begin(); pos != per_frame_init_eqn_tree.end(); ++pos)
-  {
-    assert(pos->second);
-    pos->second->evaluate();
-  }
+    for (std::map<std::string, InitCond*>::iterator pos = per_frame_init_eqn_tree.begin();
+         pos != per_frame_init_eqn_tree.end(); ++pos)
+    {
+        assert(pos->second);
+        pos->second->evaluate();
+    }
 
 }
 
 void MilkdropPreset::evalPerFrameEquations()
 {
 
-  for (std::map<std::string, InitCond*>::iterator pos = init_cond_tree.begin(); pos != init_cond_tree.end(); ++pos)
-  {
-    assert(pos->second);
-    pos->second->evaluate();
-  }
+    for (std::map<std::string, InitCond*>::iterator pos = init_cond_tree.begin(); pos != init_cond_tree.end(); ++pos)
+    {
+        assert(pos->second);
+        pos->second->evaluate();
+    }
 
-  for (std::vector<PerFrameEqn*>::iterator pos = per_frame_eqn_tree.begin(); pos != per_frame_eqn_tree.end(); ++pos)
-  {
-    (*pos)->evaluate();
-  }
+    for (std::vector<PerFrameEqn*>::iterator pos = per_frame_eqn_tree.begin(); pos != per_frame_eqn_tree.end(); ++pos)
+    {
+        (*pos)->evaluate();
+    }
 
 }
 
-void MilkdropPreset::preloadInitialize() {
+void MilkdropPreset::preloadInitialize()
+{
 
-  /// @note commented this out because it should be unnecessary
-  // Clear equation trees
-  //init_cond_tree.clear();
-  //user_param_tree.clear();
-  //per_frame_eqn_tree.clear();
-  //per_pixel_eqn_tree.clear();
-  //per_frame_init_eqn_tree.clear();
+    /// @note commented this out because it should be unnecessary
+    // Clear equation trees
+    //init_cond_tree.clear();
+    //user_param_tree.clear();
+    //per_frame_eqn_tree.clear();
+    //per_pixel_eqn_tree.clear();
+    //per_frame_init_eqn_tree.clear();
 
 
 }
 
 void MilkdropPreset::postloadInitialize()
 {
-  /* It's kind of ugly to reset these values here. Should definitely be placed in the parser somewhere */
-  this->per_frame_eqn_count = 0;
-  this->per_frame_init_eqn_count = 0;
+    /* It's kind of ugly to reset these values here. Should definitely be placed in the parser somewhere */
+    this->per_frame_eqn_count = 0;
+    this->per_frame_init_eqn_count = 0;
 
-  this->loadBuiltinParamsUnspecInitConds();
-  this->loadCustomWaveUnspecInitConds();
-  this->loadCustomShapeUnspecInitConds();
+    this->loadBuiltinParamsUnspecInitConds();
+    this->loadCustomWaveUnspecInitConds();
+    this->loadCustomShapeUnspecInitConds();
 
 
 /// @bug are you handling all the q variables conditions? in particular, the un-init case?
@@ -283,122 +313,137 @@ void MilkdropPreset::postloadInitialize()
 
 }
 
-void MilkdropPreset::Render(const BeatDetect &music, const PipelineContext &context)
+void MilkdropPreset::Render(const BeatDetect& music, const PipelineContext& context)
 {
-        _presetInputs.update(music, context);
+    _presetInputs.update(music, context);
 
-        evaluateFrame();
-        pipeline().Render(music, context);
+    evaluateFrame();
+    pipeline().Render(music, context);
 
 }
 
-void MilkdropPreset::initialize(const std::string & pathname)
+void MilkdropPreset::initialize(const std::string& pathname)
 {
-  preloadInitialize();
+    preloadInitialize();
 
-if (MILKDROP_PRESET_DEBUG)
-  std::cerr << "[Preset] loading file \"" << pathname << "\"..." << std::endl;
+    if (MILKDROP_PRESET_DEBUG)
+    {
+        std::cerr << "[Preset] loading file \"" << pathname << "\"..." << std::endl;
+    }
 
- loadPresetFile(pathname);
+    loadPresetFile(pathname);
 
-  postloadInitialize();
-    
+    postloadInitialize();
+
     if (!presetOutputs().compositeShader.programSource.empty())
+    {
         pipeline().compositeShaderFilename = pathname;
+    }
     if (!presetOutputs().warpShader.programSource.empty())
+    {
         pipeline().warpShaderFilename = pathname;
+    }
 }
 
-void MilkdropPreset::initialize(std::istream & in)
+void MilkdropPreset::initialize(std::istream& in)
 {
-  int retval;
+    int retval;
 
-  preloadInitialize();
+    preloadInitialize();
 
-  if ((retval = readIn(in)) < 0)
-  {
+    if ((retval = readIn(in)) < 0)
+    {
 
         if (MILKDROP_PRESET_DEBUG)
-     std::cerr << "[Preset] failed to load from stream " << std::endl;
+        {
+            std::cerr << "[Preset] failed to load from stream " << std::endl;
+        }
 
-    /// @bug how should we handle this problem? a well define exception?
-    throw PresetFactoryException("failed to read from input stream");
-  }
+        /// @bug how should we handle this problem? a well define exception?
+        throw PresetFactoryException("failed to read from input stream");
+    }
 
-  postloadInitialize();
+    postloadInitialize();
 }
 
-void MilkdropPreset::loadBuiltinParamsUnspecInitConds() {
+void MilkdropPreset::loadBuiltinParamsUnspecInitConds()
+{
 
-  InitCondUtils::LoadUnspecInitCond loadUnspecInitCond(this->init_cond_tree, this->per_frame_init_eqn_tree);
+    InitCondUtils::LoadUnspecInitCond loadUnspecInitCond(this->init_cond_tree, this->per_frame_init_eqn_tree);
 
-  this->builtinParams.apply(loadUnspecInitCond);
-  traverse(user_param_tree, loadUnspecInitCond);
+    this->builtinParams.apply(loadUnspecInitCond);
+    traverse(user_param_tree, loadUnspecInitCond);
 
 }
 
 void MilkdropPreset::loadCustomWaveUnspecInitConds()
 {
 
-  for (PresetOutputs::cwave_container::iterator pos = customWaves.begin(); pos != customWaves.end(); ++pos)
-  {
-    assert(*pos);
-    (*pos)->loadUnspecInitConds();
-  }
+    for (PresetOutputs::cwave_container::iterator pos = customWaves.begin(); pos != customWaves.end(); ++pos)
+    {
+        assert(*pos);
+        (*pos)->loadUnspecInitConds();
+    }
 
 }
 
 void MilkdropPreset::loadCustomShapeUnspecInitConds()
 {
 
-  for (PresetOutputs::cshape_container::iterator pos = customShapes.begin();
-        pos != customShapes.end(); ++pos)
-  {
-    assert(*pos);
-    (*pos)->loadUnspecInitConds();
-  }
+    for (PresetOutputs::cshape_container::iterator pos = customShapes.begin();
+         pos != customShapes.end(); ++pos)
+    {
+        assert(*pos);
+        (*pos)->loadUnspecInitConds();
+    }
 }
 
 
 void MilkdropPreset::evaluateFrame()
 {
 
-  // Evaluate all equation objects according to milkdrop flow diagram
+    // Evaluate all equation objects according to milkdrop flow diagram
 
-  evalPerFrameInitEquations();
-  evalPerFrameEquations();
+    evalPerFrameInitEquations();
+    evalPerFrameEquations();
 
-  // Important step to ensure custom shapes and waves don't stamp on the q variable values
-  // calculated by the per frame (init) and per pixel equations.
-  transfer_q_variables(customWaves);
-  transfer_q_variables(customShapes);
+    // Important step to ensure custom shapes and waves don't stamp on the q variable values
+    // calculated by the per frame (init) and per pixel equations.
+    transfer_q_variables(customWaves);
+    transfer_q_variables(customShapes);
 
-  initialize_PerPixelMeshes();
+    initialize_PerPixelMeshes();
 
-  evalPerPixelEqns();
+    evalPerPixelEqns();
 
-  evalCustomWaveInitConditions();
-  evalCustomWavePerFrameEquations();
+    evalCustomWaveInitConditions();
+    evalCustomWavePerFrameEquations();
 
-  evalCustomShapeInitConditions();
-  evalCustomShapePerFrameEquations();
+    evalCustomShapeInitConditions();
+    evalCustomShapePerFrameEquations();
 
-  // Setup pointers of the custom waves and shapes to the preset outputs instance
-  /// @slow an extra O(N) per frame, could do this during eval
-  _presetOutputs.customWaves = PresetOutputs::cwave_container(customWaves);
-  _presetOutputs.customShapes = PresetOutputs::cshape_container(customShapes);
+    // Setup pointers of the custom waves and shapes to the preset outputs instance
+    /// @slow an extra O(N) per frame, could do this during eval
+    _presetOutputs.customWaves = PresetOutputs::cwave_container(customWaves);
+    _presetOutputs.customShapes = PresetOutputs::cshape_container(customShapes);
 
 }
 
 
 #ifdef __SSE2__
-inline void init_mesh(float **mesh, const float value, const int gx, const int gy)
+
+inline void init_mesh(float** mesh, const float value, const int gx, const int gy)
 {
-  __m128 mvalue = _mm_set_ps1(value);
-  for (int x = 0; x < gx; x++)
-    for (int y = 0; y < gy; y += 4)
-      _mm_store_ps(&mesh[x][y], mvalue);
+    __m128 mvalue = _mm_set_ps1(value);
+    for (int x = 0; x < gx; x++)
+    {
+        for (int y = 0; y < gy; y += 4)
+        {
+            _mm_store_ps(&mesh[x][y], mvalue);
+        }
+    }
 }
+
 #else
 inline void init_mesh(float **mesh, const float value, const int gx, const int gy)
 {
@@ -410,19 +455,19 @@ inline void init_mesh(float **mesh, const float value, const int gx, const int g
 
 void MilkdropPreset::initialize_PerPixelMeshes()
 {
-  int gx = presetInputs().gx;
-  int gy = presetInputs().gy;
+    int gx = presetInputs().gx;
+    int gy = presetInputs().gy;
 
-  init_mesh(_presetOutputs.cx_mesh, presetOutputs().cx, gx, gy);
-  init_mesh(_presetOutputs.cy_mesh, presetOutputs().cy, gx, gy);
-  init_mesh(_presetOutputs.sx_mesh, presetOutputs().sx, gx, gy);
-  init_mesh(_presetOutputs.sy_mesh, presetOutputs().sy, gx, gy);
-  init_mesh(_presetOutputs.dx_mesh, presetOutputs().dx, gx, gy);
-  init_mesh(_presetOutputs.dy_mesh, presetOutputs().dy, gx, gy);
-  init_mesh(_presetOutputs.zoom_mesh, presetOutputs().zoom, gx, gy);
-  init_mesh(_presetOutputs.zoomexp_mesh, presetOutputs().zoomexp, gx, gy);
-  init_mesh(_presetOutputs.rot_mesh, presetOutputs().rot, gx, gy);
-  init_mesh(_presetOutputs.warp_mesh, presetOutputs().warp, gx, gy);
+    init_mesh(_presetOutputs.cx_mesh, presetOutputs().cx, gx, gy);
+    init_mesh(_presetOutputs.cy_mesh, presetOutputs().cy, gx, gy);
+    init_mesh(_presetOutputs.sx_mesh, presetOutputs().sx, gx, gy);
+    init_mesh(_presetOutputs.sy_mesh, presetOutputs().sy, gx, gy);
+    init_mesh(_presetOutputs.dx_mesh, presetOutputs().dx, gx, gy);
+    init_mesh(_presetOutputs.dy_mesh, presetOutputs().dy, gx, gy);
+    init_mesh(_presetOutputs.zoom_mesh, presetOutputs().zoom, gx, gy);
+    init_mesh(_presetOutputs.zoomexp_mesh, presetOutputs().zoomexp, gx, gy);
+    init_mesh(_presetOutputs.rot_mesh, presetOutputs().rot, gx, gy);
+    init_mesh(_presetOutputs.warp_mesh, presetOutputs().warp, gx, gy);
 }
 
 
@@ -431,7 +476,9 @@ void MilkdropPreset::evalPerPixelEqns()
 {
     // Quick bail out if there is nothing to do.
     if (per_pixel_eqn_tree.empty())
+    {
         return;
+    }
 
     if (nullptr == per_pixel_program)
     {
@@ -440,11 +487,14 @@ void MilkdropPreset::evalPerPixelEqns()
         // just a different place to loop over the individual steps, but the idea is that this encapsulates
         // an optimizable chunk of work.
         // See also CustomWave which does the same for PerPointEqn
-        std::vector<Expr *> steps;
-        for (std::map<int, PerPixelEqn*>::iterator pos = per_pixel_eqn_tree.begin(); pos != per_pixel_eqn_tree.end(); ++pos)
+        std::vector<Expr*> steps;
+        for (std::map<int, PerPixelEqn*>::iterator pos = per_pixel_eqn_tree.begin();
+             pos != per_pixel_eqn_tree.end(); ++pos)
+        {
             steps.push_back(pos->second->assign_expr);
-        Expr *program_expr = Expr::create_program_expr(steps, false);
-        Expr *jit = nullptr;
+        }
+        Expr* program_expr = Expr::create_program_expr(steps, false);
+        Expr* jit = nullptr;
 #if HAVE_LLVM
         std::string module_name = this->_filename + "_per_pixel";
         if (!steps.empty())
@@ -454,77 +504,88 @@ void MilkdropPreset::evalPerPixelEqns()
     }
 
     for (int mesh_x = 0; mesh_x < presetInputs().gx; mesh_x++)
+    {
         for (int mesh_y = 0; mesh_y < presetInputs().gy; mesh_y++)
-            per_pixel_program->eval( mesh_x, mesh_y );
+        {
+            per_pixel_program->eval(mesh_x, mesh_y);
+        }
+    }
 }
 
-int MilkdropPreset::readIn(std::istream & fs) {
+int MilkdropPreset::readIn(std::istream& fs)
+{
 
-  presetOutputs().compositeShader.programSource.clear();
-  presetOutputs().warpShader.programSource.clear();
+    presetOutputs().compositeShader.programSource.clear();
+    presetOutputs().warpShader.programSource.clear();
 
-  /* Parse any comments (aka "[preset00]") */
-  /* We don't do anything with this info so it's okay if it's missing */
-  if (Parser::parse_top_comment(fs) == PROJECTM_SUCCESS)
-  {
-      /* Parse the preset name and a left bracket */
-      char tmp_name[MAX_TOKEN_SIZE];
-
-      if (Parser::parse_preset_name(fs, tmp_name) < 0)
-          {
-              std::cerr <<  "[Preset::readIn] loading of preset name failed" << std::endl;
-              fs.seekg(0);
-          }
-      /// @note  We ignore the preset name because [preset00] is just not so useful
-  } else {
-      // no comment found. whatever
-        if (MILKDROP_PRESET_DEBUG)
-            std::cerr << "[Preset::readIn] no left bracket found..." << std::endl;
-        fs.seekg(0);
-  }
-
-  // Loop through each line in file, trying to successfully parse the file.
-  // If a line does not parse correctly, keep trucking along to next line.
-  int retval;
-  while ((retval = Parser::parse_line(fs, this)) != EOF)
-  {
-    if (retval == PROJECTM_PARSE_ERROR)
+    /* Parse any comments (aka "[preset00]") */
+    /* We don't do anything with this info so it's okay if it's missing */
+    if (Parser::parse_top_comment(fs) == PROJECTM_SUCCESS)
     {
-      // std::cerr << "[Preset::readIn()] parse error in file \"" << this->absoluteFilePath() << "\"" << std::endl;
+        /* Parse the preset name and a left bracket */
+        char tmp_name[MAX_TOKEN_SIZE];
+
+        if (Parser::parse_preset_name(fs, tmp_name) < 0)
+        {
+            std::cerr << "[Preset::readIn] loading of preset name failed" << std::endl;
+            fs.seekg(0);
+        }
+        /// @note  We ignore the preset name because [preset00] is just not so useful
     }
-  }
+    else
+    {
+        // no comment found. whatever
+        if (MILKDROP_PRESET_DEBUG)
+        {
+            std::cerr << "[Preset::readIn] no left bracket found..." << std::endl;
+        }
+        fs.seekg(0);
+    }
+
+    // Loop through each line in file, trying to successfully parse the file.
+    // If a line does not parse correctly, keep trucking along to next line.
+    int retval;
+    while ((retval = Parser::parse_line(fs, this)) != EOF)
+    {
+        if (retval == PROJECTM_PARSE_ERROR)
+        {
+            // std::cerr << "[Preset::readIn()] parse error in file \"" << this->absoluteFilePath() << "\"" << std::endl;
+        }
+    }
 
 //  std::cerr << "loadPresetFile: finished line parsing successfully" << std::endl;
 
-  /* Now the preset has been loaded.
-     Evaluation calls can be made at appropiate
-     times in the frame loop */
+    /* Now the preset has been loaded.
+       Evaluation calls can be made at appropiate
+       times in the frame loop */
 
-return PROJECTM_SUCCESS;
+    return PROJECTM_SUCCESS;
 }
 
 /* loadPresetFile: private function that loads a specific preset denoted
    by the given pathname */
-int MilkdropPreset::loadPresetFile(const std::string & pathname)
+int MilkdropPreset::loadPresetFile(const std::string& pathname)
 {
 
 
-  /* Open the file corresponding to pathname */
-  std::ifstream fs(pathname.c_str());
-  if (!fs || fs.eof()) {
+    /* Open the file corresponding to pathname */
+    std::ifstream fs(pathname.c_str());
+    if (!fs || fs.eof())
+    {
 
-    std::ostringstream oss;
-    oss << "Problem reading file from path: \"" << pathname << "\"";
+        std::ostringstream oss;
+        oss << "Problem reading file from path: \"" << pathname << "\"";
 
-    throw PresetFactoryException(oss.str());
+        throw PresetFactoryException(oss.str());
 
-  }
+    }
 
- return readIn(fs);
+    return readIn(fs);
 
 }
 
-const std::string & MilkdropPreset::name() const {
+const std::string& MilkdropPreset::name() const
+{
 
     return filename();
 }

--- a/src/libprojectM/MilkdropPresetFactory/MilkdropPreset.hpp
+++ b/src/libprojectM/MilkdropPresetFactory/MilkdropPreset.hpp
@@ -72,14 +72,14 @@ public:
     /// \param milkdropPresetName a descriptive name for the MilkdropPreset. Usually just the file name
     /// \param presetOutputs initialized and filled with data parsed from a MilkdropPreset
     MilkdropPreset(MilkdropPresetFactory* factory, const std::string& absoluteFilePath,
-                   const std::string& milkdropPresetName, PresetOutputs& presetOutputs);
+                   const std::string& milkdropPresetName, PresetOutputs* presetOutputs);
 
     ///  Load a MilkdropPreset from an input stream with input and output buffers specified.
     /// \param in an already initialized input stream to read the MilkdropPreset file from
     /// \param milkdropPresetName a descriptive name for the MilkdropPreset. Usually just the file name
     /// \param presetOutputs initialized and filled with data parsed from a MilkdropPreset
     MilkdropPreset(MilkdropPresetFactory* factory, std::istream& in, const std::string& milkdropPresetName,
-                   PresetOutputs& presetOutputs);
+                   PresetOutputs* presetOutputs);
 
     ~MilkdropPreset();
 
@@ -118,7 +118,7 @@ public:
     /// \returns A MilkdropPreset output instance with values computed from most recent evaluateFrame()
     PresetOutputs& presetOutputs() const
     {
-        return _presetOutputs;
+        return *_presetOutputs;
     }
 
     const PresetInputs& presetInputs() const
@@ -144,7 +144,7 @@ public:
 
     PresetOutputs& pipeline()
     {
-        return _presetOutputs;
+        return *_presetOutputs;
     }
 
     void Render(const BeatDetect& music, const PipelineContext& context);
@@ -204,8 +204,8 @@ private:
 
     void postloadInitialize();
 
-    MilkdropPresetFactory* _factory;
-    PresetOutputs& _presetOutputs;
+    MilkdropPresetFactory* _factory{ nullptr };
+    PresetOutputs* _presetOutputs{ nullptr };
 
     template<class CustomObject>
     void transfer_q_variables(std::vector<CustomObject*>& customObjects);
@@ -225,7 +225,7 @@ void MilkdropPreset::transfer_q_variables(std::vector<CustomObject*>& customObje
         custom_object = *pos;
         for (unsigned int i = 0; i < NUM_Q_VARIABLES; i++)
         {
-            custom_object->q[i] = _presetOutputs.q[i];
+            custom_object->q[i] = _presetOutputs->q[i];
         }
     }
 

--- a/src/libprojectM/MilkdropPresetFactory/MilkdropPreset.hpp
+++ b/src/libprojectM/MilkdropPresetFactory/MilkdropPreset.hpp
@@ -36,10 +36,10 @@
 #include <map>
 
 #ifdef DEBUG
-  /* 0 for no debugging, 1 for normal, 2 for insane */
-  #define MILKDROP_PRESET_DEBUG 1
+/* 0 for no debugging, 1 for normal, 2 for insane */
+#define MILKDROP_PRESET_DEBUG 1
 #else
-  #define MILKDROP_PRESET_DEBUG 0
+#define MILKDROP_PRESET_DEBUG 0
 #endif
 
 #include "CustomShape.hpp"
@@ -53,8 +53,11 @@
 #include "Preset.hpp"
 
 class MilkdropPresetFactory;
+
 class CustomWave;
+
 class CustomShape;
+
 class InitCond;
 
 
@@ -64,174 +67,202 @@ class MilkdropPreset : public Preset
 public:
 
 
-  ///  Load a MilkdropPreset by filename with input and output buffers specified.
-  /// \param absoluteFilePath the absolute file path of a MilkdropPreset to load from the file system
-  /// \param milkdropPresetName a descriptive name for the MilkdropPreset. Usually just the file name
-  /// \param presetOutputs initialized and filled with data parsed from a MilkdropPreset
-  MilkdropPreset(MilkdropPresetFactory *factory, const std::string & absoluteFilePath, const std::string & milkdropPresetName, PresetOutputs & presetOutputs);
+    ///  Load a MilkdropPreset by filename with input and output buffers specified.
+    /// \param absoluteFilePath the absolute file path of a MilkdropPreset to load from the file system
+    /// \param milkdropPresetName a descriptive name for the MilkdropPreset. Usually just the file name
+    /// \param presetOutputs initialized and filled with data parsed from a MilkdropPreset
+    MilkdropPreset(MilkdropPresetFactory* factory, const std::string& absoluteFilePath,
+                   const std::string& milkdropPresetName, PresetOutputs& presetOutputs);
 
-  ///  Load a MilkdropPreset from an input stream with input and output buffers specified.
-  /// \param in an already initialized input stream to read the MilkdropPreset file from
-  /// \param milkdropPresetName a descriptive name for the MilkdropPreset. Usually just the file name
-  /// \param presetOutputs initialized and filled with data parsed from a MilkdropPreset
-  MilkdropPreset(MilkdropPresetFactory *factory, std::istream & in, const std::string & milkdropPresetName, PresetOutputs & presetOutputs);
+    ///  Load a MilkdropPreset from an input stream with input and output buffers specified.
+    /// \param in an already initialized input stream to read the MilkdropPreset file from
+    /// \param milkdropPresetName a descriptive name for the MilkdropPreset. Usually just the file name
+    /// \param presetOutputs initialized and filled with data parsed from a MilkdropPreset
+    MilkdropPreset(MilkdropPresetFactory* factory, std::istream& in, const std::string& milkdropPresetName,
+                   PresetOutputs& presetOutputs);
 
-  ~MilkdropPreset();
+    ~MilkdropPreset();
 
-  /// All "builtin" parameters for this MilkdropPreset. Anything *but* user defined parameters and
-  /// custom waves / shapes objects go here.
-  /// @bug encapsulate
-  BuiltinParams builtinParams;
-
-
-  /// Used by parser to find/create custom waves and shapes. May be refactored
-  template <class CustomObject>
-  static CustomObject * find_custom_object(int id, std::vector<CustomObject*> & customObjects);
+    /// All "builtin" parameters for this MilkdropPreset. Anything *but* user defined parameters and
+    /// custom waves / shapes objects go here.
+    /// @bug encapsulate
+    BuiltinParams builtinParams;
 
 
-  int per_pixel_eqn_string_index;
-  int per_frame_eqn_string_index;
-  int per_frame_init_eqn_string_index;
-
-  int per_frame_eqn_count,
-  per_frame_init_eqn_count;
+    /// Used by parser to find/create custom waves and shapes. May be refactored
+    template<class CustomObject>
+    static CustomObject* find_custom_object(int id, std::vector<CustomObject*>& customObjects);
 
 
-  /// Used by parser
-  /// @bug refactor
-  int add_per_pixel_eqn( char *name, Expr *gen_expr );
+    int per_pixel_eqn_string_index;
+    int per_frame_eqn_string_index;
+    int per_frame_init_eqn_string_index;
 
-  /// Accessor method to retrieve the absolute file path of the loaded MilkdropPreset
-  /// \returns a file path string
-  std::string absoluteFilePath() const
-  {
-    return _absoluteFilePath;
-  }
+    int per_frame_eqn_count,
+        per_frame_init_eqn_count;
 
 
-  /// Accessor method for the MilkdropPreset outputs instance associated with this MilkdropPreset
-  /// \returns A MilkdropPreset output instance with values computed from most recent evaluateFrame()
-  PresetOutputs & presetOutputs() const
-  {
-    return _presetOutputs;
-  }
+    /// Used by parser
+    /// @bug refactor
+    int add_per_pixel_eqn(char* name, Expr* gen_expr);
 
-  const PresetInputs & presetInputs() const
-  {
-    return _presetInputs;
-  }
+    /// Accessor method to retrieve the absolute file path of the loaded MilkdropPreset
+    /// \returns a file path string
+    std::string absoluteFilePath() const
+    {
+        return _absoluteFilePath;
+    }
+
+
+    /// Accessor method for the MilkdropPreset outputs instance associated with this MilkdropPreset
+    /// \returns A MilkdropPreset output instance with values computed from most recent evaluateFrame()
+    PresetOutputs& presetOutputs() const
+    {
+        return _presetOutputs;
+    }
+
+    const PresetInputs& presetInputs() const
+    {
+        return _presetInputs;
+    }
 
 
 // @bug encapsulate
 
-  PresetOutputs::cwave_container customWaves;
-  PresetOutputs::cshape_container customShapes;
+    PresetOutputs::cwave_container customWaves;
+    PresetOutputs::cshape_container customShapes;
 
-  /// @bug encapsulate
-  /* Data structures that contain equation and initial condition information */
-  std::vector<PerFrameEqn*>  per_frame_eqn_tree;   /* per frame equations */
-  std::map<int, PerPixelEqn*>  per_pixel_eqn_tree; /* per pixel equation tree */
-  Expr *per_pixel_program;
-  std::map<std::string,InitCond*>  per_frame_init_eqn_tree; /* per frame initial equations */
-  std::map<std::string,InitCond*>  init_cond_tree; /* initial conditions */
-  std::map<std::string,Param*> user_param_tree; /* user parameter splay tree */
+    /// @bug encapsulate
+    /* Data structures that contain equation and initial condition information */
+    std::vector<PerFrameEqn*> per_frame_eqn_tree;   /* per frame equations */
+    std::map<int, PerPixelEqn*> per_pixel_eqn_tree; /* per pixel equation tree */
+    Expr* per_pixel_program;
+    std::map<std::string, InitCond*> per_frame_init_eqn_tree; /* per frame initial equations */
+    std::map<std::string, InitCond*> init_cond_tree; /* initial conditions */
+    std::map<std::string, Param*> user_param_tree; /* user parameter splay tree */
 
 
-  PresetOutputs & pipeline() { return _presetOutputs; } 
+    PresetOutputs& pipeline()
+    {
+        return _presetOutputs;
+    }
 
-  void Render(const BeatDetect &music, const PipelineContext &context);
-  const std::string & name() const;
-  const std::string & filename() const { return _filename; } 
+    void Render(const BeatDetect& music, const PipelineContext& context);
+
+    const std::string& name() const;
+
+    const std::string& filename() const
+    {
+        return _filename;
+    }
+
 private:
-  std::string _filename; 
-  PresetInputs _presetInputs;
-  /// Evaluates the MilkdropPreset for a frame given the current values of MilkdropPreset inputs / outputs
-  /// All calculated values are stored in the associated MilkdropPreset outputs instance
-  void evaluateFrame();
+    std::string _filename;
+    PresetInputs _presetInputs;
 
-  // The absolute file path of the MilkdropPreset
-  std::string _absoluteFilePath;
+    /// Evaluates the MilkdropPreset for a frame given the current values of MilkdropPreset inputs / outputs
+    /// All calculated values are stored in the associated MilkdropPreset outputs instance
+    void evaluateFrame();
 
-  // The absolute path of the MilkdropPreset
-  std::string _absolutePath;
+    // The absolute file path of the MilkdropPreset
+    std::string _absoluteFilePath;
 
-  void initialize(const std::string & pathname);
-  void initialize(std::istream & in);
+    // The absolute path of the MilkdropPreset
+    std::string _absolutePath;
 
-  int loadPresetFile(const std::string & pathname);
+    void initialize(const std::string& pathname);
 
-  void loadBuiltinParamsUnspecInitConds();
-  void loadCustomWaveUnspecInitConds();
-  void loadCustomShapeUnspecInitConds();
+    void initialize(std::istream& in);
 
-  void evalCustomWavePerFrameEquations();
-  void evalCustomShapePerFrameEquations();
-  void evalPerFrameInitEquations();
-  void evalCustomWaveInitConditions();
-  void evalCustomShapeInitConditions();
-  void evalPerPixelEqns();
-  void evalPerFrameEquations();
-  void initialize_PerPixelMeshes();
-  int readIn(std::istream & fs);
+    int loadPresetFile(const std::string& pathname);
 
-  void preloadInitialize();
-  void postloadInitialize();
+    void loadBuiltinParamsUnspecInitConds();
 
-  MilkdropPresetFactory *_factory;
-  PresetOutputs & _presetOutputs;
+    void loadCustomWaveUnspecInitConds();
 
-template <class CustomObject>
-void transfer_q_variables(std::vector<CustomObject*> & customObjects);
+    void loadCustomShapeUnspecInitConds();
 
-friend class MilkdropPresetFactory;
+    void evalCustomWavePerFrameEquations();
+
+    void evalCustomShapePerFrameEquations();
+
+    void evalPerFrameInitEquations();
+
+    void evalCustomWaveInitConditions();
+
+    void evalCustomShapeInitConditions();
+
+    void evalPerPixelEqns();
+
+    void evalPerFrameEquations();
+
+    void initialize_PerPixelMeshes();
+
+    int readIn(std::istream& fs);
+
+    void preloadInitialize();
+
+    void postloadInitialize();
+
+    MilkdropPresetFactory* _factory;
+    PresetOutputs& _presetOutputs;
+
+    template<class CustomObject>
+    void transfer_q_variables(std::vector<CustomObject*>& customObjects);
+
+    friend class MilkdropPresetFactory;
 };
 
 
-template <class CustomObject>
-void MilkdropPreset::transfer_q_variables(std::vector<CustomObject*> & customObjects)
+template<class CustomObject>
+void MilkdropPreset::transfer_q_variables(std::vector<CustomObject*>& customObjects)
 {
- 	CustomObject * custom_object;
+    CustomObject* custom_object;
 
-	for (typename std::vector<CustomObject*>::iterator pos = customObjects.begin(); pos != customObjects.end();++pos) {
-
-		custom_object = *pos;
-		for (unsigned int i = 0; i < NUM_Q_VARIABLES; i++)
-			custom_object->q[i] = _presetOutputs.q[i];
-	}
-
-
-}
-
-template <class CustomObject>
-CustomObject * MilkdropPreset::find_custom_object(int id, std::vector<CustomObject*> & customObjects)
-{
-
-  CustomObject * custom_object = NULL;
-
-
-  for (typename std::vector<CustomObject*>::iterator pos = customObjects.begin(); pos != customObjects.end();++pos) {
-	if ((*pos)->id == id) {
-		custom_object = *pos;
-		break;
-	}
-  }
-
-  if (custom_object == NULL)
-  {
-
-    if ((custom_object = new CustomObject(id)) == NULL)
+    for (typename std::vector<CustomObject*>::iterator pos = customObjects.begin(); pos != customObjects.end(); ++pos)
     {
-      return NULL;
+
+        custom_object = *pos;
+        for (unsigned int i = 0; i < NUM_Q_VARIABLES; i++)
+        {
+            custom_object->q[i] = _presetOutputs.q[i];
+        }
     }
 
-      customObjects.push_back(custom_object);
 
-  }
-
-  assert(custom_object);
-  return custom_object;
 }
 
+template<class CustomObject>
+CustomObject* MilkdropPreset::find_custom_object(int id, std::vector<CustomObject*>& customObjects)
+{
+
+    CustomObject* custom_object = NULL;
+
+
+    for (typename std::vector<CustomObject*>::iterator pos = customObjects.begin(); pos != customObjects.end(); ++pos)
+    {
+        if ((*pos)->id == id)
+        {
+            custom_object = *pos;
+            break;
+        }
+    }
+
+    if (custom_object == NULL)
+    {
+
+        if ((custom_object = new CustomObject(id)) == NULL)
+        {
+            return NULL;
+        }
+
+        customObjects.push_back(custom_object);
+
+    }
+
+    assert(custom_object);
+    return custom_object;
+}
 
 
 #endif /** !_MilkdropPreset_HPP */

--- a/src/libprojectM/MilkdropPresetFactory/MilkdropPresetFactory.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/MilkdropPresetFactory.cpp
@@ -17,56 +17,60 @@
 #include "IdlePreset.hpp"
 #include "PresetFrameIO.hpp"
 
-MilkdropPresetFactory::MilkdropPresetFactory(int gx_, int gy_): gx(gx_), gy(gy_), _presetOutputsCache(nullptr)
+MilkdropPresetFactory::MilkdropPresetFactory(int gx_, int gy_)
+    : gx(gx_)
+    , gy(gy_)
+    , _presetOutputsCache(nullptr)
 {
-	/* Initializes the builtin function database */
-	BuiltinFuncs::init_builtin_func_db();
+    /* Initializes the builtin function database */
+    BuiltinFuncs::init_builtin_func_db();
 
-	/* Initializes all infix operators */
-	Eval::init_infix_ops();
+    /* Initializes all infix operators */
+    Eval::init_infix_ops();
 }
 
-MilkdropPresetFactory::~MilkdropPresetFactory() {
+MilkdropPresetFactory::~MilkdropPresetFactory()
+{
 
 //	std::cerr << "[~MilkdropPresetFactory] destroy infix ops" << std::endl;
-	Eval::destroy_infix_ops();
+    Eval::destroy_infix_ops();
 //	std::cerr << "[~MilkdropPresetFactory] destroy builtin func" << std::endl;
-	BuiltinFuncs::destroy_builtin_func_db();
+    BuiltinFuncs::destroy_builtin_func_db();
 //	std::cerr << "[~MilkdropPresetFactory] delete preset out puts" << std::endl;
-	delete(_presetOutputsCache);
+    delete (_presetOutputsCache);
 //	std::cerr << "[~MilkdropPresetFactory] done" << std::endl;
 }
 
 /* Reinitializes the engine variables to a default (conservative and sane) value */
-void resetPresetOutputs(PresetOutputs * presetOutputs)
+void resetPresetOutputs(PresetOutputs* presetOutputs)
 {
 
-    presetOutputs->zoom=1.0;
+    presetOutputs->zoom = 1.0;
     presetOutputs->zoomexp = 1.0;
-    presetOutputs->rot= 0.0;
-    presetOutputs->warp= 0.0;
+    presetOutputs->rot = 0.0;
+    presetOutputs->warp = 0.0;
 
-    presetOutputs->sx= 1.0;
-    presetOutputs->sy= 1.0;
-    presetOutputs->dx= 0.0;
-    presetOutputs->dy= 0.0;
-    presetOutputs->cx= 0.5;
-    presetOutputs->cy= 0.5;
+    presetOutputs->sx = 1.0;
+    presetOutputs->sy = 1.0;
+    presetOutputs->dx = 0.0;
+    presetOutputs->dy = 0.0;
+    presetOutputs->cx = 0.5;
+    presetOutputs->cy = 0.5;
 
-    presetOutputs->screenDecay=.98;
+    presetOutputs->screenDecay = .98;
 
-    presetOutputs->wave.r= 1.0;
-    presetOutputs->wave.g= 0.2;
-    presetOutputs->wave.b= 0.0;
-    presetOutputs->wave.x= 0.5;
-    presetOutputs->wave.y= 0.5;
-    presetOutputs->wave.mystery= 0.0;
+    presetOutputs->wave.r = 1.0;
+    presetOutputs->wave.g = 0.2;
+    presetOutputs->wave.b = 0.0;
+    presetOutputs->wave.x = 0.5;
+    presetOutputs->wave.y = 0.5;
+    presetOutputs->wave.mystery = 0.0;
 
-    presetOutputs->border.outer_size= 0.0;
-    presetOutputs->border.outer_r= 0.0;
-    presetOutputs->border.outer_g= 0.0;
-    presetOutputs->border.outer_b= 0.0;
-    presetOutputs->border.outer_a= 0.0;
+    presetOutputs->border.outer_size = 0.0;
+    presetOutputs->border.outer_r = 0.0;
+    presetOutputs->border.outer_g = 0.0;
+    presetOutputs->border.outer_b = 0.0;
+    presetOutputs->border.outer_a = 0.0;
 
     presetOutputs->border.inner_size = 0.0;
     presetOutputs->border.inner_r = 0.0;
@@ -106,7 +110,7 @@ void resetPresetOutputs(PresetOutputs * presetOutputs)
     presetOutputs->bInvert = 0;
     presetOutputs->bMotionVectorsOn = 1;
 
-    presetOutputs->wave.a =1.0;
+    presetOutputs->wave.a = 1.0;
     presetOutputs->wave.scale = 1.0;
     presetOutputs->wave.smoothing = 0;
     presetOutputs->wave.mystery = 0;
@@ -119,19 +123,21 @@ void resetPresetOutputs(PresetOutputs * presetOutputs)
     /* PER_PIXEL CONSTANT END */
     /* Q VARIABLES START */
 
-    for (int i = 0;i< 32;i++)
+    for (int i = 0; i < 32; i++)
+    {
         presetOutputs->q[i] = 0;
+    }
 
 //	for ( std::vector<CustomWave*>::iterator pos = presetOutputs->customWaves.begin();
 //	        pos != presetOutputs->customWaves.end(); ++pos )
 //		if ( *pos != 0 ) delete ( *pos );
-	
+
 //	for ( std::vector<CustomShape*>::iterator pos = presetOutputs->customShapes.begin();
 //	        pos != presetOutputs->customShapes.end(); ++pos )
 //		if ( *pos != 0 ) delete ( *pos );
-	
-	presetOutputs->customWaves.clear();
-	presetOutputs->customShapes.clear();
+
+    presetOutputs->customWaves.clear();
+    presetOutputs->customShapes.clear();
 
     /* Q VARIABLES END */
 
@@ -143,72 +149,78 @@ void MilkdropPresetFactory::reset()
 {
 
     if (_presetOutputsCache)
+    {
         resetPresetOutputs(_presetOutputsCache);
+    }
 }
 
 PresetOutputs* MilkdropPresetFactory::createPresetOutputs(int gx, int gy)
 {
 
-	PresetOutputs *presetOutputs = new PresetOutputs();
+    PresetOutputs* presetOutputs = new PresetOutputs();
 
-	presetOutputs->Initialize(gx,gy);
+    presetOutputs->Initialize(gx, gy);
 
-	/* PER FRAME CONSTANTS BEGIN */
-	presetOutputs->zoom=1.0;
-	presetOutputs->zoomexp = 1.0;
-	presetOutputs->rot= 0.0;
-	presetOutputs->warp= 0.0;
+    /* PER FRAME CONSTANTS BEGIN */
+    presetOutputs->zoom = 1.0;
+    presetOutputs->zoomexp = 1.0;
+    presetOutputs->rot = 0.0;
+    presetOutputs->warp = 0.0;
 
-	presetOutputs->sx= 1.0;
-	presetOutputs->sy= 1.0;
-	presetOutputs->dx= 0.0;
-	presetOutputs->dy= 0.0;
-	presetOutputs->cx= 0.5;
-	presetOutputs->cy= 0.5;
+    presetOutputs->sx = 1.0;
+    presetOutputs->sy = 1.0;
+    presetOutputs->dx = 0.0;
+    presetOutputs->dy = 0.0;
+    presetOutputs->cx = 0.5;
+    presetOutputs->cy = 0.5;
 
-	presetOutputs->screenDecay=.98;
+    presetOutputs->screenDecay = .98;
 
 
 //_presetInputs.meshx = 0;
 //_presetInputs.meshy = 0;
 
 
-	/* PER_FRAME CONSTANTS END */
-	presetOutputs->fRating = 0;
-	presetOutputs->fGammaAdj = 1.0;
-	presetOutputs->videoEcho.zoom = 1.0;
-	presetOutputs->videoEcho.a = 0;
-	presetOutputs->videoEcho.orientation = Normal;
+    /* PER_FRAME CONSTANTS END */
+    presetOutputs->fRating = 0;
+    presetOutputs->fGammaAdj = 1.0;
+    presetOutputs->videoEcho.zoom = 1.0;
+    presetOutputs->videoEcho.a = 0;
+    presetOutputs->videoEcho.orientation = Normal;
 
-	presetOutputs->textureWrap = 0;
-	presetOutputs->bDarkenCenter = 0;
-	presetOutputs->bRedBlueStereo = 0;
-	presetOutputs->bBrighten = 0;
-	presetOutputs->bDarken = 0;
-	presetOutputs->bSolarize = 0;
-	presetOutputs->bInvert = 0;
-	presetOutputs->bMotionVectorsOn = 1;
+    presetOutputs->textureWrap = 0;
+    presetOutputs->bDarkenCenter = 0;
+    presetOutputs->bRedBlueStereo = 0;
+    presetOutputs->bBrighten = 0;
+    presetOutputs->bDarken = 0;
+    presetOutputs->bSolarize = 0;
+    presetOutputs->bInvert = 0;
+    presetOutputs->bMotionVectorsOn = 1;
     presetOutputs->fWarpAnimSpeed = 0;
-	presetOutputs->fWarpScale = 0;
-	presetOutputs->fShader = 0;
+    presetOutputs->fWarpScale = 0;
+    presetOutputs->fShader = 0;
 
-	/* PER_PIXEL CONSTANTS BEGIN */
+    /* PER_PIXEL CONSTANTS BEGIN */
 
-	/* PER_PIXEL CONSTANT END */
+    /* PER_PIXEL CONSTANT END */
 
-	/* Q AND T VARIABLES START */
+    /* Q AND T VARIABLES START */
 
-    for (unsigned int i = 0;i<NUM_Q_VARIABLES;i++)
-		presetOutputs->q[i] = 0;
-	
-	/* Q AND T VARIABLES END */
+    for (unsigned int i = 0; i < NUM_Q_VARIABLES; i++)
+    {
+        presetOutputs->q[i] = 0;
+    }
+
+    /* Q AND T VARIABLES END */
     return presetOutputs;
 }
 
 
-std::unique_ptr<Preset> MilkdropPresetFactory::allocate(const std::string & url, const std::string & name, const std::string & author) {
+std::unique_ptr<Preset>
+MilkdropPresetFactory::allocate(const std::string& url, const std::string& name, const std::string& author)
+{
 
-    PresetOutputs *presetOutputs;
+    PresetOutputs* presetOutputs;
     // use cached PresetOutputs if there is one, otherwise allocate
     if (_presetOutputsCache)
     {
@@ -217,25 +229,33 @@ std::unique_ptr<Preset> MilkdropPresetFactory::allocate(const std::string & url,
     }
     else
     {
-        presetOutputs = createPresetOutputs(gx,gy);
+        presetOutputs = createPresetOutputs(gx, gy);
     }
 
-	resetPresetOutputs(presetOutputs);
+    resetPresetOutputs(presetOutputs);
 
-	std::string path;
-	if (PresetFactory::protocol(url, path) == PresetFactory::IDLE_PRESET_PROTOCOL) {
-		return IdlePresets::allocate(this, path, *presetOutputs);
-	} else
-		return std::unique_ptr<Preset>(new MilkdropPreset(this, url, name, *presetOutputs));
+    std::string path;
+    if (PresetFactory::protocol(url, path) == PresetFactory::IDLE_PRESET_PROTOCOL)
+    {
+        return IdlePresets::allocate(this, path, *presetOutputs);
+    }
+    else
+    {
+        return std::unique_ptr<Preset>(new MilkdropPreset(this, url, name, *presetOutputs));
+    }
 }
 
 // this gives the preset a way to return the PresetOutput w/o dependency on class projectM behavior
-void MilkdropPresetFactory::releasePreset(Preset *preset_)
+void MilkdropPresetFactory::releasePreset(Preset* preset_)
 {
-    MilkdropPreset *preset = (MilkdropPreset *)preset_;
+    MilkdropPreset* preset = (MilkdropPreset*) preset_;
     // return PresetOutputs to the cache
     if (nullptr == _presetOutputsCache)
+    {
         _presetOutputsCache = &preset->_presetOutputs;
+    }
     else
+    {
         delete &preset->_presetOutputs;
+    }
 }

--- a/src/libprojectM/MilkdropPresetFactory/MilkdropPresetFactory.hpp
+++ b/src/libprojectM/MilkdropPresetFactory/MilkdropPresetFactory.hpp
@@ -15,29 +15,38 @@
 
 #include <memory>
 #include "../PresetFactory.hpp"
+
 class DLLEXPORT PresetOutputs;
+
 class DLLEXPORT PresetInputs;
 
-class MilkdropPresetFactory : public PresetFactory {
+class MilkdropPresetFactory : public PresetFactory
+{
 
 public:
- MilkdropPresetFactory(int gx, int gy);
+    MilkdropPresetFactory(int gx, int gy);
 
- virtual ~MilkdropPresetFactory();
- // called by ~MilkdropPreset
- void releasePreset(Preset *preset);
+    virtual ~MilkdropPresetFactory();
 
- std::unique_ptr<Preset> allocate(const std::string & url, const std::string & name = std::string(),
-	const std::string & author = std::string());
+    // called by ~MilkdropPreset
+    void releasePreset(Preset* preset);
 
- std::string supportedExtensions() const { return ".milk .prjm"; }
+    std::unique_ptr<Preset> allocate(const std::string& url, const std::string& name = std::string(),
+                                     const std::string& author = std::string());
+
+    std::string supportedExtensions() const
+    {
+        return ".milk .prjm";
+    }
 
 private:
     static PresetOutputs* createPresetOutputs(int gx, int gy);
-	void reset();
-	int gx;
-	int gy;
-	PresetOutputs * _presetOutputsCache;
+
+    void reset();
+
+    int gx;
+    int gy;
+    PresetOutputs* _presetOutputsCache;
 };
 
 #endif

--- a/src/libprojectM/MilkdropPresetFactory/MilkdropPresetFactory.hpp
+++ b/src/libprojectM/MilkdropPresetFactory/MilkdropPresetFactory.hpp
@@ -10,8 +10,7 @@
 //
 //
 
-#ifndef __MILKDROP_PRESET_FACTORY_HPP
-#define __MILKDROP_PRESET_FACTORY_HPP
+#pragma once
 
 #include <memory>
 #include "../PresetFactory.hpp"
@@ -26,15 +25,15 @@ class MilkdropPresetFactory : public PresetFactory
 public:
     MilkdropPresetFactory(int gx, int gy);
 
-    virtual ~MilkdropPresetFactory();
+    ~MilkdropPresetFactory() override;
 
     // called by ~MilkdropPreset
     void releasePreset(Preset* preset);
 
-    std::unique_ptr<Preset> allocate(const std::string& url, const std::string& name = std::string(),
-                                     const std::string& author = std::string());
+    std::unique_ptr<Preset> allocate(const std::string& url, const std::string& name,
+                                     const std::string& author) override;
 
-    std::string supportedExtensions() const
+    std::string supportedExtensions() const override
     {
         return ".milk .prjm";
     }
@@ -44,9 +43,7 @@ private:
 
     void reset();
 
-    int gx;
-    int gy;
-    PresetOutputs* _presetOutputsCache;
+    int gx{ 0 };
+    int gy{ 0 };
+    PresetOutputs* _presetOutputsCache{ nullptr };
 };
-
-#endif

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -706,6 +706,8 @@ int projectM::initPresetTools(int gx, int gy)
 
 void projectM::destroyPresetTools()
 {
+    m_activePreset.reset();
+    m_activePreset2.reset();
 
     if ( m_presetPos )
         delete ( m_presetPos );


### PR DESCRIPTION
Mainly two problems:
- MilkdropPresetFactory deleted a private reference-typed member in MilkdropPreset. Changed this into a plain pointer which is now checked and properly cleaned up.
- In the library interface class, projectM, the active preset pointers were not deleted before the factors, which lead to a use-after-free when the presets tried to dereference the factory pointer.