### PR TITLE
Replace "#ifdef USE_GLES" with "#if USE_GLES"

### DIFF
--- a/src/libprojectM/Renderer/StaticGlShaders.h
+++ b/src/libprojectM/Renderer/StaticGlShaders.h
@@ -10,7 +10,7 @@ class StaticGlShaders {
     // Returns the singleton StaticGlShaders instance.
     static std::shared_ptr<StaticGlShaders> Get() {
         bool use_gles = false;
-#ifdef USE_GLES
+#if USE_GLES
         use_gles = true;
 #endif
 

--- a/src/libprojectM/Renderer/hlslparser/src/GLSLGenerator.cpp
+++ b/src/libprojectM/Renderer/hlslparser/src/GLSLGenerator.cpp
@@ -114,7 +114,7 @@ GLSLGenerator::GLSLGenerator() :
     m_tree                      = NULL;
     m_entryName                 = NULL;
     m_target                    = Target_VertexShader;
-#ifdef USE_GLES
+#if USE_GLES
     m_version                   = Version_300_ES;
 #else
     m_version                   = Version_330;

--- a/src/libprojectM/gltext.h
+++ b/src/libprojectM/gltext.h
@@ -832,7 +832,7 @@ GLT_API void gltTerminate(void)
 	gltInitialized = GL_FALSE;
 }
 	
-#ifdef USE_GLES
+#if USE_GLES
 #define GLSL_VERSION "300 es"
 #else
 #define GLSL_VERSION "330"
@@ -860,7 +860,7 @@ static const GLchar* _gltText2DFragmentShaderSource =
 "#version "
 GLSL_VERSION
 "\n"
-#ifdef USE_GLES
+#if USE_GLES
 "precision mediump float;\n"
 "\n"
 #endif


### PR DESCRIPTION
The old configure script either did not #define USE_GLES at all, or defined it to 1. CMake only supports #define or #undef without a value, or #define it to either 0 or 1. Using #if will make it compatible with both ways of configuring the macro.

This will fix the issues with shaders not compiling, complaining about the OpenGL version being too low or #version missing in the shader declaration.