### PR TITLE
Some CMake build fixes, mostly affecting Windows builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ endif()
 
 # Feature options, including dependencies.
 option(ENABLE_STATIC_LIB "Build and install libprojectM as a static library" ON)
-cmake_dependent_option(ENABLE_SHARED_LIB "Build and install libprojectM as a shared library" ON "NOT ENABLE_EMSCRIPTEN;NOT CMAKE_SYSTEM_NAME STREQUAL Windows" OFF)
+cmake_dependent_option(ENABLE_SHARED_LIB "Build and install libprojectM as a shared library" ON "NOT ENABLE_EMSCRIPTEN" OFF)
 cmake_dependent_option(ENABLE_SHARED_LINKING "Link the SDL test UI against the shared library." OFF "ENABLE_SHARED_LIB" OFF)
 option(ENABLE_DOXYGEN "Build and install Doxygen source code documentation in PROJECTM_DATADIR_PATH/docs." OFF)
 option(ENABLE_CXX_INTERFACE "Enable exporting all C++ symbols, not only the C API, in the shared library. Warning: This is not very portable." OFF)

--- a/src/libprojectM/CMakeLists.txt
+++ b/src/libprojectM/CMakeLists.txt
@@ -161,9 +161,6 @@ export(TARGETS
         FILE projectM-exports.cmake
         )
 
-export(PACKAGE libprojectM)
-
-
 
 # For use from an installed package (system install, vcpkg, homebrew etc.)
 include(CMakePackageConfigHelpers)

--- a/src/libprojectM/libprojectMConfig.cmake.in
+++ b/src/libprojectM/libprojectMConfig.cmake.in
@@ -2,13 +2,14 @@ set(libprojectM_VERSION @PROJECT_VERSION@)
 
 @PACKAGE_INIT@
 
-set_and_check(libprojectM_BIN_DIR "@PACKAGE_PROJECTM_BIN_DIR@")
-set_and_check(libprojectM_INCLUDE_DIR "@PACKAGE_PROJECTM_INCLUDE_DIR@")
-set_and_check(libprojectM_DATA_DIR "@PACKAGE_PROJECTM_DATADIR_PATH@")
-
 include(CMakeFindDependencyMacro)
 
 find_dependency(OpenGL)
 if("@ENABLE_THREADING@") # ENABLE_THREADING
     find_dependency(Threads)
 endif()
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    find_dependency(GLEW)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/libprojectMTargets.cmake")

--- a/src/libprojectM/libprojectM_static.cmake
+++ b/src/libprojectM/libprojectM_static.cmake
@@ -18,7 +18,7 @@ target_compile_options(projectM_static
         )
 
 set_target_properties(projectM_static PROPERTIES
-        OUTPUT_NAME projectM
+        OUTPUT_NAME $<IF:$<PLATFORM_ID:Windows>,libprojectM,projectM>
         EXPORT_NAME static
         FOLDER libprojectM
         )

--- a/src/libprojectM/omptl/CMakeLists.txt
+++ b/src/libprojectM/omptl/CMakeLists.txt
@@ -13,18 +13,3 @@ target_sources(omptl
         omptl_numeric_ser.h
         omptl_tools.h
         )
-
-# MSVC standard library doesn't define WORD_BIT (from xopen_lim.h)
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-        target_compile_definitions(omptl
-                INTERFACE
-                -DWORD_BIT=64
-                )
-    else()
-        target_compile_definitions(omptl
-                INTERFACE
-                -DWORD_BIT=32
-                )
-    endif()
-endif()

--- a/src/libprojectM/omptl/omptl_tools.h
+++ b/src/libprojectM/omptl/omptl_tools.h
@@ -34,29 +34,21 @@ const unsigned C = 12;
 template <typename T>
 T log2N_(T n)
 {
-	if (n == 0)
-		return 0;
+    assert(n > 0);
+    const std::size_t N = CHAR_BIT*sizeof(T);
 
-	const unsigned b[] =
-#if (WORD_BIT == 32)
-		{0x2u, 0xCu, 0xF0u, 0xFF00u, 0xFFFF0000u};
-#else // 64-bit
-		{0x2u, 0xCu, 0xF0u, 0xFF00u, 0xFFFF0000u, 0xFFFFFFFF00000000u};
-	assert(WORD_BIT == 64);
-#endif
-	const T S[] = {1u, 2u, 4u, 8u, 16u, 32u, 64u, 128u};
+    T result = 0;
+    for (std::size_t i = 1; i < N; ++i)
+    {
+        const std::size_t M = N-i;
+        if ( n >= (std::size_t(1) << M) )
+        {
+            n >>= M;
+            result |= M;
+        }
+    }
 
-	T result = 0u; // result of log2(v) will go here
-	for (int i = static_cast<int>(sizeof(T)); i >= 0; --i)
-	{
-		if (n & b[i])
-		{
-			n >>= S[i];
-			result |= S[i];
-		}
-	}
-
-	return result;
+    return result;
 }
 
 template<typename Iterator>


### PR DESCRIPTION
- Got rid of the WORD_BITS usage in omptl_tools.h, which is a macro that is only defined on UNIX platforms, but not MSVC.
- Removed export(PACKAGE) call, as it's been disabled/deprecated since CMake 3.15 and puts a half-baked config into the registry. Better install and use CMAKE_PREFIX_PATH.
- Removed set_and_check commands in the package config file, added missing include for the target definition file.
- Added "lib" prefix to the static library file on Windows as it will otherwise have the exact same name (projectM.lib) as the shared library exports file.
- Enable shared library building on Windows by default as on all other platforms.