### PR TITLE
Add DPI awareness flag to the SDL app on Windows.

### DIFF
--- a/src/projectM-sdl/CMakeLists.txt
+++ b/src/projectM-sdl/CMakeLists.txt
@@ -28,6 +28,20 @@ target_link_libraries(projectMSDL
         ${CMAKE_DL_LIBS}
         )
 
+if(MSVC)
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.16")
+        set_target_properties(projectMSDL
+                PROPERTIES
+                VS_DPI_AWARE "PerMonitor"
+                )
+    else()
+        message(AUTHOR_WARNING
+                "You're using a CMake version less than 3.16 with Visual Studio.\n"
+                "The resulting projectMSDL executable will not be DPI-aware and possibly render at a "
+                "lower-than-expected resolution on high-DPI displays.")
+    endif()
+endif()
+
 install(TARGETS projectMSDL
         RUNTIME DESTINATION "${PROJECTM_BIN_DIR}"
         COMPONENT Applications


### PR DESCRIPTION
This was fixed for the manually created VS solution in commit 3171507, but not yet ported to CMake.