### PR TITLE
Add definition for WORD_BIT on Windows.

### DIFF
--- a/src/libprojectM/omptl/CMakeLists.txt
+++ b/src/libprojectM/omptl/CMakeLists.txt
@@ -13,3 +13,18 @@ target_sources(omptl
         omptl_numeric_ser.h
         omptl_tools.h
         )
+
+# MSVC standard library doesn't define WORD_BIT (from xopen_lim.h)
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        target_compile_definitions(omptl
+                INTERFACE
+                -DWORD_BIT=64
+                )
+    else()
+        target_compile_definitions(omptl
+                INTERFACE
+                -DWORD_BIT=32
+                )
+    endif()
+endif()


### PR DESCRIPTION
The WORD_BIT macro is defined in xopen_lim.h, but missing on Windows. Just setting it to the appropriate value in CMake helps.