### PR TITLE
SDL: Allow using the system default capture device

### DIFF
--- a/src/projectM-sdl/pmSDL.hpp
+++ b/src/projectM-sdl/pmSDL.hpp
@@ -160,13 +160,13 @@ private:
 
     // audio input device characteristics
     unsigned int NumAudioDevices{ 0 };
-    unsigned int CurAudioDevice{ 0 };
+    int CurAudioDevice{ 0 };            // SDL's device indexes are 0-based, -1 means "system default"
     unsigned short audioChannelsCount{ 0 };
     unsigned short audioSampleRate{ 0 };
     unsigned short audioSampleCount{ 0 };
     SDL_AudioFormat audioFormat{ 0 };
     SDL_AudioDeviceID audioDeviceID{ 0 };
-    SDL_AudioDeviceID selectedAudioDevice{ 0 };
+    int selectedAudioDevice{ 0 };
 };
 
 


### PR DESCRIPTION
SDL allows to use the "system default" capture device by passing `device == NULL` to [`SDL_OpenAudioDevice`](https://wiki.libsdl.org/SDL_OpenAudioDevice).
This is a well-behaved default option that has several advantages:

- It is much more likely that the user expects to use the device configured as system default, rather than the one that happens to be at index 0 (the one currently used by `projectMSDL`).

- When the default device changes, SDL __automatically moves to the new device__. I tried this with `pulsemixer`, I change the default capture device when `projectMSDL` is running (with this PR) and I immediately see `projectMSDL` seamlessly switching to the new one!

- The system default can be changed via a variety of methods (GUI tools, command line scripts, etc), it is more user friendly than having to use `Ctrl-I`. Such changes also persist across restarts of `projectMSDL`, chages via `Ctrl-I` do not.

- It allows to use __monitor__ devices even on older SDL versions (without `SDL_HINT_AUDIO_INCLUDE_MONITORS`), by simply setting the monitor device as default. Quite useful, since most systems still have old SDL versions with no `SDL_HINT_AUDIO_INCLUDE_MONITORS` support.

This PR adds a `System default capture device` to the list of devices selectable by `Ctrl-I`. So `projectMSDL` starts with this default, but the user can select a specific device via `Ctrl-I`, as usual.

I hope you will consider such a PR, I think it makes `projectMSDL` easier to use.

PS. Thanks for this truly amazing tool!


