### PR TITLE
Fix windows includes for mingw

### DIFF
--- a/src/libprojectM/projectM-opengl.h
+++ b/src/libprojectM/projectM-opengl.h
@@ -31,9 +31,10 @@
 #include <EGL/eglext.h>
 #elif defined(_WIN32)
 #define GLM_FORCE_CXX03
+# include <winsock2.h>
 # include <windows.h>
-#include "GL/glew.h"
-#include "GL/wglew.h"
+# include "GL/glew.h"
+# include "GL/wglew.h"
 #else /* linux/unix/other */
 # if USE_GLES
 #  include <GLES3/gl3.h>


### PR DESCRIPTION
mingw kindly asks for `winsock2.h` to always be included before `windows.h`
doesn't hurt or break anything for MSVC as far as I know, so why not.
