### PR TITLE
Add .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,34 @@
+Checks: '
+-*,
+
+readability-*,
+-readability-named-parameter,
+-readability-magic-numbers,
+-readability-make-member-function-const,
+
+cppcoreguidelines-*,
+-cppcoreguidelines-owning-memory,
+-cppcoreguidelines-pro-type-union-access,
+-cppcoreguidelines-avoid-magic-numbers,
+-cppcoreguidelines-pro-bounds-constant-array-index,
+-cppcoreguidelines-pro-bounds-pointer-arithmetic,
+
+bugprone-*,
+-bugprone-easily-swappable-parameters,
+
+modernize-*,
+performance-*,
+misc-*'
+
+CheckOptions:
+  - key: readability-identifier-naming.VariableCase
+    value: lower_case
+  - key: readability-identifier-naming.ClassCase
+    value: lower_case
+  - key: readability-identifier-naming.ScopedEnumConstantCase
+    value: lower_case
+  - key: readability-identifier-naming.PrivateMemberPrefix
+    value: m_
+
+  - key: readability-uppercase-literal-suffix.NewSuffixes
+    value: L;LL;Lu;LLu


### PR DESCRIPTION
Add .clang-tidy.

This simply contains my personal preferences.
I like m_ as a prefix for private members,
it can make code a lot clearer ime to quickly see which variables are members.

The specific casing otherwise I don't have much opinion on,
just that we need to be more consistent.
