### PR TITLE
Fix native preset build issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ cmake_dependent_option(ENABLE_SHARED_LINKING "Link all built UI applications aga
 option(ENABLE_DOXYGEN "Build and install Doxygen source code documentation in PROJECTM_DATADIR_PATH/docs." OFF)
 option(ENABLE_CXX_INTERFACE "Enable exporting all C++ symbols, not only the C API, in the shared library. Warning: This is not very portable." OFF)
 option(ENABLE_PRESETS "Build and install bundled presets" ON)
-option(ENABLE_NATIVE_PRESETS "Build and install native libraries written in C/C++" OFF)
+option(ENABLE_NATIVE_PRESETS "Build and install native preset loading support and preset libraries written in C/C++" OFF)
 option(ENABLE_TESTING "Build and install the projectM test suite" OFF)
 option(ENABLE_EMSCRIPTEN "Build for web with emscripten" OFF)
 cmake_dependent_option(ENABLE_SDL "Enable SDL2 support" ON "NOT ENABLE_EMSCRIPTEN;NOT ENABLE_TESTING" ON)

--- a/config.h.cmake.in
+++ b/config.h.cmake.in
@@ -69,5 +69,8 @@
 /* Define USE_THREADS */
 #cmakedefine01 USE_THREADS
 
+/* Define ENABLE_NATIVE_PRESETS */
+#cmakedefine ENABLE_NATIVE_PRESETS
+
 /* Version number of package */
 #define VERSION "@PROJECT_VERSION@"

--- a/src/libprojectM/CMakeLists.txt
+++ b/src/libprojectM/CMakeLists.txt
@@ -28,6 +28,15 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
             )
 endif()
 
+# List of targets used in export().
+# Optional libraries will be added to the list as configured in the build options.
+set(EXPORTED_TARGETS
+        MilkdropPresetFactory
+        Renderer
+        hlslparser
+        SOIL2
+        )
+
 add_subdirectory(MilkdropPresetFactory)
 add_subdirectory(NativePresetFactory)
 add_subdirectory(Renderer)
@@ -147,13 +156,7 @@ endif()
 
 # For use from a local projectM build tree (without installing)
 export(TARGETS
-        MilkdropPresetFactory
-        NativePresetFactory
-        Renderer
-        hlslparser
-        SOIL2
-        ${EXPORT_STATIC_LIB_TARGET}
-        ${EXPORT_SHARED_LIB_TARGET}
+        ${EXPORTED_TARGETS}
         NAMESPACE libprojectM::
         FILE projectM-exports.cmake
         )

--- a/src/libprojectM/NativePresetFactory/CMakeLists.txt
+++ b/src/libprojectM/NativePresetFactory/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(NativePresetFactory
         PUBLIC
         GLM::GLM
         ${PROJECTM_OPENGL_LIBRARIES}
+        ${CMAKE_DL_LIBS}
         )
         
 set_target_properties(NativePresetFactory PROPERTIES

--- a/src/libprojectM/NativePresetFactory/CMakeLists.txt
+++ b/src/libprojectM/NativePresetFactory/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(NOT ENABLE_NATIVE_PRESETS)
+    return()
+endif()
+
 add_library(NativePresetFactory OBJECT
         MilkdropCompatability.hpp
         NativePreset.hpp
@@ -22,3 +26,5 @@ target_link_libraries(NativePresetFactory
 set_target_properties(NativePresetFactory PROPERTIES
         FOLDER libprojectM
         )
+
+set(EXPORTED_TARGETS ${EXPORTED_TARGETS} NativePresetFactory PARENT_SCOPE)

--- a/src/libprojectM/PresetFactoryManager.cpp
+++ b/src/libprojectM/PresetFactoryManager.cpp
@@ -10,17 +10,16 @@
 //
 //
 #include "PresetFactoryManager.hpp"
-
-#ifndef DISABLE_MILKDROP_PRESETS
 #include "MilkdropPresetFactory/MilkdropPresetFactory.hpp"
-#endif
 
-#ifndef DISABLE_NATIVE_PRESETS
+#ifdef ENABLE_NATIVE_PRESETS
 #include "NativePresetFactory/NativePresetFactory.hpp"
 #endif
 
+#include "config.h"
 #include "Common.hpp"
 #include <sstream>
+
 PresetFactoryManager::PresetFactoryManager() : _gx(0), _gy(0), initialized(false) {}
 
 PresetFactoryManager::~PresetFactoryManager() {
@@ -45,13 +44,11 @@ void PresetFactoryManager::initialize(int gx, int gy) {
 	}
 	  
 	PresetFactory * factory;
-	
-	#ifndef DISABLE_MILKDROP_PRESETS
+
 	factory = new MilkdropPresetFactory(_gx, _gy);
 	registerFactory(factory->supportedExtensions(), factory);		
-	#endif
-	
-	#ifndef DISABLE_NATIVE_PRESETS
+
+	#ifdef ENABLE_NATIVE_PRESETS
 	factory = new NativePresetFactory();
 	registerFactory(factory->supportedExtensions(), factory);
 	#endif

--- a/src/libprojectM/libprojectM_shared.cmake
+++ b/src/libprojectM/libprojectM_shared.cmake
@@ -5,7 +5,7 @@ add_library(projectM_shared SHARED
 
         $<TARGET_OBJECTS:projectM_main>
         $<TARGET_OBJECTS:MilkdropPresetFactory>
-        $<TARGET_OBJECTS:NativePresetFactory>
+        $<$<TARGET_EXISTS:NativePresetFactory>:$<TARGET_OBJECTS:NativePresetFactory>>
         $<TARGET_OBJECTS:Renderer>
         $<TARGET_OBJECTS:hlslparser>
         $<TARGET_OBJECTS:SOIL2>
@@ -76,4 +76,4 @@ install(TARGETS projectM_shared
         COMPONENT Runtime
         )
 
-set(EXPORT_SHARED_LIB_TARGET projectM_shared)
+list(APPEND EXPORTED_TARGETS projectM_shared)

--- a/src/libprojectM/libprojectM_static.cmake
+++ b/src/libprojectM/libprojectM_static.cmake
@@ -5,7 +5,7 @@ add_library(projectM_static STATIC
 
         $<TARGET_OBJECTS:projectM_main>
         $<TARGET_OBJECTS:MilkdropPresetFactory>
-        $<TARGET_OBJECTS:NativePresetFactory>
+        $<$<TARGET_EXISTS:NativePresetFactory>:$<TARGET_OBJECTS:NativePresetFactory>>
         $<TARGET_OBJECTS:Renderer>
         $<TARGET_OBJECTS:hlslparser>
         $<TARGET_OBJECTS:SOIL2>
@@ -71,7 +71,7 @@ install(TARGETS projectM_static
         COMPONENT Runtime
         )
 
-set(EXPORT_SHARED_LIB_TARGET projectM_static)
+list(APPEND EXPORTED_TARGETS projectM_static)
 
 
 # pkg-config export, only supports static library on UNIX systems.


### PR DESCRIPTION
First commit is the minimum required change to fix issue #543 and is basically overlapping with PR #544.

This PR contains an additional commit that fully disables native preset loading support if the `ENABLE_NATIVE_PRESETS` build setting if `OFF` (default value) by omitting the NativePresetFactory library.