### PR TITLE
Windows fix for SDL DPI scaling

### DIFF
--- a/msvc/projectMSDL.vcxproj
+++ b/msvc/projectMSDL.vcxproj
@@ -94,6 +94,9 @@
     <ProjectReference>
       <LinkLibraryDependencies>false</LinkLibraryDependencies>
     </ProjectReference>
+    <Manifest>
+      <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -138,6 +141,9 @@
     <ProjectReference>
       <LinkLibraryDependencies>false</LinkLibraryDependencies>
     </ProjectReference>
+    <Manifest>
+      <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)../src\projectM-sdl\projectM_SDL_main.cpp" />


### PR DESCRIPTION
I recall there was a bug for this and we found a trick by right clicking the .exe properties and changing a setting.

I purchase a high resolution monitor and experienced the problem myself for the first time. Windows by default will offer scaling to make apps easier to read at large resolutions.
![image](https://user-images.githubusercontent.com/59471060/124983557-2866eb00-e049-11eb-9697-74d518e8f5be.png)

So projectM will virtually scale. 200% means your resolution is cut in half.
![image](https://user-images.githubusercontent.com/59471060/124983654-4af90400-e049-11eb-85ba-aab290ccc623.png)

This minor fix makes projectM ignore scaling so you get true resolution:
![image](https://user-images.githubusercontent.com/59471060/124983720-5ea46a80-e049-11eb-80b4-8c8ff0183d1a.png)
