### PR TITLE
Add missing "round" intrinsic in HLSLParser

### DIFF
--- a/src/libprojectM/Renderer/hlslparser/src/HLSLParser.cpp
+++ b/src/libprojectM/Renderer/hlslparser/src/HLSLParser.cpp
@@ -455,6 +455,7 @@ const Intrinsic _intrinsic[] =
 
         INTRINSIC_FLOAT1_FUNCTION( "floor" ),
         INTRINSIC_FLOAT1_FUNCTION( "ceil" ),
+        INTRINSIC_FLOAT1_FUNCTION( "round" ),
         INTRINSIC_FLOAT1_FUNCTION( "frac" ),
 
         INTRINSIC_FLOAT2_FUNCTION( "fmod" ),


### PR DESCRIPTION
Just a one-liner.
Adds the missing "round" intrinsic in the HLSL transpiler, which is used in a few presets ("EVET - The Rift" for example) and can be used 1:1 in GLSL.