### PR TITLE
Improve overlay text rendering performance and a few Renderer cleanups.

### DIFF
--- a/src/libprojectM/Renderer/CMakeLists.txt
+++ b/src/libprojectM/Renderer/CMakeLists.txt
@@ -6,31 +6,33 @@ add_library(Renderer OBJECT
         BeatDetect.hpp
         Filters.cpp
         Filters.hpp
+        MenuText.cpp
+        MenuText.h
         MilkdropWaveform.cpp
         MilkdropWaveform.hpp
+        PerPixelMesh.cpp
+        PerPixelMesh.hpp
         PerlinNoise.cpp
         PerlinNoise.hpp
         PerlinNoiseWithAlpha.cpp
         PerlinNoiseWithAlpha.hpp
-        PerPixelMesh.cpp
-        PerPixelMesh.hpp
-        PipelineContext.cpp
-        PipelineContext.hpp
         Pipeline.cpp
         Pipeline.hpp
-        Renderable.cpp
-        Renderable.hpp
-        Renderer.cpp
-        Renderer.hpp
+        PipelineContext.cpp
+        PipelineContext.hpp
         RenderItemDistanceMetric.cpp
         RenderItemDistanceMetric.hpp
         RenderItemMatcher.cpp
         RenderItemMatcher.hpp
         RenderItemMergeFunction.hpp
+        Renderable.cpp
+        Renderable.hpp
+        Renderer.cpp
+        Renderer.hpp
         Shader.cpp
+        Shader.hpp
         ShaderEngine.cpp
         ShaderEngine.hpp
-        Shader.hpp
         StaticGlShaders.cpp
         Texture.cpp
         Texture.hpp

--- a/src/libprojectM/Renderer/MenuText.cpp
+++ b/src/libprojectM/Renderer/MenuText.cpp
@@ -1,0 +1,163 @@
+#ifdef USE_TEXT_MENU
+
+#include "MenuText.h"
+
+#include "Common.hpp"
+
+#define GLT_IMPLEMENTATION
+#include "gltext.h"
+
+MenuText::MenuText(int viewportWidth)
+    : _viewportWidth(viewportWidth)
+{
+    gltInit();
+    _glTextInstance = gltCreateText();
+}
+
+MenuText::~MenuText()
+{
+    if (_glTextInstance)
+    {
+        gltDeleteText(_glTextInstance);
+        _glTextInstance = nullptr;
+    }
+}
+
+void MenuText::SetViewportWidth(int viewportWidth)
+{
+    _viewportWidth = viewportWidth;
+}
+
+void MenuText::CleanUp()
+{
+    gltTerminate();
+}
+
+void MenuText::DrawBegin() const
+{
+    // Begin text drawing (this for instance calls glUseProgram)
+    gltBeginDraw();
+}
+
+void MenuText::DrawEnd() const
+{
+    // Finish drawing text - will unbind font texture & shaders.
+    gltEndDraw();
+}
+
+void MenuText::Draw(std::string textLine,
+                    GLfloat x,
+                    GLfloat y,
+                    GLfloat scale,
+                    HorizontalAlignment horizontalAlignment,
+                    VerticalAlignment verticalAlignment,
+                    float r,
+                    float b,
+                    float g,
+                    float a,
+                    bool highlightable,
+                    const std::string& highlightText) const
+{
+    if (!gltInitialized || !_glTextInstance)
+    {
+        return;
+    }
+
+    int gltHorizontalAlignment = static_cast<int>(horizontalAlignment);
+    int gltVerticalAlignment = static_cast<int>(verticalAlignment);
+
+    gltSetText(_glTextInstance, textLine.c_str());
+    GLfloat textWidth = gltGetTextWidth(_glTextInstance, scale);
+
+    auto windowWidth = static_cast<float>(_viewportWidth);
+    if (gltHorizontalAlignment == GLT_LEFT)
+    {
+        // if left aligned factor in X offset
+        windowWidth -= x;
+    }
+
+    // if our window is greater than the text width, there is no overflow so let's display it normally.
+    if (windowWidth < textWidth)
+    {
+        // if the text is greater than the window width, we have a problem.
+        while (textWidth > windowWidth)
+        {
+            textLine.pop_back();
+            gltSetText(_glTextInstance, textLine.c_str());
+
+            gltDrawText2DAligned(_glTextInstance, x, y, scale, gltHorizontalAlignment, gltVerticalAlignment);
+            textWidth = gltGetTextWidth(_glTextInstance, scale);
+        }
+
+        // if it's not multi-line then append a ...
+        if (textLine.find('\n') != std::string::npos)
+        {
+           textLine.pop_back();
+           textLine.pop_back();
+           textLine.pop_back();
+           textLine += "...";
+        }
+    }
+
+    // redraw without transparency
+    if (highlightable && highlightText.length() > 1)
+    {
+        HighlightNeedle(textLine, highlightText, x, y, scale, gltHorizontalAlignment, gltVerticalAlignment, r, g, b, a);
+    }
+    else
+    {
+        gltColor(r, g, b, a);
+        gltSetText(_glTextInstance, textLine.c_str());
+        gltDrawText2DAligned(_glTextInstance, x, y, scale, gltHorizontalAlignment, gltVerticalAlignment);
+    }
+}
+
+void MenuText::HighlightNeedle(const std::string& textLine,
+                               const std::string& highlightText,
+                               GLfloat x,
+                               GLfloat y,
+                               GLfloat scale,
+                               int horizontalAlignment = GLT_LEFT,
+                               int verticalAlignment = GLT_TOP,
+                               float r = 1.0f,
+                               float b = 1.0f,
+                               float g = 1.0f,
+                               float a = 1.0f) const
+{
+
+    size_t pos = caseInsensitiveSubstringFind(textLine, highlightText);
+
+    gltColor(r, g, b, a);
+
+    if (pos == std::string::npos)
+    {
+        // Search term not found (e.g. cropped due to window size), render whole line.
+        gltSetText(_glTextInstance, textLine.c_str());
+        gltDrawText2DAligned(_glTextInstance, x, y, scale, horizontalAlignment, verticalAlignment);
+
+        return;
+    }
+
+    // Draw everything normal, up to search term.
+    gltSetText(_glTextInstance, textLine.substr(0, pos).c_str());
+    gltDrawText2DAligned(_glTextInstance, x, y, scale, horizontalAlignment, verticalAlignment);
+
+    // Crop original text from "textLine" to retain casing.
+    std::string originalHighlightText = textLine.substr(pos, highlightText.length());
+
+    // highlight search term
+    GLfloat textWidth = gltGetTextWidth(_glTextInstance, scale);
+    GLfloat offset = x + textWidth;
+    gltColor(1.0f, 0.0f, 1.0f, a);
+    gltSetText(_glTextInstance, originalHighlightText.c_str());
+    gltDrawText2DAligned(_glTextInstance, offset, y, scale, horizontalAlignment, verticalAlignment);
+
+    // draw rest of name, normally
+    textWidth = gltGetTextWidth(_glTextInstance, scale);
+    offset = offset + textWidth;
+    gltColor(r, g, b, a);
+    gltSetText(_glTextInstance, textLine.substr(pos + originalHighlightText.length(), textLine.length()).c_str());
+    gltDrawText2DAligned(_glTextInstance, offset, y, scale, horizontalAlignment, verticalAlignment);
+}
+
+#endif

--- a/src/libprojectM/Renderer/MenuText.h
+++ b/src/libprojectM/Renderer/MenuText.h
@@ -1,0 +1,152 @@
+#pragma once
+
+#ifdef USE_TEXT_MENU
+
+#include "projectM-opengl.h"
+
+#include <string>
+
+class GLTtext;
+
+/**
+ * @brief Menu text renderer
+ *
+ * <p>Uses the single-header glText library to render the menu overlay and toast messages.</p>
+ *
+ * <p>For proper cleanup, the CleanUp() method should be called once before shutdown or when resetting
+ * the OpenGL renderer. It will destroy the texture atlas and shaders. It just calls gltTerminate().
+ * The gltInit() function is called each time an instance of MenuText is created, assuring that everything
+ * is properly initialized. This is only done once on start or after calling CleanUp().</p>
+ */
+class MenuText
+{
+public:
+    /**
+     * Constants for horizontal text alignment.
+     */
+    enum class HorizontalAlignment
+    {
+        Left = 0, //!< Render text aligned to the left
+        Center = 1, //!< Render text aligned to the center
+        Right = 2 //!< Render text aligned to the right
+    };
+
+    /**
+     * Constants for vertical text alignment.
+     */
+    enum class VerticalAlignment
+    {
+        Top = 0, //!< Render text aligned to the top
+        Center = 1, //!< Render text aligned to the center
+        Bottom = 2//!< Render text aligned to the bottom
+    };
+
+    MenuText() = delete;
+
+    /**
+     * Constructor.
+     * @param viewportWidth Sets the maximum viewport width.
+     */
+    explicit MenuText(int viewportWidth);
+    virtual ~MenuText();
+
+    /**
+     * @brief Sets the maximum viewport width.
+     * @param viewportWidth
+     */
+    void SetViewportWidth(int viewportWidth);
+
+    /**
+     * @brief Destroy the internal glText objects, e.g. shaders and the font texture.
+     *
+     * Only call this on shutdown or when resetting the OpenGL renderer and after all instances of MenuText
+     * were destroyed. The next instance of MenuText will reinitialize glText.
+     */
+    static void CleanUp();
+
+    /**
+     * @brief Binds text drawing shaders and textures.
+     *
+     * Always needs to be called before the initial call to Draw().
+     */
+    void DrawBegin() const;
+
+    /**
+     * @brief Unbinds text drawing shaders and textures.
+     *
+     * Should be called after the last call to Draw().
+     */
+    void DrawEnd() const;
+
+    /**
+     * @brief Renders a line or block of text.
+     *
+     * <p>Text is cut off if wider than the viewport. Note this can cull more text than intended if
+     * it consists of multiple lines, e.g. after a long line, no more text is rendered.</p>
+     *
+     * <p>Before calling Draw(), BeginDraw() must be called to set up the required OpenGL states. Draw()
+     * can then be called any number of times. If text rendering is done, DrawEnd() should be called.</p>
+     *
+     * @param textLine The text that should be rendered.
+     * @param x X offset of the text.
+     * @param y Y offset of the text.
+     * @param scale Font size.
+     * @param horizontalAlignment Horizontal text alignment inside the viewport.
+     * @param verticalAlignment Vertical text alignment inside the viewport.
+     * @param r Red color value, 0.0 to 1.0.
+     * @param b Blue color value, 0.0 to 1.0.
+     * @param g Green color value, 0.0 to 1.0.
+     * @param a Alpha value, 0.0 (transparent) to 1.0 (opaque).
+     * @param highlightable If true, highlightText will be searched in textLine and highlighted in magenta in the output.
+     * @param highlightText Text to be seaqrched and highlighted, case-insensitive.
+     */
+    void Draw(std::string textLine,
+              GLfloat x,
+              GLfloat y,
+              GLfloat scale,
+              HorizontalAlignment horizontalAlignment = HorizontalAlignment::Left,
+              VerticalAlignment verticalAlignment = VerticalAlignment::Top,
+              float r = 1.0f,
+              float b  = 1.0f,
+              float g  = 1.0f,
+              float a  = 1.0f,
+              bool highlightable = false,
+              const std::string& highlightText = "") const;
+
+protected:
+
+    /**
+     * @brief Searches for highlightText in textLine and renders the search text in a different color.
+     *
+     * If the text is not found, the line will be rendered normally. The highlighted text is rendered in magenta
+     * with the same alpha value as the normal text.
+     *
+     * @param textLine The text that should be rendered.
+     * @param highlightText The text that should be highlighted.
+     * @param x X offset of the text.
+     * @param y Y offset of the text.
+     * @param scale Font size.
+     * @param horizontalAlignment Horizontal text alignment inside the viewport.
+     * @param verticalAlignment Vertical text alignment inside the viewport.
+     * @param r Red color value, 0.0 to 1.0. Only used for the non-highlighted part of the text.
+     * @param b Blue color value, 0.0 to 1.0. Only used for the non-highlighted part of the text.
+     * @param g Green color value, 0.0 to 1.0. Only used for the non-highlighted part of the text.
+     * @param a Alpha value, 0.0 (transparent) to 1.0 (opaque).
+     */
+    void HighlightNeedle(const std::string& textLine,
+                         const std::string& highlightText,
+                         GLfloat x,
+                         GLfloat y,
+                         GLfloat scale,
+                         int horizontalAlignment,
+                         int verticalAlignment,
+                         float r,
+                         float b,
+                         float g,
+                         float a) const;
+
+    int _viewportWidth{ 0 }; //!< The viewport width in pixels that can be used.
+    GLTtext* _glTextInstance{ nullptr }; //!< The glText instance pointer.
+};
+
+#endif

--- a/src/libprojectM/Renderer/Renderer.hpp
+++ b/src/libprojectM/Renderer/Renderer.hpp
@@ -3,29 +3,25 @@
 
 #include "BeatDetect.hpp"
 #include "Common.hpp"
-#include <string>
-#include <set>
-#include "projectM-opengl.h"
-#include "Pipeline.hpp"
-#include "PerPixelMesh.hpp"
-#include "Transformation.hpp"
 #include "MilkdropWaveform.hpp"
+#include "PerPixelMesh.hpp"
+#include "Pipeline.hpp"
 #include "ShaderEngine.hpp"
-#include <iostream>
+#include "Transformation.hpp"
+#include "projectM-opengl.h"
+#ifdef USE_TEXT_MENU
+#include "MenuText.h"
+#endif /** USE_TEXT_MENU */
+
 #include <chrono>
 #include <ctime>
+#include <iostream>
 #include <list>
+#include <set>
+#include <string>
+
 
 using namespace std::chrono;
-
-#ifdef USE_TEXT_MENU
-
-#define GLT_IMPLEMENTATION
-#define GLT_DEBUG_PRINT
-#define __gl_h_  // gltext doesn't do a great job of noticing we included gl
-#include "gltext.h"
-
-#endif /** USE_TEXT_MENU */
 
 #define TOAST_TIME 2
 #define TOUCH_TIME 5
@@ -62,66 +58,68 @@ public:
         touchg(double) Green
         toucha(double) Alpha
     */
-  float touchx;
-  float touchy;
-  int touchp; // Touch Pressure.
-  int touchtype; // Touch Type
-  double touchr;
-  double touchg;
-  double touchb;
-  double toucha;
+  float touchx{ 0.0 };
+  float touchy{ 0.0 };
+  int touchp{ 0 }; // Touch Pressure.
+  int touchtype{ 0 }; // Touch Type
+  double touchr{ 0.0 };
+  double touchg{ 0.0 };
+  double touchb{ 0.0 };
+  double toucha{ 0.0 };
   
-  bool showtoast;
-  bool showfps;
-  bool showtitle;
-  bool showpreset;
-  bool showhelp;
-  bool showsearch;
-  bool showmenu;
-  bool showstats;
+  bool showtoast{ false };
+  bool showfps{ false };
+  bool showtitle{ false };
+  bool showpreset{ false };
+  bool showhelp{ false };
+  bool showsearch{ false };
+  bool showmenu{ false };
+  bool showstats{ false };
 
-  bool shuffletrack;
+  bool shuffletrack{ false };
 
-  bool studio;
-  bool correction;
+  bool studio{ false };
+  bool correction{ true };
 
-  bool noSwitch;
+  bool noSwitch{ false };
   bool writeNextFrameToFile;
 
   struct preset {
     int id;
-    std::string name, presetPack;
+    std::string name;
+    std::string presetPack;
   };
 
 
-  milliseconds lastTimeFPS;
-  milliseconds currentTimeFPS;
+  milliseconds lastTimeFPS{ nowMilliseconds() };
+  milliseconds currentTimeFPS{ nowMilliseconds() };
 
-  milliseconds lastTimeToast;
-  milliseconds currentTimeToast;
+  milliseconds lastTimeToast{ nowMilliseconds() };
+  milliseconds currentTimeToast{ nowMilliseconds() };
 
   std::string m_helpText;
 
   std::vector<MilkdropWaveform> waveformList;
 
-  int totalframes;
-  float realfps;
+  int totalframes{ 1 };
+  float realfps{ 0.0 };
 
   std::string title;
-  int m_activePresetID;
+  int m_activePresetID{ 0 };
   std::vector<preset> m_presetList;
 
-  int drawtitle;
-  int texsizeX;
-  int texsizeY;
-  int textMenuPageSize = 10;
-  int textMenuLineHeight = 25;
-  int textMenuYOffset = 60;
-  float m_fAspectX;
-  float m_fAspectY;
-  float m_fInvAspectX;
-  float m_fInvAspectY;
+  int drawtitle{ 0 };
+  int texsizeX{ 0 };
+  int texsizeY{ 0 };
+  int textMenuPageSize{ 10 };
+  int textMenuLineHeight{ 25 };
+  int textMenuYOffset{ 60 };
+  float m_fAspectX{ 1.0 };
+  float m_fAspectY{ 1.0 };
+  float m_fInvAspectX{ 1.0 };
+  float m_fInvAspectY{ 1.0 };
 
+  Renderer() = delete;
   Renderer(int width, int height, int gx, int gy, BeatDetect *_beatDetect, std::string presetURL, std::string title_fontURL, std::string menu_fontURL, const std::string& datadir = "");
   ~Renderer();
 
@@ -192,20 +190,10 @@ public:
 private:
 
   PerPixelMesh mesh;
-  BeatDetect *beatDetect;
-  TextureManager *textureManager;
-  Pipeline* currentPipe;
-  TimeKeeper *timeKeeperFPS;
-  TimeKeeper *timeKeeperToast;
+  BeatDetect *beatDetect{ nullptr };
+  TextureManager *textureManager{ nullptr };
+  Pipeline* currentPipe{ nullptr };
 
-#ifdef USE_TEXT_MENU
-  // draw text with search term a/k/a needle & highlight text
-  void drawText(GLTtext* text, const char* string, const char* needle, GLfloat x, GLfloat y, GLfloat scale, int horizontalAlignment, int verticalAlignment, float r, float b, float g, float a, bool highlightable);
-  void drawText(GLTtext* text, const char* string, GLfloat x, GLfloat y, GLfloat scale, int horizontalAlignment, int verticalAlignment, float r, float b, float g, float a, bool highlightable);
-  void drawText(const char* string, GLfloat x, GLfloat y, GLfloat scale, int horizontalAlignment, int verticalAlignment, float r, float b, float g, float a, bool highlightable);
-  bool textHighlightable(bool highlightable);
-
-#endif /** USE_TEXT_MENU */
   RenderContext renderContext;
   //per pixel equation variables
   ShaderEngine shaderEngine;
@@ -215,16 +203,25 @@ private:
   std::string m_toastMessage;
   std::string m_searchText;
 
-  float* p;
+  float* p{ nullptr };
 
-  int vstartx; /* view start x position - normally 0, but could be different if doing a subset of the window - like
-                  for virtual reality */
-  int vstarty; /* view start y position - normally 0, but could be different if doing a subset of the window - like
-                  for virtual reality */
-	       /* these are currently set only for rendering to the screen, not to the textbuffer */
-		  
-  int vw;
-  int vh;
+  /**
+   * @brief View start x position
+   *
+   * <p>Normally 0, but could be different if doing a subset of the window - like for virtual reality</p>
+   */
+  int vstartx{ 0 };
+
+  /**
+   * @brief View start y position
+   *
+   * <p>Normally 0, but could be different if doing a subset of the window - like
+   * for virtual reality. These are currently set only for rendering to the screen, not to the textbuffer.</p>
+  */
+  int vstarty{ 0 };
+
+  int vw{ 0 };
+  int vh{ 0 };
 
   float aspect;
 
@@ -232,19 +229,17 @@ private:
   std::string menu_fontURL;
   std::string presetURL;
 
-  GLuint m_vbo_Interpolation;
-  GLuint m_vao_Interpolation;
+  GLuint m_vbo_Interpolation{ 0 };
+  GLuint m_vao_Interpolation{ 0 };
 
-  GLuint m_vbo_CompositeOutput;
-  GLuint m_vao_CompositeOutput;
+  GLuint m_vbo_CompositeOutput{ 0 };
+  GLuint m_vao_CompositeOutput{ 0 };
 
-  GLuint m_vbo_CompositeShaderOutput;
-  GLuint m_vao_CompositeShaderOutput;
+  GLuint m_vbo_CompositeShaderOutput{ 0 };
+  GLuint m_vao_CompositeShaderOutput{ 0 };
 
 #ifdef USE_TEXT_MENU
-  GLTtext *title_font;
-  GLTtext *other_font;
-  GLTtext *poly_font;
+  MenuText m_menuText;
 #endif /** USE_TEXT_MENU */
 
   void SetupPass1(const Pipeline &pipeline, const PipelineContext &pipelineContext);
@@ -273,7 +268,7 @@ private:
   
 int nearestPower2( int value );
 
-  GLuint textureRenderToTexture;
+  GLuint textureRenderToTexture{ 0 };
 
   void InitCompositeShaderVertex();
   float SquishToCenter(float x, float fExp);


### PR DESCRIPTION
For each line of text, glText was fully reinitialized, which meant that the font texture, vertex and fragment shaders were recompiled and uploaded to the GPU, then destroyed again. This created a huge FPS drop, especially in GLES environments.

Also moved the text rendering into a separate class and cleaned up the initialization of the Renderer class, moving all default values to the header and deleting the default constructor to avoid unwanted effects.