### PR TITLE
Add a dummy source file so the CMake Xcode generator creates libprojectM.a

### DIFF
--- a/src/libprojectM/CMakeLists.txt
+++ b/src/libprojectM/CMakeLists.txt
@@ -100,6 +100,9 @@ target_link_libraries(projectM_main
         )
 
 add_library(projectM_static STATIC
+        # Xcode needs at least one source file, otherwise it won't create the static library.
+        StaticLibDummy.cpp
+
         $<TARGET_OBJECTS:projectM_main>
         $<TARGET_OBJECTS:MilkdropPresetFactory>
         $<TARGET_OBJECTS:NativePresetFactory>

--- a/src/libprojectM/StaticLibDummy.cpp
+++ b/src/libprojectM/StaticLibDummy.cpp
@@ -1,0 +1,6 @@
+/**
+ * Dummy file for Xcode, as it doesn't create static libs with only $<TARGET_OBJECTS:...> sources.
+ * Linking this file will not add any code to the executables as the function is never referenced.
+ */
+
+void DummyFunction() {}


### PR DESCRIPTION
Xcode targets seem to need at least one "real" source file for static libs to be built. Added a dummy file with an empty function to satisfy this requirement.