### PR TITLE
Update GitHub Actions workflow on Windows to use VS 2022

### DIFF
--- a/.github/workflows/configure.cmake
+++ b/.github/workflows/configure.cmake
@@ -1,6 +1,6 @@
 if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
     execute_process(COMMAND "${CMAKE_COMMAND}"
-            -G "Visual Studio 16 2019"
+            -G "Visual Studio 17 2022"
             -A "X64"
             -S "$ENV{GITHUB_WORKSPACE}"
             -B "$ENV{GITHUB_WORKSPACE}/cmake-build"


### PR DESCRIPTION
GitHub made the new Windows Server 2022 image the default, and it uses VS 2022 Enterprise, so it's needed to update the CMake generator accordingly.