### PR TITLE
Refactor BeatDetect code

### DIFF
--- a/src/libprojectM/Common.hpp
+++ b/src/libprojectM/Common.hpp
@@ -109,11 +109,6 @@ extern FILE *fmemopen(void *buf, size_t len, const char *pMode);
 /* default float upper bound */
 #define DEFAULT_DOUBLE_UB MAX_DOUBLE_SIZE
 
-#ifdef WIN32
-#include <float.h>
-#define isnan _isnan
-#endif /** WIN32 */
-
 /** Per-platform path separators */
 #define WIN32_PATH_SEPARATOR '\\'
 #define UNIX_PATH_SEPARATOR '/'

--- a/src/libprojectM/Common.hpp
+++ b/src/libprojectM/Common.hpp
@@ -62,24 +62,6 @@ extern FILE *fmemopen(void *buf, size_t len, const char *pMode);
 
 
 #ifdef __unix__
-#include <cstdlib>
-#define projectM_isnan std::isnan
-#endif
-
-#ifdef EMSCRIPTEN
-#include <cstdlib>
-#define projectM_isnan isnan
-#endif
-
-#ifdef WIN32
-#define projectM_isnan(x) ((x) != (x))
-#endif
-
-#ifdef __APPLE__
-#define projectM_isnan(x) ((x) != (x))
-#endif
-
-#ifdef __unix__
 #define projectM_fmax fmax
 #endif
 

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -40,17 +40,10 @@
 BeatDetect::BeatDetect(PCM* _pcm)
     : pcm(_pcm)
 {
-    for (unsigned y = 0; y < this->vol_buffer.size(); y++)
-        this->vol_buffer[y] = 0;
-
-    for (unsigned y = 0; y < this->bass_buffer.size(); y++)
-        this->bass_buffer[y] = 0;
-
-    for (unsigned y = 0; y < this->mid_buffer.size(); y++)
-        this->mid_buffer[y] = 0;
-
-    for (unsigned y = 0; y < this->treb_buffer.size(); y++)
-        this->treb_buffer[y] = 0;
+    this->vol_buffer.fill(0);
+    this->bass_buffer.fill(0);
+    this->mid_buffer.fill(0);
+    this->treb_buffer.fill(0);
 }
 
 

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -61,12 +61,6 @@ void BeatDetect::reset()
 
 void BeatDetect::detectFromSamples()
 {
-    vol_old = vol;
-    bass = 0;
-    mid = 0;
-    treb = 0;
-    vol = 0;
-
     float vdataL[FFT_LENGTH];
     float vdataR[FFT_LENGTH];
     pcm.getSpectrum(vdataL, CHANNEL_0, FFT_LENGTH, 0.0);

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -116,10 +116,10 @@ void BeatDetect::getBeatVals(float samplerate, unsigned fft_length, float* vdata
     vol_history += vol_instant * (1.0 / vol_buffer.size());
 
     //    fprintf(stderr, "%6.3f %6.2f %6.3f\n", bass_history/vol_history, mid_history/vol_history, treb_history/vol_history);
-    bass = bass_instant / fmax(0.0001, bass_history);
-    mid = mid_instant / fmax(0.0001, mid_history);
-    treb = treb_instant / fmax(0.0001, treb_history);
-    vol = vol_instant / fmax(0.0001, vol_history);
+    bass = bass_instant / std::max(0.0001f, bass_history);
+    mid = mid_instant / std::max(0.0001f, mid_history);
+    treb = treb_instant / std::max(0.0001f, treb_history);
+    vol = vol_instant / std::max(0.0001f, vol_history);
 
     if (projectM_isnan(treb))
     {

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -39,7 +39,7 @@
 #include <cmath>
 
 
-BeatDetect::BeatDetect(PCM* _pcm)
+BeatDetect::BeatDetect(PCM& _pcm)
     : pcm(_pcm)
 {
 }
@@ -69,8 +69,8 @@ void BeatDetect::detectFromSamples()
 
     float vdataL[FFT_LENGTH];
     float vdataR[FFT_LENGTH];
-    pcm->getSpectrum(vdataL, CHANNEL_0, FFT_LENGTH, 0.0);
-    pcm->getSpectrum(vdataR, CHANNEL_1, FFT_LENGTH, 0.0);
+    pcm.getSpectrum(vdataL, CHANNEL_0, FFT_LENGTH, 0.0);
+    pcm.getSpectrum(vdataR, CHANNEL_1, FFT_LENGTH, 0.0);
 
     // OK, we're not really using this number 44.1 anywhere
     // This is more of a nod to the fact that if the actually data rate is REALLY different

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -76,11 +76,6 @@ BeatDetect::BeatDetect(PCM* _pcm)
 }
 
 
-BeatDetect::~BeatDetect()
-{
-}
-
-
 void BeatDetect::reset()
 {
     this->treb = 0;

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -34,6 +34,8 @@
 #include "BeatDetect.hpp"
 #include "Common.hpp"
 #include "PCM.hpp"
+
+#include <algorithm>
 #include <cmath>
 
 

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -42,10 +42,6 @@
 BeatDetect::BeatDetect(PCM* _pcm)
     : pcm(_pcm)
 {
-    this->vol_buffer.fill(0);
-    this->bass_buffer.fill(0);
-    this->mid_buffer.fill(0);
-    this->treb_buffer.fill(0);
 }
 
 

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -26,42 +26,42 @@
  * you'll find it online
  */
 
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "wipemalloc.h"
 
+#include "BeatDetect.hpp"
 #include "Common.hpp"
 #include "PCM.hpp"
 #include <cmath>
-#include "BeatDetect.hpp"
 
 
-BeatDetect::BeatDetect(PCM *_pcm)
+BeatDetect::BeatDetect(PCM* _pcm)
 {
-    this->pcm=_pcm;
+    this->pcm = _pcm;
 
-    this->vol_instant=0;
-    this->vol_history=0;
-    for (unsigned y=0; y < this->vol_buffer.size(); y++)
-        this->vol_buffer[y]=0;
+    this->vol_instant = 0;
+    this->vol_history = 0;
+    for (unsigned y = 0; y < this->vol_buffer.size(); y++)
+        this->vol_buffer[y] = 0;
 
-    this->beat_buffer_pos=0;
+    this->beat_buffer_pos = 0;
 
     this->bass_instant = 0;
     this->bass_history = 0;
-    for (unsigned y=0; y < this->bass_buffer.size(); y++)
-        this->bass_buffer[y]=0;
+    for (unsigned y = 0; y < this->bass_buffer.size(); y++)
+        this->bass_buffer[y] = 0;
 
     this->mid_instant = 0;
     this->mid_history = 0;
     for (unsigned y = 0; y < this->mid_buffer.size(); y++)
-        this->mid_buffer[y]=0;
+        this->mid_buffer[y] = 0;
 
     this->treb_instant = 0;
     this->treb_history = 0;
     for (unsigned y = 0; y < this->treb_buffer.size(); y++)
-        this->treb_buffer[y]=0;
+        this->treb_buffer[y] = 0;
 
     this->treb = 0;
     this->mid = 0;
@@ -78,7 +78,6 @@ BeatDetect::BeatDetect(PCM *_pcm)
 
 BeatDetect::~BeatDetect()
 {
-
 }
 
 
@@ -92,17 +91,17 @@ void BeatDetect::reset()
     this->bass_att = 0;
     this->vol_att = 0;
     this->vol_old = 0;
-    this->vol_instant=0;
+    this->vol_instant = 0;
 }
 
 
 void BeatDetect::detectFromSamples()
 {
     vol_old = vol;
-    bass=0;
-    mid=0;
-    treb=0;
-    vol=0;
+    bass = 0;
+    mid = 0;
+    treb = 0;
+    vol = 0;
 
     float vdataL[FFT_LENGTH];
     float vdataR[FFT_LENGTH];
@@ -117,70 +116,79 @@ void BeatDetect::detectFromSamples()
 }
 
 
-void BeatDetect::getBeatVals( float samplerate, unsigned fft_length, float *vdataL, float *vdataR )
+void BeatDetect::getBeatVals(float samplerate, unsigned fft_length, float* vdataL, float* vdataR)
 {
     assert(fft_length >= 256);
-    unsigned ranges[4]  = {0, 3, 23, 255};
+    unsigned ranges[4] = {0, 3, 23, 255};
 
-    bass_instant=0;
-    for (unsigned i=ranges[0] ; i<ranges[1] ; i++)
+    bass_instant = 0;
+    for (unsigned i = ranges[0]; i < ranges[1]; i++)
         bass_instant += vdataL[i] + vdataR[i];
-    bass_history -= bass_buffer[beat_buffer_pos] * (1.0/bass_buffer.size());
+    bass_history -= bass_buffer[beat_buffer_pos] * (1.0 / bass_buffer.size());
     bass_buffer[beat_buffer_pos] = bass_instant;
-    bass_history += bass_instant * (1.0/bass_buffer.size());
+    bass_history += bass_instant * (1.0 / bass_buffer.size());
 
-    mid_instant=0;
-    for (unsigned i=ranges[1] ; i<ranges[2] ; i++)
+    mid_instant = 0;
+    for (unsigned i = ranges[1]; i < ranges[2]; i++)
         mid_instant += vdataL[i] + vdataR[i];
-    mid_history -= mid_buffer[beat_buffer_pos] * (1.0/mid_buffer.size());
+    mid_history -= mid_buffer[beat_buffer_pos] * (1.0 / mid_buffer.size());
     mid_buffer[beat_buffer_pos] = mid_instant;
-    mid_history += mid_instant * (1.0/mid_buffer.size());
+    mid_history += mid_instant * (1.0 / mid_buffer.size());
 
     treb_instant = 0;
-    for (unsigned i=ranges[2] ; i<ranges[3] ; i++)
+    for (unsigned i = ranges[2]; i < ranges[3]; i++)
         treb_instant += vdataL[i] + vdataR[i];
-    treb_history -= treb_buffer[beat_buffer_pos] * (1.0/treb_buffer.size());
+    treb_history -= treb_buffer[beat_buffer_pos] * (1.0 / treb_buffer.size());
     treb_buffer[beat_buffer_pos] = treb_instant;
-    treb_history += treb_instant * (1.0/treb_buffer.size());
+    treb_history += treb_instant * (1.0 / treb_buffer.size());
 
-    vol_instant  = (bass_instant + mid_instant + treb_instant) / 3.0f;
-    vol_history -= (vol_buffer[beat_buffer_pos]) * (1.0/vol_buffer.size());
+    vol_instant = (bass_instant + mid_instant + treb_instant) / 3.0f;
+    vol_history -= (vol_buffer[beat_buffer_pos]) * (1.0 / vol_buffer.size());
     vol_buffer[beat_buffer_pos] = vol_instant;
-    vol_history += vol_instant * (1.0/vol_buffer.size());
+    vol_history += vol_instant * (1.0 / vol_buffer.size());
 
-//    fprintf(stderr, "%6.3f %6.2f %6.3f\n", bass_history/vol_history, mid_history/vol_history, treb_history/vol_history);
+    //    fprintf(stderr, "%6.3f %6.2f %6.3f\n", bass_history/vol_history, mid_history/vol_history, treb_history/vol_history);
     bass = bass_instant / fmax(0.0001, bass_history);
-    mid  = mid_instant  / fmax(0.0001, mid_history);
+    mid = mid_instant / fmax(0.0001, mid_history);
     treb = treb_instant / fmax(0.0001, treb_history);
-    vol  = vol_instant  / fmax(0.0001, vol_history);
+    vol = vol_instant / fmax(0.0001, vol_history);
 
-    if ( projectM_isnan( treb ) ) {
+    if (projectM_isnan(treb))
+    {
         treb = 0.0;
     }
-    if ( projectM_isnan( mid ) ) {
+    if (projectM_isnan(mid))
+    {
         mid = 0.0;
     }
-    if ( projectM_isnan( bass ) ) {
+    if (projectM_isnan(bass))
+    {
         bass = 0.0;
     }
 
     treb_att = .6f * treb_att + .4f * treb;
-    mid_att  = .6f * mid_att + .4f * mid;
+    mid_att = .6f * mid_att + .4f * mid;
     bass_att = .6f * bass_att + .4f * bass;
-    vol_att =  .6f * vol_att + .4f * vol;
+    vol_att = .6f * vol_att + .4f * vol;
 
-    if (bass_att>100) bass_att=100;
-    if (bass >100) bass=100;
-    if (mid_att>100) mid_att=100;
-    if (mid >100) mid=100;
-    if (treb_att>100) treb_att=100;
-    if (treb >100) treb=100;
-    if (vol_att>100) vol_att=100;
-    if (vol>100) vol=100;
+    if (bass_att > 100)
+        bass_att = 100;
+    if (bass > 100)
+        bass = 100;
+    if (mid_att > 100)
+        mid_att = 100;
+    if (mid > 100)
+        mid = 100;
+    if (treb_att > 100)
+        treb_att = 100;
+    if (treb > 100)
+        treb = 100;
+    if (vol_att > 100)
+        vol_att = 100;
+    if (vol > 100)
+        vol = 100;
 
     beat_buffer_pos++;
-    if (beat_buffer_pos>79)
-        beat_buffer_pos=0;
+    if (beat_buffer_pos > 79)
+        beat_buffer_pos = 0;
 }
-
-

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -38,41 +38,19 @@
 
 
 BeatDetect::BeatDetect(PCM* _pcm)
+    : pcm(_pcm)
 {
-    this->pcm = _pcm;
-
-    this->vol_instant = 0;
-    this->vol_history = 0;
     for (unsigned y = 0; y < this->vol_buffer.size(); y++)
         this->vol_buffer[y] = 0;
 
-    this->beat_buffer_pos = 0;
-
-    this->bass_instant = 0;
-    this->bass_history = 0;
     for (unsigned y = 0; y < this->bass_buffer.size(); y++)
         this->bass_buffer[y] = 0;
 
-    this->mid_instant = 0;
-    this->mid_history = 0;
     for (unsigned y = 0; y < this->mid_buffer.size(); y++)
         this->mid_buffer[y] = 0;
 
-    this->treb_instant = 0;
-    this->treb_history = 0;
     for (unsigned y = 0; y < this->treb_buffer.size(); y++)
         this->treb_buffer[y] = 0;
-
-    this->treb = 0;
-    this->mid = 0;
-    this->bass = 0;
-    this->vol_old = 0;
-    this->beatSensitivity = 1.00;
-    this->treb_att = 0;
-    this->mid_att = 0;
-    this->bass_att = 0;
-    this->vol_att = 0;
-    this->vol = 0;
 }
 
 

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -43,24 +43,24 @@ BeatDetect::BeatDetect(PCM *_pcm)
 
     this->vol_instant=0;
     this->vol_history=0;
-    for (unsigned y=0;y<BEAT_HISTORY_LENGTH;y++)
+    for (unsigned y=0; y < this->vol_buffer.size(); y++)
         this->vol_buffer[y]=0;
 
     this->beat_buffer_pos=0;
 
     this->bass_instant = 0;
     this->bass_history = 0;
-    for (unsigned y=0;y<BEAT_HISTORY_LENGTH;y++)
+    for (unsigned y=0; y < this->bass_buffer.size(); y++)
         this->bass_buffer[y]=0;
 
     this->mid_instant = 0;
     this->mid_history = 0;
-    for (unsigned y=0;y<BEAT_HISTORY_LENGTH;y++)
+    for (unsigned y = 0; y < this->mid_buffer.size(); y++)
         this->mid_buffer[y]=0;
 
     this->treb_instant = 0;
     this->treb_history = 0;
-    for (unsigned y=0;y<BEAT_HISTORY_LENGTH;y++)
+    for (unsigned y = 0; y < this->treb_buffer.size(); y++)
         this->treb_buffer[y]=0;
 
     this->treb = 0;
@@ -125,28 +125,28 @@ void BeatDetect::getBeatVals( float samplerate, unsigned fft_length, float *vdat
     bass_instant=0;
     for (unsigned i=ranges[0] ; i<ranges[1] ; i++)
         bass_instant += vdataL[i] + vdataR[i];
-    bass_history -= bass_buffer[beat_buffer_pos] * (1.0/BEAT_HISTORY_LENGTH);
+    bass_history -= bass_buffer[beat_buffer_pos] * (1.0/bass_buffer.size());
     bass_buffer[beat_buffer_pos] = bass_instant;
-    bass_history += bass_instant * (1.0/BEAT_HISTORY_LENGTH);
+    bass_history += bass_instant * (1.0/bass_buffer.size());
 
     mid_instant=0;
     for (unsigned i=ranges[1] ; i<ranges[2] ; i++)
         mid_instant += vdataL[i] + vdataR[i];
-    mid_history -= mid_buffer[beat_buffer_pos] * (1.0/BEAT_HISTORY_LENGTH);
+    mid_history -= mid_buffer[beat_buffer_pos] * (1.0/mid_buffer.size());
     mid_buffer[beat_buffer_pos] = mid_instant;
-    mid_history += mid_instant * (1.0/BEAT_HISTORY_LENGTH);
+    mid_history += mid_instant * (1.0/mid_buffer.size());
 
     treb_instant = 0;
     for (unsigned i=ranges[2] ; i<ranges[3] ; i++)
         treb_instant += vdataL[i] + vdataR[i];
-    treb_history -= treb_buffer[beat_buffer_pos] * (1.0/BEAT_HISTORY_LENGTH);
+    treb_history -= treb_buffer[beat_buffer_pos] * (1.0/treb_buffer.size());
     treb_buffer[beat_buffer_pos] = treb_instant;
-    treb_history += treb_instant * (1.0/BEAT_HISTORY_LENGTH);
+    treb_history += treb_instant * (1.0/treb_buffer.size());
 
     vol_instant  = (bass_instant + mid_instant + treb_instant) / 3.0f;
-    vol_history -= (vol_buffer[beat_buffer_pos])* (1.0/BEAT_HISTORY_LENGTH);
+    vol_history -= (vol_buffer[beat_buffer_pos]) * (1.0/vol_buffer.size());
     vol_buffer[beat_buffer_pos] = vol_instant;
-    vol_history += vol_instant * (1.0/BEAT_HISTORY_LENGTH);
+    vol_history += vol_instant * (1.0/vol_buffer.size());
 
 //    fprintf(stderr, "%6.3f %6.2f %6.3f\n", bass_history/vol_history, mid_history/vol_history, treb_history/vol_history);
     bass = bass_instant / fmax(0.0001, bass_history);

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -139,22 +139,14 @@ void BeatDetect::getBeatVals(float samplerate, unsigned fft_length, float* vdata
     bass_att = .6f * bass_att + .4f * bass;
     vol_att = .6f * vol_att + .4f * vol;
 
-    if (bass_att > 100)
-        bass_att = 100;
-    if (bass > 100)
-        bass = 100;
-    if (mid_att > 100)
-        mid_att = 100;
-    if (mid > 100)
-        mid = 100;
-    if (treb_att > 100)
-        treb_att = 100;
-    if (treb > 100)
-        treb = 100;
-    if (vol_att > 100)
-        vol_att = 100;
-    if (vol > 100)
-        vol = 100;
+    bass_att = std::min(bass_att, 100.f);
+    bass = std::min(bass, 100.f);
+    mid_att = std::min(mid_att, 100.f);
+    mid = std::min(mid, 100.f);
+    treb_att = std::min(treb_att, 100.f);
+    treb = std::min(treb, 100.f);
+    vol_att = std::min(vol_att, 100.f);
+    vol = std::min(vol, 100.f);
 
     beat_buffer_pos++;
     if (beat_buffer_pos > 79)

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -121,15 +121,15 @@ void BeatDetect::getBeatVals(float samplerate, unsigned fft_length, float* vdata
     treb = treb_instant / std::max(0.0001f, treb_history);
     vol = vol_instant / std::max(0.0001f, vol_history);
 
-    if (projectM_isnan(treb))
+    if (std::isnan(treb))
     {
         treb = 0.0;
     }
-    if (projectM_isnan(mid))
+    if (std::isnan(mid))
     {
         mid = 0.0;
     }
-    if (projectM_isnan(bass))
+    if (std::isnan(bass))
     {
         bass = 0.0;
     }

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -59,24 +59,16 @@ void BeatDetect::reset()
 }
 
 
-void BeatDetect::detectFromSamples()
+void BeatDetect::calculateBeatStatistics()
 {
+    size_t constexpr fft_length = FFT_LENGTH;
     float vdataL[FFT_LENGTH];
     float vdataR[FFT_LENGTH];
     pcm.getSpectrum(vdataL, CHANNEL_0, FFT_LENGTH, 0.0);
     pcm.getSpectrum(vdataR, CHANNEL_1, FFT_LENGTH, 0.0);
 
-    // OK, we're not really using this number 44.1 anywhere
-    // This is more of a nod to the fact that if the actually data rate is REALLY different
-    // then in theory the bass/mid/treb ranges should be adjusted.
-    // In practice, I doubt it would adversely affect the actually display very much
-    getBeatVals(44100.0f, FFT_LENGTH, vdataL, vdataR);
-}
 
-
-void BeatDetect::getBeatVals(float samplerate, unsigned fft_length, float* vdataL, float* vdataR)
-{
-    assert(fft_length >= 256);
+    static_assert(fft_length >= 256, "fft_length too small");
     unsigned ranges[4] = {0, 3, 23, 255};
 
     bass_instant = 0;

--- a/src/libprojectM/Renderer/BeatDetect.hpp
+++ b/src/libprojectM/Renderer/BeatDetect.hpp
@@ -34,11 +34,7 @@
 #include "../PCM.hpp"
 #include <algorithm>
 #include <cmath>
-
-
-// this is the size of the buffer used to determine avg levels of the input audio
-// the actual time represented in the history depends on FPS
-#define BEAT_HISTORY_LENGTH 80
+#include <array>
 
 class BeatDetect
 {
@@ -75,20 +71,25 @@ class BeatDetect
         }
 
 	private:
+        // this is the size of the buffer used to determine avg levels of the input audio
+        // the actual time represented in the history depends on FPS
+        static size_t constexpr BEAT_HISTORY_LENGTH = 80;
+
 		int beat_buffer_pos;
-        float bass_buffer[BEAT_HISTORY_LENGTH];
+
+        std::array<float, BEAT_HISTORY_LENGTH> bass_buffer;
 		float bass_history;
         float bass_instant;
 
-		float mid_buffer[BEAT_HISTORY_LENGTH];
+        std::array<float, BEAT_HISTORY_LENGTH> mid_buffer;
         float mid_history;
 		float mid_instant;
 
-		float treb_buffer[BEAT_HISTORY_LENGTH];
+        std::array<float, BEAT_HISTORY_LENGTH> treb_buffer;
 		float treb_history;
 		float treb_instant;
 
-        float vol_buffer[BEAT_HISTORY_LENGTH];
+        std::array<float, BEAT_HISTORY_LENGTH> vol_buffer;
         float vol_history;
         float vol_instant;
 };

--- a/src/libprojectM/Renderer/BeatDetect.hpp
+++ b/src/libprojectM/Renderer/BeatDetect.hpp
@@ -56,8 +56,11 @@ public:
     /** Methods */
     explicit BeatDetect(PCM& pcm);
     void reset();
-    void detectFromSamples();
-    void getBeatVals(float samplerate, unsigned fft_length, float* vdataL, float* vdataR);
+
+    /**
+     * Calculates and updates information about the beat
+     */
+    void calculateBeatStatistics();
 
     // getPCMScale() was added to address https://github.com/projectM-visualizer/projectm/issues/161
     // Returning 1.0 results in using the raw PCM data, which can make the presets look pretty unresponsive

--- a/src/libprojectM/Renderer/BeatDetect.hpp
+++ b/src/libprojectM/Renderer/BeatDetect.hpp
@@ -33,65 +33,65 @@
 
 #include "../PCM.hpp"
 #include <algorithm>
-#include <cmath>
 #include <array>
+#include <cmath>
 
 class BeatDetect
 {
-	public:
-        // Does this really belong here? maybe belongs on projectM.Settings?
-        float beatSensitivity;
+public:
+    // Does this really belong here? maybe belongs on projectM.Settings?
+    float beatSensitivity;
 
-        float treb ;
-		float mid ;
-		float bass ;
-		float vol_old ;
+    float treb;
+    float mid;
+    float bass;
+    float vol_old;
 
-		float treb_att ;
-		float mid_att ;
-		float bass_att ;
-		float vol;
-        float vol_att ;
+    float treb_att;
+    float mid_att;
+    float bass_att;
+    float vol;
+    float vol_att;
 
-		PCM *pcm;
+    PCM* pcm;
 
-		/** Methods */
-		explicit BeatDetect(PCM *pcm);
-		~BeatDetect();
-		void reset();
-		void detectFromSamples();
-		void getBeatVals( float samplerate, unsigned fft_length, float *vdataL, float *vdataR );
+    /** Methods */
+    explicit BeatDetect(PCM* pcm);
+    ~BeatDetect();
+    void reset();
+    void detectFromSamples();
+    void getBeatVals(float samplerate, unsigned fft_length, float* vdataL, float* vdataR);
 
-        // getPCMScale() was added to address https://github.com/projectM-visualizer/projectm/issues/161
-        // Returning 1.0 results in using the raw PCM data, which can make the presets look pretty unresponsive
-        // if the application volume is low.
-		float getPCMScale()
-        {
-		    return beatSensitivity;
-        }
+    // getPCMScale() was added to address https://github.com/projectM-visualizer/projectm/issues/161
+    // Returning 1.0 results in using the raw PCM data, which can make the presets look pretty unresponsive
+    // if the application volume is low.
+    float getPCMScale()
+    {
+        return beatSensitivity;
+    }
 
-	private:
-        // this is the size of the buffer used to determine avg levels of the input audio
-        // the actual time represented in the history depends on FPS
-        static size_t constexpr BEAT_HISTORY_LENGTH = 80;
+private:
+    // this is the size of the buffer used to determine avg levels of the input audio
+    // the actual time represented in the history depends on FPS
+    static size_t constexpr BEAT_HISTORY_LENGTH = 80;
 
-		int beat_buffer_pos;
+    int beat_buffer_pos;
 
-        std::array<float, BEAT_HISTORY_LENGTH> bass_buffer;
-		float bass_history;
-        float bass_instant;
+    std::array<float, BEAT_HISTORY_LENGTH> bass_buffer;
+    float bass_history;
+    float bass_instant;
 
-        std::array<float, BEAT_HISTORY_LENGTH> mid_buffer;
-        float mid_history;
-		float mid_instant;
+    std::array<float, BEAT_HISTORY_LENGTH> mid_buffer;
+    float mid_history;
+    float mid_instant;
 
-        std::array<float, BEAT_HISTORY_LENGTH> treb_buffer;
-		float treb_history;
-		float treb_instant;
+    std::array<float, BEAT_HISTORY_LENGTH> treb_buffer;
+    float treb_history;
+    float treb_instant;
 
-        std::array<float, BEAT_HISTORY_LENGTH> vol_buffer;
-        float vol_history;
-        float vol_instant;
+    std::array<float, BEAT_HISTORY_LENGTH> vol_buffer;
+    float vol_history;
+    float vol_instant;
 };
 
 #endif /** !_BEAT_DETECT_H */

--- a/src/libprojectM/Renderer/BeatDetect.hpp
+++ b/src/libprojectM/Renderer/BeatDetect.hpp
@@ -37,23 +37,6 @@
 class BeatDetect
 {
 public:
-    // Does this really belong here? maybe belongs on projectM.Settings?
-    float beatSensitivity{1.f};
-
-    float treb{0.f};
-    float mid{0.f};
-    float bass{0.f};
-    float vol_old{0.f};
-
-    float treb_att{0.f};
-    float mid_att{0.f};
-    float bass_att{0.f};
-    float vol{0.f};
-    float vol_att{0.f};
-
-    PCM& pcm;
-
-    /** Methods */
     explicit BeatDetect(PCM& pcm);
     void reset();
 
@@ -69,6 +52,21 @@ public:
     {
         return beatSensitivity;
     }
+
+    float beatSensitivity{1.f};
+
+    float treb{0.f};
+    float mid{0.f};
+    float bass{0.f};
+    float vol_old{0.f};
+
+    float treb_att{0.f};
+    float mid_att{0.f};
+    float bass_att{0.f};
+    float vol{0.f};
+    float vol_att{0.f};
+
+    PCM& pcm;
 
 private:
     // this is the size of the buffer used to determine avg levels of the input audio

--- a/src/libprojectM/Renderer/BeatDetect.hpp
+++ b/src/libprojectM/Renderer/BeatDetect.hpp
@@ -51,10 +51,10 @@ public:
     float vol{0.f};
     float vol_att{0.f};
 
-    PCM* pcm;
+    PCM& pcm;
 
     /** Methods */
-    explicit BeatDetect(PCM* pcm);
+    explicit BeatDetect(PCM& pcm);
     void reset();
     void detectFromSamples();
     void getBeatVals(float samplerate, unsigned fft_length, float* vdataL, float* vdataR);

--- a/src/libprojectM/Renderer/BeatDetect.hpp
+++ b/src/libprojectM/Renderer/BeatDetect.hpp
@@ -72,7 +72,7 @@ private:
     // the actual time represented in the history depends on FPS
     static size_t constexpr BEAT_HISTORY_LENGTH = 80;
 
-    int beat_buffer_pos = 0;
+    size_t beat_buffer_pos = 0;
 
     std::array<float, BEAT_HISTORY_LENGTH> bass_buffer;
     float bass_history = 0.f;

--- a/src/libprojectM/Renderer/BeatDetect.hpp
+++ b/src/libprojectM/Renderer/BeatDetect.hpp
@@ -74,19 +74,19 @@ private:
 
     size_t beat_buffer_pos = 0;
 
-    std::array<float, BEAT_HISTORY_LENGTH> bass_buffer;
+    std::array<float, BEAT_HISTORY_LENGTH> bass_buffer{0.f};
     float bass_history = 0.f;
     float bass_instant = 0.f;
 
-    std::array<float, BEAT_HISTORY_LENGTH> mid_buffer;
+    std::array<float, BEAT_HISTORY_LENGTH> mid_buffer{0.f};
     float mid_history = 0.f;
     float mid_instant = 0.f;
 
-    std::array<float, BEAT_HISTORY_LENGTH> treb_buffer;
+    std::array<float, BEAT_HISTORY_LENGTH> treb_buffer{0.f};
     float treb_history = 0.f;
     float treb_instant = 0.f;
 
-    std::array<float, BEAT_HISTORY_LENGTH> vol_buffer;
+    std::array<float, BEAT_HISTORY_LENGTH> vol_buffer{0.f};
     float vol_history = 0.f;
     float vol_instant = 0.f;
 };

--- a/src/libprojectM/Renderer/BeatDetect.hpp
+++ b/src/libprojectM/Renderer/BeatDetect.hpp
@@ -57,7 +57,6 @@ public:
 
     /** Methods */
     explicit BeatDetect(PCM* pcm);
-    ~BeatDetect();
     void reset();
     void detectFromSamples();
     void getBeatVals(float samplerate, unsigned fft_length, float* vdataL, float* vdataR);

--- a/src/libprojectM/Renderer/BeatDetect.hpp
+++ b/src/libprojectM/Renderer/BeatDetect.hpp
@@ -38,18 +38,18 @@ class BeatDetect
 {
 public:
     // Does this really belong here? maybe belongs on projectM.Settings?
-    float beatSensitivity = 1.f;
+    float beatSensitivity{1.f};
 
-    float treb = 0.f;
-    float mid = 0.f;
-    float bass = 0.f;
-    float vol_old = 0.f;
+    float treb{0.f};
+    float mid{0.f};
+    float bass{0.f};
+    float vol_old{0.f};
 
-    float treb_att = 0.f;
-    float mid_att = 0.f;
-    float bass_att = 0.f;
-    float vol = 0.f;
-    float vol_att = 0.f;
+    float treb_att{0.f};
+    float mid_att{0.f};
+    float bass_att{0.f};
+    float vol{0.f};
+    float vol_att{0.f};
 
     PCM* pcm;
 
@@ -70,25 +70,25 @@ public:
 private:
     // this is the size of the buffer used to determine avg levels of the input audio
     // the actual time represented in the history depends on FPS
-    static size_t constexpr BEAT_HISTORY_LENGTH = 80;
+    static size_t constexpr BEAT_HISTORY_LENGTH{80};
 
-    size_t beat_buffer_pos = 0;
+    size_t beat_buffer_pos{0};
 
     std::array<float, BEAT_HISTORY_LENGTH> bass_buffer{0.f};
-    float bass_history = 0.f;
-    float bass_instant = 0.f;
+    float bass_history{0.f};
+    float bass_instant{0.f};
 
     std::array<float, BEAT_HISTORY_LENGTH> mid_buffer{0.f};
-    float mid_history = 0.f;
-    float mid_instant = 0.f;
+    float mid_history{0.f};
+    float mid_instant{0.f};
 
     std::array<float, BEAT_HISTORY_LENGTH> treb_buffer{0.f};
-    float treb_history = 0.f;
-    float treb_instant = 0.f;
+    float treb_history{0.f};
+    float treb_instant{0.f};
 
     std::array<float, BEAT_HISTORY_LENGTH> vol_buffer{0.f};
-    float vol_history = 0.f;
-    float vol_instant = 0.f;
+    float vol_history{0.f};
+    float vol_instant{0.f};
 };
 
 #endif /** !_BEAT_DETECT_H */

--- a/src/libprojectM/Renderer/BeatDetect.hpp
+++ b/src/libprojectM/Renderer/BeatDetect.hpp
@@ -40,18 +40,18 @@ class BeatDetect
 {
 public:
     // Does this really belong here? maybe belongs on projectM.Settings?
-    float beatSensitivity;
+    float beatSensitivity = 1.f;
 
-    float treb;
-    float mid;
-    float bass;
-    float vol_old;
+    float treb = 0.f;
+    float mid = 0.f;
+    float bass = 0.f;
+    float vol_old = 0.f;
 
-    float treb_att;
-    float mid_att;
-    float bass_att;
-    float vol;
-    float vol_att;
+    float treb_att = 0.f;
+    float mid_att = 0.f;
+    float bass_att = 0.f;
+    float vol = 0.f;
+    float vol_att = 0.f;
 
     PCM* pcm;
 
@@ -74,23 +74,23 @@ private:
     // the actual time represented in the history depends on FPS
     static size_t constexpr BEAT_HISTORY_LENGTH = 80;
 
-    int beat_buffer_pos;
+    int beat_buffer_pos = 0;
 
     std::array<float, BEAT_HISTORY_LENGTH> bass_buffer;
-    float bass_history;
-    float bass_instant;
+    float bass_history = 0.f;
+    float bass_instant = 0.f;
 
     std::array<float, BEAT_HISTORY_LENGTH> mid_buffer;
-    float mid_history;
-    float mid_instant;
+    float mid_history = 0.f;
+    float mid_instant = 0.f;
 
     std::array<float, BEAT_HISTORY_LENGTH> treb_buffer;
-    float treb_history;
-    float treb_instant;
+    float treb_history = 0.f;
+    float treb_instant = 0.f;
 
     std::array<float, BEAT_HISTORY_LENGTH> vol_buffer;
-    float vol_history;
-    float vol_instant;
+    float vol_history = 0.f;
+    float vol_instant = 0.f;
 };
 
 #endif /** !_BEAT_DETECT_H */

--- a/src/libprojectM/Renderer/BeatDetect.hpp
+++ b/src/libprojectM/Renderer/BeatDetect.hpp
@@ -32,9 +32,7 @@
 #define _BEAT_DETECT_H
 
 #include "../PCM.hpp"
-#include <algorithm>
 #include <array>
-#include <cmath>
 
 class BeatDetect
 {

--- a/src/libprojectM/Renderer/MilkdropWaveform.cpp
+++ b/src/libprojectM/Renderer/MilkdropWaveform.cpp
@@ -192,8 +192,8 @@ void MilkdropWaveform::WaveformMath(RenderContext &context)
     // NOTE: these buffer sizes are based on the MilkdropWaveformMode implementation later in this method.
     float pcmdataL[512];
 	float pcmdataR[512];
-    context.beatDetect->pcm->getPCM(pcmdataL, CHANNEL_0, 512, smoothing);
-    context.beatDetect->pcm->getPCM(pcmdataR, CHANNEL_1, 512, smoothing);
+    context.beatDetect->pcm.getPCM(pcmdataL, CHANNEL_0, 512, smoothing);
+    context.beatDetect->pcm.getPCM(pcmdataR, CHANNEL_1, 512, smoothing);
 
     // tie size of waveform to beatSensitivity
     const float  vol_scale = context.beatDetect->getPCMScale();

--- a/src/libprojectM/Renderer/Waveform.cpp
+++ b/src/libprojectM/Renderer/Waveform.cpp
@@ -55,13 +55,13 @@ void Waveform::Draw(RenderContext &context)
     float *value2 = new float[samples_count];
     if (spectrum)
     {
-        context.beatDetect->pcm->getSpectrum( value1, CHANNEL_0, samples_count, smoothing );
-        context.beatDetect->pcm->getSpectrum( value2, CHANNEL_1, samples_count, smoothing );
+        context.beatDetect->pcm.getSpectrum( value1, CHANNEL_0, samples_count, smoothing );
+        context.beatDetect->pcm.getSpectrum( value2, CHANNEL_1, samples_count, smoothing );
     }
     else
     {
-        context.beatDetect->pcm->getPCM( value1, CHANNEL_0, samples_count, smoothing );
-        context.beatDetect->pcm->getPCM( value2, CHANNEL_1, samples_count, smoothing );
+        context.beatDetect->pcm.getPCM( value1, CHANNEL_0, samples_count, smoothing );
+        context.beatDetect->pcm.getPCM( value2, CHANNEL_1, samples_count, smoothing );
     }
 
     const float mult = scaling * vol_scale * (spectrum ? 0.005f : 1.0f);

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -562,7 +562,7 @@ void projectM::projectM_init ( int gx, int gy, int fps, int texsize, int width, 
     if (!_pcm)
         _pcm = new PCM();
     assert(pcm());
-    beatDetect = new BeatDetect ( _pcm );
+    beatDetect = new BeatDetect ( *_pcm );
 
     if ( _settings.fps > 0 )
         mspf= ( int ) ( 1000.0/ ( float ) _settings.fps );

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -368,7 +368,7 @@ Pipeline * projectM::renderFrameOnlyPass1(Pipeline *pPipeline) /*pPipeline is a 
     context.progress = timeKeeper->PresetProgressA();
     renderer->UpdateContext(context);
 
-    beatDetect->detectFromSamples();
+    beatDetect->calculateBeatStatistics();
 
     //m_activePreset->evaluateFrame();
 


### PR DESCRIPTION
Did some general cleanup in BeatDetect.hpp and BeatDetect.cpp.

Things I'm thinking about changing from having looked at this:

- Remove `projectM_fmax`, `projectM_fmin`, `TRUE` and `FALSE` from 
`src/libprojectM/Common.hpp`.

- Change PCM::getSpectrum to return a `std::vector` instead of writing to the
`data` argument.
Everywhere it is used in the codebase, new data is allocated before being sent
to be filled by the member function,
so just allocating and returning a vector should be equally efficient.

Some other thoughts:
- Do we prefer to use or not use `this->`?

- Is there a need for `BeatDetect::getBeatVals` to be public?

- Naming standard for variables? Could be enforced using clang-tidy.
