### PR TITLE
Add GitHub Action to build with CMake on Windows, Linux and macOS.

### DIFF
--- a/.github/workflows/build.cmake
+++ b/.github/workflows/build.cmake
@@ -1,0 +1,24 @@
+if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
+    execute_process(COMMAND "${CMAKE_COMMAND}" --build "$ENV{GITHUB_WORKSPACE}/cmake-build"
+            --config $ENV{BUILD_TYPE}
+
+            RESULT_VARIABLE result
+            )
+elseif("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux")
+    execute_process(COMMAND "${CMAKE_COMMAND}" --build "$ENV{GITHUB_WORKSPACE}/cmake-build"
+            -- -j 3
+
+            RESULT_VARIABLE result
+            )
+elseif("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Darwin")
+    execute_process(COMMAND "${CMAKE_COMMAND}" --build "$ENV{GITHUB_WORKSPACE}/cmake-build"
+            --config $ENV{BUILD_TYPE}
+            -- -j 5
+
+            RESULT_VARIABLE result
+            )
+endif()
+
+if(NOT result EQUAL 0)
+    message(FATAL_ERROR "CMake returned bad exit status")
+endif()

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -1,0 +1,37 @@
+name: CMake Build
+
+on: [ push, pull_request ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ windows-latest, ubuntu-latest, macos-latest ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Prerequisites
+        run: cmake -P ${{ github.workspace }}/.github/workflows/install_prerequisites.cmake
+
+      - name: Configure CMake
+        run: cmake -P ${{ github.workspace }}/.github/workflows/configure.cmake
+
+      - name: Build
+        run: cmake -P ${{ github.workspace }}/.github/workflows/build.cmake
+
+      - name: Package
+        run: cmake -P ${{ github.workspace }}/.github/workflows/package.cmake
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.os }}
+          path: package/projectM-*

--- a/.github/workflows/configure.cmake
+++ b/.github/workflows/configure.cmake
@@ -1,0 +1,39 @@
+if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
+    execute_process(COMMAND "${CMAKE_COMMAND}"
+            -G "Visual Studio 16 2019"
+            -A "X64"
+            -S "$ENV{GITHUB_WORKSPACE}"
+            -B "$ENV{GITHUB_WORKSPACE}/cmake-build"
+            -DTARGET_TRIPLET=x64-windows
+            -DCMAKE_VERBOSE_MAKEFILE=YES
+            "-DCMAKE_INSTALL_PREFIX=$ENV{GITHUB_WORKSPACE}/cmake-install"
+            "-DCMAKE_TOOLCHAIN_FILE=$ENV{VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake"
+
+            RESULT_VARIABLE result
+            )
+elseif("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux")
+    execute_process(COMMAND "${CMAKE_COMMAND}"
+            -G "Unix Makefiles"
+            -S "$ENV{GITHUB_WORKSPACE}"
+            -B "$ENV{GITHUB_WORKSPACE}/cmake-build"
+            -DCMAKE_VERBOSE_MAKEFILE=YES
+            -DCMAKE_BUILD_TYPE=$ENV{BUILD_TYPE}
+            "-DCMAKE_INSTALL_PREFIX=$ENV{GITHUB_WORKSPACE}/cmake-install"
+
+            RESULT_VARIABLE result
+            )
+elseif("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Darwin")
+    execute_process(COMMAND "${CMAKE_COMMAND}"
+            -G "Unix Makefiles"
+            -S "$ENV{GITHUB_WORKSPACE}"
+            -B "$ENV{GITHUB_WORKSPACE}/cmake-build"
+            -DCMAKE_VERBOSE_MAKEFILE=YES
+            "-DCMAKE_INSTALL_PREFIX=$ENV{GITHUB_WORKSPACE}/cmake-install"
+
+            RESULT_VARIABLE result
+            )
+endif()
+
+if(NOT result EQUAL 0)
+    message(FATAL_ERROR "CMake returned bad exit status")
+endif()

--- a/.github/workflows/install_prerequisites.cmake
+++ b/.github/workflows/install_prerequisites.cmake
@@ -1,0 +1,47 @@
+message(STATUS "Using host CMake version: ${CMAKE_VERSION}")
+
+if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
+    # On Windows, using vcpkg to install and build is the best practice.
+    set(VCPKG "$ENV{VCPKG_INSTALLATION_ROOT}/vcpkg.exe")
+    execute_process(COMMAND "${VCPKG}" --triplet=x64-windows install glew sdl2
+
+            RESULT_VARIABLE result
+            )
+elseif("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux")
+    # On Ubuntu, installing the required dev packages is sufficient
+    message(STATUS "Updating apt package sources")
+    execute_process(COMMAND sudo apt-get update
+            COMMAND sudo apt-get -f install
+
+            RESULT_VARIABLE result
+            )
+
+    if(NOT result EQUAL 0)
+        message(FATAL_ERROR "Could not update apt package lists")
+    endif()
+
+    execute_process(COMMAND sudo apt-get install
+            libgl1-mesa-dev
+            mesa-common-dev
+            libsdl2-dev
+            libglm-dev
+            qtbase5-dev
+            llvm-dev
+            libvisual-0.4-dev
+            libjack-jackd2-dev
+
+            RESULT_VARIABLE result
+            )
+
+elseif("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Darwin")
+    # macOS uses Homebrew to install additional software packages.
+    execute_process(COMMAND brew update
+            COMMAND brew install sdl2
+
+            RESULT_VARIABLE result
+            )
+endif()
+
+if(NOT result EQUAL 0)
+    message(FATAL_ERROR "A command returned bad exit status")
+endif()

--- a/.github/workflows/package.cmake
+++ b/.github/workflows/package.cmake
@@ -1,0 +1,21 @@
+if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
+    execute_process(COMMAND "${CMAKE_CPACK_COMMAND}"
+            -G ZIP
+            --config "$ENV{GITHUB_WORKSPACE}/cmake-build/CPackConfig.cmake"
+            -B "$ENV{GITHUB_WORKSPACE}/package"
+
+            RESULT_VARIABLE result
+            )
+else("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux")
+    execute_process(COMMAND "${CMAKE_CPACK_COMMAND}"
+            -G TGZ
+            --config "$ENV{GITHUB_WORKSPACE}/cmake-build/CPackConfig.cmake"
+            -B "$ENV{GITHUB_WORKSPACE}/package"
+
+            RESULT_VARIABLE result
+            )
+endif()
+
+if(NOT result EQUAL 0)
+    message(FATAL_ERROR "CPack returned bad exit status")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,18 +73,8 @@ endif()
 if(ENABLE_SDL)
     find_package(SDL2 REQUIRED)
 
-    # Temporary fix to deal with wrong include dir set by SDL2's CMake configuration.
-    get_target_property(_SDL2_INCLUDE_DIR SDL2::SDL2 INTERFACE_INCLUDE_DIRECTORIES)
-    if(_SDL2_INCLUDE_DIR MATCHES "(.+)/SDL2\$")
-        message(STATUS "SDL2 include dir contains \"SDL2\" subdir (SDL bug #4004) - fixing to \"${CMAKE_MATCH_1}\".")
-        set_target_properties(SDL2::SDL2 PROPERTIES
-                INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_MATCH_1}"
-                )
-    endif()
-
-    if(SDL2_VERSION VERSION_LESS "2.0.5")
-        message(FATAL_ERROR "SDL2 libraries were found, but have version ${SDL2_VERSION}. At least version 2.0.5 is required.")
-    endif()
+    # Apply some fixes, as SDL2's CMake support is new and still a WiP.
+    include(SDL2Target)
 endif()
 
 if(ENABLE_GLES)
@@ -197,3 +187,8 @@ message(AUTHOR_WARNING
         "fully supported.\n"
         "DO NOT base any production work on it yet!\n"
         )
+
+# Create CPack configuration
+set(CPACK_PACKAGE_NAME "projectM")
+set(CPACK_VERBATIM_VARIABLES YES)
+include(CPack)

--- a/cmake/SDL2Target.cmake
+++ b/cmake/SDL2Target.cmake
@@ -1,0 +1,68 @@
+# Helper script to add the SDL2 CMake target and version variable as introduced in SDL 2.0.12.
+# Also fixes a wrong include path provided by the SDL2 config script.
+
+
+# Proper CMake target support was added in SDL 2.0.12, create one
+# Need to search again to find the full path of libSDL2
+if(NOT TARGET SDL2::SDL2)
+    # Remove -lSDL2 as that is handled by CMake, note the space at the end so it does not replace e.g. -lSDL2main
+    # This may require "libdir" being set (from above)
+    string(REPLACE "-lSDL2 " "" SDL2_EXTRA_LINK_FLAGS " -lSDL2 ")
+    string(STRIP "${SDL2_EXTRA_LINK_FLAGS}" SDL2_EXTRA_LINK_FLAGS)
+    string(REPLACE "-lSDL2 " "" SDL2_EXTRA_LINK_FLAGS_STATIC " -Wl,--no-undefined -lm -ldl  -lasound -lm -ldl -lpthread -lpulse-simple -lpulse  -lX11 -lXext -lXcursor -lXinerama -lXi -lXrandr -lXss -lXxf86vm -lpthread -lrt ")
+    string(STRIP "${SDL2_EXTRA_LINK_FLAGS_STATIC}" SDL2_EXTRA_LINK_FLAGS_STATIC)
+
+    find_library(SDL2_LIBRARY SDL2)
+    if(NOT SDL2_LIBRARY)
+        message(FATAL_ERROR "Could not determine the location of the SDL2 library.")
+    endif()
+
+    add_library(SDL2::SDL2 SHARED IMPORTED)
+    set_target_properties(SDL2::SDL2 PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIRS}"
+            IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+            IMPORTED_LOCATION "${SDL2_LIBRARY}"
+            INTERFACE_LINK_LIBRARIES "${SDL2_EXTRA_LINK_FLAGS}")
+
+    find_library(SDL2MAIN_LIBRARY SDL2main)
+    if(NOT SDL2MAIN_LIBRARY)
+        message(FATAL_ERROR "Could not determine the location of the SDL2main library.")
+    endif()
+
+    add_library(SDL2::SDL2main STATIC IMPORTED)
+    set_target_properties(SDL2::SDL2main PROPERTIES
+            IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+            IMPORTED_LOCATION "${SDL2MAIN_LIBRARY}")
+
+    # Retrieve the version from the SDL2_version.h header
+    if(SDL2_INCLUDE_DIRS AND EXISTS "${SDL2_INCLUDE_DIRS}/SDL_version.h")
+        file(STRINGS "${SDL2_INCLUDE_DIRS}/SDL_version.h" SDL_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_MAJOR_VERSION[ \t]+[0-9]+$")
+        file(STRINGS "${SDL2_INCLUDE_DIRS}/SDL_version.h" SDL_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL_MINOR_VERSION[ \t]+[0-9]+$")
+        file(STRINGS "${SDL2_INCLUDE_DIRS}/SDL_version.h" SDL_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL_PATCHLEVEL[ \t]+[0-9]+$")
+        string(REGEX REPLACE "^#define[ \t]+SDL_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL_VERSION_MAJOR "${SDL_VERSION_MAJOR_LINE}")
+        string(REGEX REPLACE "^#define[ \t]+SDL_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL_VERSION_MINOR "${SDL_VERSION_MINOR_LINE}")
+        string(REGEX REPLACE "^#define[ \t]+SDL_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL_VERSION_PATCH "${SDL_VERSION_PATCH_LINE}")
+        set(SDL2_VERSION ${SDL_VERSION_MAJOR}.${SDL_VERSION_MINOR}.${SDL_VERSION_PATCH})
+        unset(SDL_VERSION_MAJOR_LINE)
+        unset(SDL_VERSION_MINOR_LINE)
+        unset(SDL_VERSION_PATCH_LINE)
+        unset(SDL_VERSION_MAJOR)
+        unset(SDL_VERSION_MINOR)
+        unset(SDL_VERSION_PATCH)
+    endif()
+
+endif()
+
+# Temporary fix to deal with wrong include dir set by SDL2's CMake configuration.
+get_target_property(_SDL2_INCLUDE_DIR SDL2::SDL2 INTERFACE_INCLUDE_DIRECTORIES)
+if(_SDL2_INCLUDE_DIR MATCHES "(.+)/SDL2\$")
+    message(STATUS "SDL2 include dir contains \"SDL2\" subdir (SDL bug #4004) - fixing to \"${CMAKE_MATCH_1}\".")
+    set_target_properties(SDL2::SDL2 PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_MATCH_1}"
+            )
+endif()
+
+if(SDL2_VERSION AND SDL2_VERSION VERSION_LESS "2.0.5")
+    message(FATAL_ERROR "SDL2 libraries were found, but have version ${SDL2_VERSION}. At least version 2.0.5 is required.")
+endif()
+

--- a/src/libprojectM/CMakeLists.txt
+++ b/src/libprojectM/CMakeLists.txt
@@ -92,6 +92,13 @@ target_include_directories(projectM_main
         "${MSVC_EXTRA_INCLUDE_DIR}"
         )
 
+target_link_libraries(projectM_main
+        PRIVATE
+        GLM::GLM
+        PUBLIC
+        ${PROJECTM_OPENGL_LIBRARIES}
+        )
+
 add_library(projectM_static STATIC
         $<TARGET_OBJECTS:projectM_main>
         $<TARGET_OBJECTS:MilkdropPresetFactory>


### PR DESCRIPTION
Just a workflow file plus some CMake scripts for each step that do the actual work.

The workflow builds projectM on all three major desktop platforms using the public GitHub runners and packages the results. Currently, the archives will not be unpack-and-run, as the structure is currently fixed to the Linux install layout. It's mainly there to check for build failures on one or more platforms using the CMake scripts.