### PR TITLE
libprojectm: Fix static DL_LIBS for Qt PulseAudio

### DIFF
--- a/src/libprojectM/libprojectM_static.cmake
+++ b/src/libprojectM/libprojectM_static.cmake
@@ -40,6 +40,7 @@ target_link_libraries(projectM_static
         GLM::GLM
         PUBLIC
         ${PROJECTM_OPENGL_LIBRARIES}
+        ${CMAKE_DL_LIBS}
         )
 
 if(ENABLE_THREADING)


### PR DESCRIPTION
## In short
* Add missing `${CMAKE_DL_LIBS}` for `libprojectM_static.cmake`
  * Fixes `projectM-pulseaudio` build variant

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Fixes broken build of standalone Qt visualizer
Risk | ★☆☆ *1/3* | May impact static library builds on other platforms
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests


## Testing
### Steps

On Kubuntu 20.04 LTS, after installing dependencies…

```
mkdir build && cd build
cmake .. -DENABLE_SDL=OFF -DENABLE_SDL_UI=OFF -DENABLE_PULSEAUDIO=ON
make -j$(nproc)
```

### Before
```
[100%] Linking CXX executable projectM-pulseaudio
/usr/bin/ld: ../libprojectM/libprojectM.a(NativePresetFactory.cpp.o): undefined reference to symbol 'dlclose@@GLIBC_2.2.5'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/9/../../../x86_64-linux-gnu/libdl.so: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [src/projectM-pulseaudio/CMakeFiles/projectM-pulseaudio.dir/build.make:168: src/projectM-pulseaudio/projectM-pulseaudio] Error 1
make[1]: *** [CMakeFiles/Makefile2:673: src/projectM-pulseaudio/CMakeFiles/projectM-pulseaudio.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
```

### After
Builds and runs successfully!

```
[100%] Linking CXX executable projectM-pulseaudio
[100%] Built target projectM-pulseaudio
```

### Future work
Expand CMake CI build matrix to enable all non-conflicting options.