### PR TITLE
Wrap floating point numbers with float() in HLSLParser output.

### DIFF
--- a/src/libprojectM/Renderer/hlslparser/src/Engine.cpp
+++ b/src/libprojectM/Renderer/hlslparser/src/Engine.cpp
@@ -45,7 +45,7 @@ int String_FormatFloat(char * buffer, int size, float value) {
     oss.imbue(std::locale("C"));
     oss << value;
 
-    return String_Printf(buffer, size, "%s", oss.str().c_str());
+    return String_Printf(buffer, size, "float(%s)", oss.str().c_str());
 }
 
 bool String_Equal(const char * a, const char * b) {


### PR DESCRIPTION
Another small fixup in HLSLParser to improve preset compat in GLES environments.

Integer floats (e.g. 2.0) will lose their decimals in the conversion (2.0 -> 2), causing issues with GLES shader compilation as it doesn't allow implicit conversion. Writing it as "float(2)" will tell the compiler to interpret this correctly. The same is already done for function parameters, but was not done here for some reason.