### PR TITLE
Added four missing built-in equation parameters.

### DIFF
--- a/src/libprojectM/MilkdropPresetFactory/BuiltinParams.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/BuiltinParams.cpp
@@ -456,6 +456,12 @@ int BuiltinParams::load_all_builtin_param(const PresetInputs& presetInputs, Pres
     load_builtin_param_int("meshx", (void*) &presetInputs.gx, P_FLAG_READONLY, 32, 96, 8, "");
     load_builtin_param_int("meshy", (void*) &presetInputs.gy, P_FLAG_READONLY, 24, 72, 6, "");
 
+    load_builtin_param_int("pixelsx", (void*) &presetInputs.pixelsx, P_FLAG_READONLY, 512, 4096, 16, "");
+    load_builtin_param_int("pixelsy", (void*) &presetInputs.pixelsy, P_FLAG_READONLY, 512, 72, 6, "");
+
+    load_builtin_param_float("aspectx", (void*) &presetInputs.aspectx, nullptr, P_FLAG_READONLY, 1.0, MAX_DOUBLE_SIZE, 1.0, "");
+    load_builtin_param_float("aspecty", (void*) &presetInputs.aspecty, nullptr, P_FLAG_READONLY, 1.0, MAX_DOUBLE_SIZE, 1.0, "");
+
     return PROJECTM_SUCCESS;
 
 }

--- a/src/libprojectM/MilkdropPresetFactory/PresetFrameIO.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/PresetFrameIO.cpp
@@ -34,6 +34,12 @@ void PresetInputs::update(const BeatDetect & music, const PipelineContext & cont
 
     this->frame = context.frame;
     this->progress = context.progress;
+
+    this->pixelsx = context.pixelsx;
+    this->pixelsy = context.pixelsy;
+
+    this->aspectx = context.aspectx;
+    this->aspecty = context.aspecty;
 }
 
 
@@ -79,6 +85,10 @@ void PresetInputs::Initialize ( int _gx, int _gy )
 	y_per_pixel = 0;
 	rad_per_pixel = 0;
 	ang_per_pixel = 0;
+    pixelsx = 512;
+    pixelsx = 512;
+    aspectx = 1.0;
+    aspecty = 1.0;
 	// ***
 
 	this->x_mesh    = alloc_mesh(gx, gy);

--- a/src/libprojectM/MilkdropPresetFactory/PresetFrameIO.hpp
+++ b/src/libprojectM/MilkdropPresetFactory/PresetFrameIO.hpp
@@ -35,6 +35,13 @@ public:
 
     float **x_mesh;
     float **y_mesh;
+
+    int pixelsx;
+    int pixelsy;
+
+    float aspectx;
+    float aspecty;
+
     float **rad_mesh;
     float **theta_mesh;
 

--- a/src/libprojectM/Renderer/PipelineContext.hpp
+++ b/src/libprojectM/Renderer/PipelineContext.hpp
@@ -17,7 +17,13 @@ public:
 	int   frame;
 	float progress;
 
-	PipelineContext();
+    int pixelsx;
+    int pixelsy;
+
+    float aspectx;
+    float aspecty;
+
+    PipelineContext();
 	virtual ~PipelineContext();
 };
 

--- a/src/libprojectM/Renderer/Renderer.cpp
+++ b/src/libprojectM/Renderer/Renderer.cpp
@@ -647,7 +647,7 @@ void Renderer::reset(int w, int h)
 	}
 	textureManager = new TextureManager(presetURL, texsizeX, texsizeY, m_datadir);
 
-	shaderEngine.setParams(texsizeX, texsizeY, beatDetect, textureManager);
+	shaderEngine.setParams(texsizeX, texsizeY, m_fAspectX, m_fAspectY, beatDetect, textureManager);
 	shaderEngine.reset();
 	shaderEngine.loadPresetShaders(*currentPipe, m_presetName);
 
@@ -876,6 +876,16 @@ void Renderer::debugWriteMainTextureToFile() const {
 	glDeleteFramebuffers(1, &fbo);
 	safeWriteFile(totalframes, pixels, mainTexture->width, mainTexture->height);
 	delete[] pixels;
+}
+
+void Renderer::UpdateContext(PipelineContext& context)
+{
+    context.pixelsx = vw;
+    context.pixelsy = vh;
+
+    // It's actually the inverse of the aspect ratio.
+    context.aspectx = m_fInvAspectX;
+    context.aspecty = m_fInvAspectY;
 }
 
 void Renderer::setToastMessage(const std::string& theValue)

--- a/src/libprojectM/Renderer/Renderer.hpp
+++ b/src/libprojectM/Renderer/Renderer.hpp
@@ -189,6 +189,8 @@ public:
     return m_searchText;
   }
 
+  void UpdateContext(PipelineContext& context);
+
 private:
 
   PerPixelMesh mesh;

--- a/src/libprojectM/Renderer/ShaderEngine.cpp
+++ b/src/libprojectM/Renderer/ShaderEngine.cpp
@@ -110,18 +110,15 @@ bool ShaderEngine::checkCompileStatus(GLuint shader, const std::string & shaderT
     return false;
 }
 
-void ShaderEngine::setParams(const int _texsizeX, const int _texsizeY, BeatDetect *_beatDetect,
-        TextureManager *_textureManager)
+void ShaderEngine::setParams(int _texsizeX, int _texsizeY,
+                             float _aspectX, float _aspectY,
+                             BeatDetect *_beatDetect, TextureManager *_textureManager)
 {
     this->beatDetect = _beatDetect;
     this->textureManager = _textureManager;
 
-    aspectX = 1;
-    aspectY = 1;
-    if (_texsizeX > _texsizeY)
-        aspectY = (float)_texsizeY/(float)_texsizeX;
-    else
-        aspectX = (float)_texsizeX/(float)_texsizeY;
+    this->aspectX = _aspectX;
+    this->aspectY = _aspectY;
 
     this->texsizeX = _texsizeX;
     this->texsizeY = _texsizeY;
@@ -439,7 +436,7 @@ void ShaderEngine::SetupShaderVariables(GLuint program, const Pipeline &pipeline
     glUniform4f(glGetUniformLocation(program, "rand_frame"), (rand() % 100) * .01, (rand() % 100) * .01, (rand()% 100) * .01, (rand() % 100) * .01);
     glUniform4f(glGetUniformLocation(program, "rand_preset"), rand_preset[0], rand_preset[1], rand_preset[2], rand_preset[3]);
 
-    glUniform4f(glGetUniformLocation(program, "_c0"), aspectX, aspectY, 1 / aspectX, 1 / aspectY);
+    glUniform4f(glGetUniformLocation(program, "_c0"), aspectX, aspectY, 1.0f / aspectX, 1.0f / aspectY);
     glUniform4f(glGetUniformLocation(program, "_c1"), 0.0, 0.0, 0.0, 0.0);
     glUniform4f(glGetUniformLocation(program, "_c2"), time_since_preset_start_wrapped, context.fps,  context.frame, context.progress);
     glUniform4f(glGetUniformLocation(program, "_c3"), beatDetect->bass/100, beatDetect->mid/100, beatDetect->treb/100, beatDetect->vol/100);

--- a/src/libprojectM/Renderer/ShaderEngine.hpp
+++ b/src/libprojectM/Renderer/ShaderEngine.hpp
@@ -42,7 +42,9 @@ public:
     bool enableWarpShader(Shader &shader, const Pipeline &pipeline, const PipelineContext &pipelineContext, const glm::mat4 & mat_ortho);
     bool enableCompositeShader(Shader &shader, const Pipeline &pipeline, const PipelineContext &pipelineContext);
     void RenderBlurTextures(const Pipeline  &pipeline, const PipelineContext &pipelineContext);
-    void setParams(const int _texsizeX, const int texsizeY, BeatDetect *beatDetect, TextureManager *_textureManager);
+    void setParams(int _texsizeX, int texsizeY,
+                   float _aspectX, float _aspectY,
+                   BeatDetect *beatDetect, TextureManager *_textureManager);
     void reset();
 
     static GLuint CompileShaderProgram(const std::string & VertexShaderCode, const std::string & FragmentShaderCode, const std::string & shaderTypeString);

--- a/src/libprojectM/Renderer/Waveform.cpp
+++ b/src/libprojectM/Renderer/Waveform.cpp
@@ -55,9 +55,8 @@ void Waveform::Draw(RenderContext &context)
     float *value2 = new float[samples_count];
     if (spectrum)
     {
-        // TODO support smoothing parameter for getSpectrum()
-        context.beatDetect->pcm->getSpectrum( value1, CHANNEL_0, samples_count, 1.0 );
-        context.beatDetect->pcm->getSpectrum( value2, CHANNEL_1, samples_count, 1.0 );
+        context.beatDetect->pcm->getSpectrum( value1, CHANNEL_0, samples_count, smoothing );
+        context.beatDetect->pcm->getSpectrum( value2, CHANNEL_1, samples_count, smoothing );
     }
     else
     {

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -361,10 +361,12 @@ Pipeline * projectM::renderFrameOnlyPass1(Pipeline *pPipeline) /*pPipeline is a 
     mspf= ( int ) ( 1000.0/ ( float ) settings().fps ); //milliseconds per frame
 
     /// @bug who is responsible for updating this now?"
-    pipelineContext().time = timeKeeper->GetRunningTime();
-    pipelineContext().presetStartTime = timeKeeper->PresetTimeA();
-    pipelineContext().frame = timeKeeper->PresetFrameA();
-    pipelineContext().progress = timeKeeper->PresetProgressA();
+    auto& context = pipelineContext();
+    context.time = timeKeeper->GetRunningTime();
+    context.presetStartTime = timeKeeper->PresetTimeA();
+    context.frame = timeKeeper->PresetFrameA();
+    context.progress = timeKeeper->PresetProgressA();
+    renderer->UpdateContext(context);
 
     beatDetect->detectFromSamples();
 


### PR DESCRIPTION
Also use smoothing parameter in spectrum waveforms and the same aspect ratio values in both equation and shader code.

Values take quite a path through the class hierarchy, through `PipelineContext` and `PresetInputs`.