### PR TITLE
Add SDL2 hint to use monitor/virtual capture devices which are available starting with SDL 2.0.16.

### DIFF
--- a/src/projectM-sdl/setup.cpp
+++ b/src/projectM-sdl/setup.cpp
@@ -1,5 +1,7 @@
 #include "setup.hpp"
 
+#include <SDL2/SDL_hints.h>
+
 #include <chrono>
 #include <cmath>
 
@@ -154,6 +156,10 @@ projectMSDL *setupSDLApp() {
 
 #if UNLOCK_FPS
     setenv("vblank_mode", "0", 1);
+#endif
+
+#ifdef SDL_HINT_AUDIO_INCLUDE_MONITORS
+    SDL_SetHint(SDL_HINT_AUDIO_INCLUDE_MONITORS, "1");
 #endif
 
     SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO);


### PR DESCRIPTION
Along with Ryan's fix (big thanks!) becoming available in the SDL2 2.0.16 release, adding the newly added hint will finally make "monitor" devices work in SDL's PulseAudio driver.

Closes issues #429 and #30.