### PR TITLE
Refactor Pcm (chunk 2)

### DIFF
--- a/src/libprojectM/PCM.cpp
+++ b/src/libprojectM/PCM.cpp
@@ -440,7 +440,7 @@ auto Pcm::MakeTest() -> Test*
 
 #else
 
-Test* PCM::test()
+auto Pcm::MakeTest() -> Test*
 {
     return nullptr;
 }

--- a/src/libprojectM/PCM.cpp
+++ b/src/libprojectM/PCM.cpp
@@ -52,36 +52,36 @@ double Pcm::AutoLevel::UpdateLevel(size_t samples, double sum, double max)
     // This is an arbitrary number that helps control
     //   a) how quickly the level can change and
     //   b) keeps code from being affected by how the caller provides data (lot of short buffers, or fewer long buffers)
-    size_t constexpr AUTOLEVEL_SEGMENT = 4096;
+    size_t constexpr autolevelSegment = 4096;
 
     if (sum / samples < 0.00001)
         return m_level;
     m_levelSum += sum;
     m_levelax = std::max(m_levelax, max * 1.02);
     m_levelSamples += samples;
-    if (m_levelSamples >= AUTOLEVEL_SEGMENT || m_l0 <= 0)
+    if (m_levelSamples >= autolevelSegment || m_l0 <= 0)
     {
-        double max_recent = std::max(std::max(m_l0, m_l1), std::max(m_l2, m_levelax));
+        double maxRecent = std::max(std::max(m_l0, m_l1), std::max(m_l2, m_levelax));
         m_l0 = m_l1;
         m_l1 = m_l2;
         m_l2 = m_levelax;
         m_levelax *= 0.95;
         m_levelSum = m_levelSamples = 0;
-        m_level = (m_l0 <= 0) ? max_recent : m_level * 0.96 + max_recent * 0.04;
+        m_level = (m_l0 <= 0) ? maxRecent : m_level * 0.96 + maxRecent * 0.04;
         m_level = std::max(m_level, 0.0001);
     }
     return m_level;
 }
 
 
-void Pcm::AddPcmFloat(const float* PCMdata, size_t samples)
+void Pcm::AddPcmFloat(const float* pcmData, size_t samples)
 {
     float a, sum = 0, max = 0;
     for (size_t i = 0; i < samples; i++)
     {
         size_t j = (i + m_start) % maxSamples;
-        a = m_pcmL[j] = PCMdata[i];
-        m_pcmR[j] = PCMdata[i];
+        a = m_pcmL[j] = pcmData[i];
+        m_pcmR[j] = pcmData[i];
         sum += std::abs(a);
         max = std::max(max, a);
     }
@@ -92,15 +92,15 @@ void Pcm::AddPcmFloat(const float* PCMdata, size_t samples)
 
 
 /* NOTE: this method expects total samples, not samples per channel */
-void Pcm::AddPcmFloat2Ch(const float* PCMdata, size_t count)
+void Pcm::AddPcmFloat2Ch(const float* pcmData, size_t count)
 {
     size_t samples = count / 2;
     float a, b, sum = 0, max = 0;
     for (size_t i = 0; i < samples; i++)
     {
         size_t j = (m_start + i) % maxSamples;
-        a = m_pcmL[j] = PCMdata[i * 2];
-        b = m_pcmR[j] = PCMdata[i * 2 + 1];
+        a = m_pcmL[j] = pcmData[i * 2];
+        b = m_pcmR[j] = pcmData[i * 2 + 1];
         sum += std::abs(a) + std::abs(b);
         max = std::max(std::max(max, std::abs(a)), std::abs(b));
     }
@@ -127,15 +127,15 @@ void Pcm::AddPcm16Data(const int16_t* pcm_data, size_t samples)
 }
 
 
-void Pcm::AddPcm16(const int16_t PCMdata[2][512])
+void Pcm::AddPcm16(const int16_t pcmData[2][512])
 {
     const int samples = 512;
     float a, b, sum = 0, max = 0;
     for (size_t i = 0; i < samples; i++)
     {
         size_t j = (i + m_start) % maxSamples;
-        a = m_pcmL[j] = (PCMdata[0][i] / 16384.0);
-        b = m_pcmR[j] = (PCMdata[1][i] / 16384.0);
+        a = m_pcmL[j] = (pcmData[0][i] / 16384.0);
+        b = m_pcmR[j] = (pcmData[1][i] / 16384.0);
         sum += std::abs(a) + std::abs(b);
         max = std::max(std::max(max, a), b);
     }
@@ -145,15 +145,15 @@ void Pcm::AddPcm16(const int16_t PCMdata[2][512])
 }
 
 
-void Pcm::AddPcm8(const uint8_t PCMdata[2][1024])
+void Pcm::AddPcm8(const uint8_t pcmData[2][1024])
 {
     const int samples = 1024;
     float a, b, sum = 0, max = 0;
     for (size_t i = 0; i < samples; i++)
     {
         size_t j = (i + m_start) % maxSamples;
-        a = m_pcmL[j] = (((float) PCMdata[0][i] - 128.0) / 64);
-        b = m_pcmR[j] = (((float) PCMdata[1][i] - 128.0) / 64);
+        a = m_pcmL[j] = (((float) pcmData[0][i] - 128.0) / 64);
+        b = m_pcmR[j] = (((float) pcmData[1][i] - 128.0) / 64);
         sum += std::abs(a) + std::abs(b);
         max = std::max(std::max(max, a), b);
     }
@@ -163,15 +163,15 @@ void Pcm::AddPcm8(const uint8_t PCMdata[2][1024])
 }
 
 
-void Pcm::AddPcm8(const uint8_t PCMdata[2][512])
+void Pcm::AddPcm8(const uint8_t pcmData[2][512])
 {
     const size_t samples = 512;
     float a, b, sum = 0, max = 0;
     for (size_t i = 0; i < samples; i++)
     {
         size_t j = (i + m_start) % maxSamples;
-        a = m_pcmL[j] = (((float) PCMdata[0][i] - 128.0) / 64);
-        b = m_pcmR[j] = (((float) PCMdata[1][i] - 128.0) / 64);
+        a = m_pcmL[j] = (((float) pcmData[0][i] - 128.0) / 64);
+        b = m_pcmR[j] = (((float) pcmData[1][i] - 128.0) / 64);
         sum += std::abs(a) + std::abs(b);
         max = std::max(std::max(max, a), b);
     }
@@ -182,7 +182,7 @@ void Pcm::AddPcm8(const uint8_t PCMdata[2][512])
 
 
 template<size_t aSize, size_t ipSize, size_t wSize>
-void rdft(
+void Rdft(
     int const isgn,
     std::array<double, aSize>& a,
     std::array<int, ipSize>& ip,
@@ -251,7 +251,7 @@ void Pcm::UpdateFFTChannel(size_t channel)
 
     auto& freq = channel == 0 ? m_freqL : m_freqR;
     CopyPcm(freq.data(), channel, freq.size());
-    rdft(1, freq, m_ip, m_w);
+    Rdft(1, freq, m_ip, m_w);
 
     // compute magnitude data (m^2 actually)
     auto& spectrum = channel == 0 ? m_spectrumL : m_spectrumR;
@@ -264,7 +264,7 @@ void Pcm::UpdateFFTChannel(size_t channel)
 }
 
 // CPP17: std::clamp
-inline double clamp(double x, double lo, double hi)
+inline double Clamp(double x, double lo, double hi)
 {
     return x > hi ? hi : x < lo ? lo
                                 : x;
@@ -320,13 +320,13 @@ public:
     {
     }
 
-    bool eq(float a, float b)
+    bool Eq(float a, float b)
     {
         return std::abs(a - b) < (std::abs(a) + std::abs(b) + 1) / 1000.0f;
     }
 
     /* smoke test for each addPCM method */
-    bool test_addpcm()
+    bool TestAddpcm()
     {
         Pcm pcm;
 
@@ -342,10 +342,10 @@ public:
             pcm.m_level = 1.0;
             pcm.CopyPcm(copy.data(), 0, copy.size());
             for (size_t i = 0; i < samples; i++)
-                TEST(eq(copy[i], ((float) samples - 1 - i) / (samples - 1)));
+                TEST(Eq(copy[i], ((float) samples - 1 - i) / (samples - 1)));
             pcm.CopyPcm(copy.data(), 1, copy.size());
             for (size_t i = 0; i < samples; i++)
-                TEST(eq(copy[i], ((float) samples - 1 - i) / (samples - 1)));
+                TEST(Eq(copy[i], ((float) samples - 1 - i) / (samples - 1)));
         }
 
         // float_2ch
@@ -365,18 +365,18 @@ public:
             pcm.CopyPcm(copy0.data(), 0, copy0.size());
             pcm.CopyPcm(copy1.data(), 1, copy1.size());
             for (size_t i = 0; i < samples; i++)
-                TEST(eq(1.0, copy0[i] + copy1[i]));
+                TEST(Eq(1.0, copy0[i] + copy1[i]));
         }
 
         //        void PCM::addPCM16Data(const short* pcm_data, size_t samples)
-        //        void PCM::addPCM16(const short PCMdata[2][512])
-        //        void PCM::addPCM8(const unsigned char PCMdata[2][1024])
-        //        void PCM::addPCM8_512(const unsigned char PCMdata[2][512])
+        //        void PCM::addPCM16(const short pcmData[2][512])
+        //        void PCM::addPCM8(const unsigned char pcmData[2][1024])
+        //        void PCM::addPCM8_512(const unsigned char pcmData[2][512])
 
         return true;
     }
 
-    bool test_fft()
+    bool TestFft()
     {
         Pcm pcm;
 
@@ -399,7 +399,7 @@ public:
             pcm.GetSpectrum(freq1.data(), CHANNEL_1, fftLength, 0.0);
             // freq0 and freq1 should be equal
             for (size_t i = 0; i < fftLength; i++)
-                TEST(eq(freq0[i], freq1[i]));
+                TEST(Eq(freq0[i], freq1[i]));
             TEST(freq0[0] > 500);
             for (size_t i = 1; i < fftLength; i++)
                 TEST(freq0[i] < 0.1);
@@ -418,7 +418,7 @@ public:
             pcm.GetSpectrum(freq1.data(), CHANNEL_1, fftLength, 0.0);
             // freq0 and freq1 should be equal
             for (size_t i = 0; i < fftLength; i++)
-                TEST(eq(freq0[i], freq1[i]));
+                TEST(Eq(freq0[i], freq1[i]));
             for (size_t i = 0; i < fftLength - 1; i++)
                 TEST(0 == freq0[i]);
             TEST(freq0[fftLength - 1] > 100000);
@@ -430,8 +430,8 @@ public:
 
     bool test() override
     {
-        TEST(test_addpcm());
-        TEST(test_fft());
+        TEST(TestAddpcm());
+        TEST(TestFft());
         return true;
     }
 };

--- a/src/libprojectM/PCM.cpp
+++ b/src/libprojectM/PCM.cpp
@@ -57,8 +57,10 @@ auto Pcm::AutoLevel::UpdateLevel(
     //   b) keeps code from being affected by how the caller provides data (lot of short buffers, or fewer long buffers)
     size_t constexpr autolevelSegment = 4096;
 
-    if (sum / samples < 0.00001)
+    if (sum / static_cast<double>(samples) < 0.00001)
+    {
         return m_level;
+    }
     m_levelSum += sum;
     m_levelax = std::max(m_levelax, max * 1.02);
     m_levelSamples += samples;
@@ -69,7 +71,8 @@ auto Pcm::AutoLevel::UpdateLevel(
         m_l1 = m_l2;
         m_l2 = m_levelax;
         m_levelax *= 0.95;
-        m_levelSum = m_levelSamples = 0;
+        m_levelSamples = 0;
+        m_levelSum = 0;
         m_level = (m_l0 <= 0) ? maxRecent : m_level * 0.96 + maxRecent * 0.04;
         m_level = std::max(m_level, 0.0001);
     }
@@ -104,40 +107,40 @@ void Pcm::AddPcm(
 }
 
 
-void Pcm::AddPcmFloat(float const* const pcmData, size_t const samples)
+void Pcm::AddPcmFloat(float const* const pcmData, size_t const count)
 {
-    AddPcm<0, 0, 1, 1, 0>(pcmData, samples);
+    AddPcm<0, 0, 1, 1, 0>(pcmData, count);
 }
 
 
 /* NOTE: this method expects total samples, not samples per channel */
-void Pcm::AddPcmFloat2Ch(float const* const pcmData, size_t const samples)
+void Pcm::AddPcmFloat2Ch(float const* const pcmData, size_t const count)
 {
-    AddPcm<0, 1, 2, 1, 0>(pcmData, samples / 2);
+    AddPcm<0, 1, 2, 1, 0>(pcmData, count / 2);
 }
 
 
-void Pcm::AddPcm16Data(int16_t const* const pcmData, size_t const samples)
+void Pcm::AddPcm16Data(int16_t const* const pcmData, size_t const count)
 {
-    AddPcm<0, 0, 1, 16384, 0>(pcmData, samples);
+    AddPcm<0, 0, 1, 16384, 0>(pcmData, count);
 }
 
 
 void Pcm::AddPcm16(int16_t const pcmData[2][512])
 {
-    AddPcm<0, 512, 1, 16384, 0>(*pcmData, 512);
+    AddPcm<0, 512, 1, 16384, 0>(static_cast<int16_t const*>(*pcmData), 512);
 }
 
 
 void Pcm::AddPcm8(uint8_t const pcmData[2][1024])
 {
-    AddPcm<0, 1024, 1, 64, 128>(*pcmData, 1024);
+    AddPcm<0, 1024, 1, 64, 128>(static_cast<uint8_t const*>(*pcmData), 1024);
 }
 
 
 void Pcm::AddPcm8(uint8_t const pcmData[2][512])
 {
-    AddPcm<0, 512, 1, 64, 128>(*pcmData, 512);
+    AddPcm<0, 512, 1, 64, 128>(static_cast<uint8_t const*>(*pcmData), 512);
 }
 
 
@@ -177,7 +180,6 @@ void Pcm::GetPcm(
     assert(channel == 0 || channel == 1);
 
     CopyPcm(data, channel, samples);
-    return;
 }
 
 
@@ -192,9 +194,13 @@ void Pcm::GetSpectrum(
     auto const& spectrum = channel == 0 ? m_spectrumL : m_spectrumR;
     size_t const count = samples <= fftLength ? samples : fftLength;
     for (size_t i = 0; i < count; i++)
+    {
         data[i] = spectrum[i];
+    }
     for (size_t i = count; i < samples; i++)
+    {
         data[0] = 0;
+    }
 }
 
 void Pcm::UpdateFFT()
@@ -221,10 +227,10 @@ void Pcm::UpdateFftChannel(size_t const channel)
     auto& spectrum = channel == 0 ? m_spectrumL : m_spectrumR;
     for (size_t i = 1; i < fftLength; i++)
     {
-        double const m2 = (freq[i * 2] * freq[i * 2] + freq[i * 2 + 1] * freq[i * 2 + 1]);
-        spectrum[i - 1] = m2 * ((double) i) / fftLength;
+        auto const m2 = static_cast<float>(freq[i * 2] * freq[i * 2] + freq[i * 2 + 1] * freq[i * 2 + 1]);
+        spectrum[i - 1] = static_cast<float>(i) * m2 / fftLength;
     }
-    spectrum[fftLength - 1] = freq[1] * freq[1];
+    spectrum[fftLength - 1] = static_cast<float>(freq[1] * freq[1]);
 }
 
 // CPP17: std::clamp
@@ -235,7 +241,7 @@ auto Clamp(double const x, double const lo, double const hi) -> double
 }
 
 // pull data from circular buffer
-void Pcm::CopyPcm(float* const to, int const channel, size_t const count) const
+void Pcm::CopyPcm(float* const to, size_t const channel, size_t const count) const
 {
     assert(channel == 0 || channel == 1);
     assert(count < maxSamples);
@@ -244,12 +250,14 @@ void Pcm::CopyPcm(float* const to, int const channel, size_t const count) const
     for (size_t i = 0, pos = m_start; i < count; i++)
     {
         if (pos == 0)
+        {
             pos = maxSamples;
-        to[i] = from[--pos] * volume;
+        }
+        to[i] = static_cast<float>(from[--pos] * volume);
     }
 }
 
-void Pcm::CopyPcm(double* const to, int const channel, size_t const count) const
+void Pcm::CopyPcm(double* const to, size_t const channel, size_t const count) const
 {
     assert(channel == 0 || channel == 1);
     auto const& from = channel == 0 ? m_pcmL : m_pcmR;
@@ -257,7 +265,9 @@ void Pcm::CopyPcm(double* const to, int const channel, size_t const count) const
     for (size_t i = 0, pos = m_start; i < count; i++)
     {
         if (pos == 0)
+        {
             pos = maxSamples;
+        }
         to[i] = from[--pos] * volume;
     }
 }
@@ -285,7 +295,7 @@ public:
     {
     }
 
-    bool Eq(float const a, float const b)
+    static auto Eq(float const a, float const b) -> bool
     {
         return std::abs(a - b) < (std::abs(a) + std::abs(b) + 1) / 1000.0f;
     }
@@ -298,39 +308,51 @@ public:
         // mono float
         {
             size_t constexpr samples = 301;
-            std::array<float, samples> data;
+            std::array<float, samples> data{};
             for (size_t i = 0; i < samples; i++)
+            {
                 data[i] = ((float) i) / (samples - 1);
+            }
             for (size_t i = 0; i < 10; i++)
+            {
                 pcm.AddPcmFloat(data.data(), samples);
-            std::array<float, samples> copy;
+            }
+            std::array<float, samples> copy{};
             pcm.m_level = 1.0;
             pcm.CopyPcm(copy.data(), 0, copy.size());
             for (size_t i = 0; i < samples; i++)
+            {
                 TEST(Eq(copy[i], ((float) samples - 1 - i) / (samples - 1)));
+            }
             pcm.CopyPcm(copy.data(), 1, copy.size());
             for (size_t i = 0; i < samples; i++)
+            {
                 TEST(Eq(copy[i], ((float) samples - 1 - i) / (samples - 1)));
+            }
         }
 
         // float_2ch
         {
             size_t constexpr samples = 301;
-            std::array<float, 2 * samples> data;
+            std::array<float, 2 * samples> data{};
             for (size_t i = 0; i < samples; i++)
             {
                 data[i * 2] = ((float) i) / (samples - 1);
-                data[i * 2 + 1] = 1.0 - data[i * 2];
+                data[i * 2 + 1] = 1.f - data[i * 2];
             }
             for (size_t i = 0; i < 10; i++)
+            {
                 pcm.AddPcmFloat2Ch(data.data(), samples * 2);
-            std::array<float, samples> copy0;
-            std::array<float, samples> copy1;
+            }
+            std::array<float, samples> copy0{};
+            std::array<float, samples> copy1{};
             pcm.m_level = 1;
             pcm.CopyPcm(copy0.data(), 0, copy0.size());
             pcm.CopyPcm(copy1.data(), 1, copy1.size());
             for (size_t i = 0; i < samples; i++)
+            {
                 TEST(Eq(1.0, copy0[i] + copy1[i]));
+            }
         }
 
         //        void PCM::addPCM16Data(const short* pcm_data, size_t samples)
@@ -348,44 +370,54 @@ public:
         // low frequency
         {
             size_t constexpr samples = 1024;
-            std::array<float, 2 * samples> data;
+            std::array<float, 2 * samples> data{};
             for (size_t i = 0; i < samples; i++)
             {
-                float const f = 2 * 3.141592653589793 * ((double) i) / (samples - 1);
-                data[i * 2] = sin(f);
-                data[i * 2 + 1] = sin(f + 1.0);// out of phase
+                float const f = static_cast<float>(i) * 2 * 3.141592653589793f / (samples - 1);
+                data[i * 2] = std::sin(f);
+                data[i * 2 + 1] = std::sin(f + 1.f);// out of phase
             }
             pcm.AddPcmFloat2Ch(data.data(), samples * 2);
             pcm.AddPcmFloat2Ch(data.data(), samples * 2);
-            std::array<float, fftLength> freq0;
-            std::array<float, fftLength> freq1;
+            std::array<float, fftLength> freq0{};
+            std::array<float, fftLength> freq1{};
             pcm.m_level = 1.0;
             pcm.GetSpectrum(freq0.data(), CHANNEL_0, fftLength);
             pcm.GetSpectrum(freq1.data(), CHANNEL_1, fftLength);
             // freq0 and freq1 should be equal
             for (size_t i = 0; i < fftLength; i++)
+            {
                 TEST(Eq(freq0[i], freq1[i]));
+            }
             TEST(freq0[0] > 500);
             for (size_t i = 1; i < fftLength; i++)
+            {
                 TEST(freq0[i] < 0.1);
+            }
         }
 
         // high frequency
         {
             size_t constexpr samples = 2;
-            float constexpr data[4] = {1.0, 0.0, 0.0, 1.0};
+            std::array<float, 4> constexpr data{1.0, 0.0, 0.0, 1.0};
             for (size_t i = 0; i < 1024; i++)
-                pcm.AddPcmFloat2Ch(data, samples * 2);
-            std::array<float, fftLength> freq0;
-            std::array<float, fftLength> freq1;
+            {
+                pcm.AddPcmFloat2Ch(data.data(), samples * 2);
+            }
+            std::array<float, fftLength> freq0{};
+            std::array<float, fftLength> freq1{};
             pcm.m_level = 1.0;
             pcm.GetSpectrum(freq0.data(), CHANNEL_0, fftLength);
             pcm.GetSpectrum(freq1.data(), CHANNEL_1, fftLength);
             // freq0 and freq1 should be equal
             for (size_t i = 0; i < fftLength; i++)
+            {
                 TEST(Eq(freq0[i], freq1[i]));
+            }
             for (size_t i = 0; i < fftLength - 1; i++)
+            {
                 TEST(0 == freq0[i]);
+            }
             TEST(freq0[fftLength - 1] > 100000);
         }
 

--- a/src/libprojectM/PCM.cpp
+++ b/src/libprojectM/PCM.cpp
@@ -74,21 +74,24 @@ auto Pcm::AutoLevel::UpdateLevel(size_t samples, double sum, double max) -> doub
 }
 
 
-template<int signalAmplitude, int signalOffset, class SampleType>
+template<
+    size_t lOffset,
+    size_t rOffset,
+    size_t stride,
+    int signalAmplitude,
+    int signalOffset,
+    class SampleType>
 void Pcm::AddPcm(
-        const SampleType* pcmData,
-        size_t lOffset,
-        size_t rOffset,
-        size_t stride,
-        size_t count)
+    const SampleType* pcmData,
+    size_t count)
 {
     float sum = 0;
     float max = 0;
     for (size_t i = 0; i < count; i++)
     {
         size_t j = (m_start + i) % maxSamples;
-        m_pcmL[j] = (pcmData[lOffset + i * stride]-signalOffset)/float(signalAmplitude);
-        m_pcmR[j] = (pcmData[rOffset + i * stride]-signalOffset)/float(signalAmplitude);
+        m_pcmL[j] = (pcmData[lOffset + i * stride] - signalOffset) / float(signalAmplitude);
+        m_pcmR[j] = (pcmData[rOffset + i * stride] - signalOffset) / float(signalAmplitude);
         sum += std::abs(m_pcmL[j]) + std::abs(m_pcmR[j]);
         max = std::max(std::max(max, std::abs(m_pcmL[j])), std::abs(m_pcmR[j]));
     }
@@ -100,38 +103,38 @@ void Pcm::AddPcm(
 
 void Pcm::AddPcmFloat(const float* pcmData, size_t samples)
 {
-    AddPcm<1, 0>(pcmData, 0, 0, 1, samples);
+    AddPcm<0, 0, 1, 1, 0>(pcmData, samples);
 }
 
 
 /* NOTE: this method expects total samples, not samples per channel */
 void Pcm::AddPcmFloat2Ch(const float* pcmData, size_t samples)
 {
-    AddPcm<1, 0>(pcmData, 0, 1, 2, samples/2);
+    AddPcm<0, 1, 2, 1, 0>(pcmData, samples / 2);
 }
 
 
 void Pcm::AddPcm16Data(const int16_t* pcmData, size_t samples)
 {
-    AddPcm<16384, 0>(pcmData, 0, 0, 1, samples);
+    AddPcm<0, 0, 1, 16384, 0>(pcmData, samples);
 }
 
 
 void Pcm::AddPcm16(const int16_t pcmData[2][512])
 {
-    AddPcm<16384, 0>(*pcmData, 0, 512, 1, 512);
+    AddPcm<0, 512, 1, 16384, 0>(*pcmData, 512);
 }
 
 
 void Pcm::AddPcm8(const uint8_t pcmData[2][1024])
 {
-    AddPcm<64, 128>(*pcmData, 0, 1024, 1, 1024);
+    AddPcm<0, 1024, 1, 64, 128>(*pcmData, 1024);
 }
 
 
 void Pcm::AddPcm8(const uint8_t pcmData[2][512])
 {
-    AddPcm<64, 128>(*pcmData, 0, 512, 1, 512);
+    AddPcm<0, 512, 1, 64, 128>(*pcmData, 512);
 }
 
 

--- a/src/libprojectM/PCM.cpp
+++ b/src/libprojectM/PCM.cpp
@@ -167,14 +167,12 @@ void Rdft(
 // puts sound data requested at provided pointer
 //
 // samples is number of PCM samples to return
-// smoothing does nothing
 // returned values are normalized from -1 to 1
 
 void Pcm::GetPcm(
     float* const data,
     CHANNEL const channel,
-    size_t const samples,
-    float const smoothing) const
+    size_t const samples) const
 {
     assert(channel == 0 || channel == 1);
 
@@ -183,12 +181,10 @@ void Pcm::GetPcm(
 }
 
 
-/* NOTE: smoothing does nothing */
 void Pcm::GetSpectrum(
     float* const data,
     CHANNEL const channel,
-    size_t const samples,
-    float const smoothing)
+    size_t const samples)
 {
     assert(channel == 0 || channel == 1);
     UpdateFFT();
@@ -364,8 +360,8 @@ public:
             std::array<float, fftLength> freq0;
             std::array<float, fftLength> freq1;
             pcm.m_level = 1.0;
-            pcm.GetSpectrum(freq0.data(), CHANNEL_0, fftLength, 0.0);
-            pcm.GetSpectrum(freq1.data(), CHANNEL_1, fftLength, 0.0);
+            pcm.GetSpectrum(freq0.data(), CHANNEL_0, fftLength);
+            pcm.GetSpectrum(freq1.data(), CHANNEL_1, fftLength);
             // freq0 and freq1 should be equal
             for (size_t i = 0; i < fftLength; i++)
                 TEST(Eq(freq0[i], freq1[i]));
@@ -383,8 +379,8 @@ public:
             std::array<float, fftLength> freq0;
             std::array<float, fftLength> freq1;
             pcm.m_level = 1.0;
-            pcm.GetSpectrum(freq0.data(), CHANNEL_0, fftLength, 0.0);
-            pcm.GetSpectrum(freq1.data(), CHANNEL_1, fftLength, 0.0);
+            pcm.GetSpectrum(freq0.data(), CHANNEL_0, fftLength);
+            pcm.GetSpectrum(freq1.data(), CHANNEL_1, fftLength);
             // freq0 and freq1 should be equal
             for (size_t i = 0; i < fftLength; i++)
                 TEST(Eq(freq0[i], freq1[i]));

--- a/src/libprojectM/PCM.cpp
+++ b/src/libprojectM/PCM.cpp
@@ -46,7 +46,7 @@
  * I don't know if it's necessary to have both sum and max, but that makes
  * it easier to experiment...
  */
-double PCM::AutoLevel::updateLevel(size_t samples, double sum, double max)
+double Pcm::AutoLevel::UpdateLevel(size_t samples, double sum, double max)
 {
 
     // This is an arbitrary number that helps control
@@ -55,129 +55,129 @@ double PCM::AutoLevel::updateLevel(size_t samples, double sum, double max)
     size_t constexpr AUTOLEVEL_SEGMENT = 4096;
 
     if (sum / samples < 0.00001)
-        return level;
-    level_sum += sum;
-    level_max = std::max(level_max, max * 1.02);
-    level_samples += samples;
-    if (level_samples >= AUTOLEVEL_SEGMENT || l0 <= 0)
+        return m_level;
+    m_levelSum += sum;
+    m_levelax = std::max(m_levelax, max * 1.02);
+    m_levelSamples += samples;
+    if (m_levelSamples >= AUTOLEVEL_SEGMENT || m_l0 <= 0)
     {
-        double max_recent = std::max(std::max(l0, l1), std::max(l2, level_max));
-        l0 = l1;
-        l1 = l2;
-        l2 = level_max;
-        level_max *= 0.95;
-        level_sum = level_samples = 0;
-        level = (l0 <= 0) ? max_recent : level * 0.96 + max_recent * 0.04;
-        level = std::max(level, 0.0001);
+        double max_recent = std::max(std::max(m_l0, m_l1), std::max(m_l2, m_levelax));
+        m_l0 = m_l1;
+        m_l1 = m_l2;
+        m_l2 = m_levelax;
+        m_levelax *= 0.95;
+        m_levelSum = m_levelSamples = 0;
+        m_level = (m_l0 <= 0) ? max_recent : m_level * 0.96 + max_recent * 0.04;
+        m_level = std::max(m_level, 0.0001);
     }
-    return level;
+    return m_level;
 }
 
 
-void PCM::addPCMfloat(const float* PCMdata, size_t samples)
+void Pcm::AddPcmFloat(const float* PCMdata, size_t samples)
 {
     float a, sum = 0, max = 0;
     for (size_t i = 0; i < samples; i++)
     {
-        size_t j = (i + start) % maxSamples;
-        a = pcmL[j] = PCMdata[i];
-        pcmR[j] = PCMdata[i];
+        size_t j = (i + m_start) % maxSamples;
+        a = m_pcmL[j] = PCMdata[i];
+        m_pcmR[j] = PCMdata[i];
         sum += std::abs(a);
         max = std::max(max, a);
     }
-    start = (start + samples) % maxSamples;
-    newSamples += samples;
-    level = leveler.updateLevel(samples, sum, max);
+    m_start = (m_start + samples) % maxSamples;
+    m_newSamples += samples;
+    m_level = m_leveler.UpdateLevel(samples, sum, max);
 }
 
 
 /* NOTE: this method expects total samples, not samples per channel */
-void PCM::addPCMfloat_2ch(const float* PCMdata, size_t count)
+void Pcm::AddPcmFloat2Ch(const float* PCMdata, size_t count)
 {
     size_t samples = count / 2;
     float a, b, sum = 0, max = 0;
     for (size_t i = 0; i < samples; i++)
     {
-        size_t j = (start + i) % maxSamples;
-        a = pcmL[j] = PCMdata[i * 2];
-        b = pcmR[j] = PCMdata[i * 2 + 1];
+        size_t j = (m_start + i) % maxSamples;
+        a = m_pcmL[j] = PCMdata[i * 2];
+        b = m_pcmR[j] = PCMdata[i * 2 + 1];
         sum += std::abs(a) + std::abs(b);
         max = std::max(std::max(max, std::abs(a)), std::abs(b));
     }
-    start = (start + samples) % maxSamples;
-    newSamples += samples;
-    level = leveler.updateLevel(samples, sum / 2, max);
+    m_start = (m_start + samples) % maxSamples;
+    m_newSamples += samples;
+    m_level = m_leveler.UpdateLevel(samples, sum / 2, max);
 }
 
 
-void PCM::addPCM16Data(const int16_t* pcm_data, size_t samples)
+void Pcm::AddPcm16Data(const int16_t* pcm_data, size_t samples)
 {
     float a, b, sum = 0, max = 0;
     for (size_t i = 0; i < samples; ++i)
     {
-        size_t j = (i + start) % maxSamples;
-        a = pcmL[j] = (pcm_data[i * 2 + 0] / 16384.0);
-        b = pcmR[j] = (pcm_data[i * 2 + 1] / 16384.0);
+        size_t j = (i + m_start) % maxSamples;
+        a = m_pcmL[j] = (pcm_data[i * 2 + 0] / 16384.0);
+        b = m_pcmR[j] = (pcm_data[i * 2 + 1] / 16384.0);
         sum += std::abs(a) + std::abs(b);
         max = std::max(std::max(max, a), b);
     }
-    start = (start + samples) % maxSamples;
-    newSamples += samples;
-    level = leveler.updateLevel(samples, sum / 2, max);
+    m_start = (m_start + samples) % maxSamples;
+    m_newSamples += samples;
+    m_level = m_leveler.UpdateLevel(samples, sum / 2, max);
 }
 
 
-void PCM::addPCM16(const int16_t PCMdata[2][512])
+void Pcm::AddPcm16(const int16_t PCMdata[2][512])
 {
     const int samples = 512;
     float a, b, sum = 0, max = 0;
     for (size_t i = 0; i < samples; i++)
     {
-        size_t j = (i + start) % maxSamples;
-        a = pcmL[j] = (PCMdata[0][i] / 16384.0);
-        b = pcmR[j] = (PCMdata[1][i] / 16384.0);
+        size_t j = (i + m_start) % maxSamples;
+        a = m_pcmL[j] = (PCMdata[0][i] / 16384.0);
+        b = m_pcmR[j] = (PCMdata[1][i] / 16384.0);
         sum += std::abs(a) + std::abs(b);
         max = std::max(std::max(max, a), b);
     }
-    start = (start + samples) % maxSamples;
-    newSamples += samples;
-    level = leveler.updateLevel(samples, sum / 2, max);
+    m_start = (m_start + samples) % maxSamples;
+    m_newSamples += samples;
+    m_level = m_leveler.UpdateLevel(samples, sum / 2, max);
 }
 
 
-void PCM::addPCM8(const uint8_t PCMdata[2][1024])
+void Pcm::AddPcm8(const uint8_t PCMdata[2][1024])
 {
     const int samples = 1024;
     float a, b, sum = 0, max = 0;
     for (size_t i = 0; i < samples; i++)
     {
-        size_t j = (i + start) % maxSamples;
-        a = pcmL[j] = (((float) PCMdata[0][i] - 128.0) / 64);
-        b = pcmR[j] = (((float) PCMdata[1][i] - 128.0) / 64);
+        size_t j = (i + m_start) % maxSamples;
+        a = m_pcmL[j] = (((float) PCMdata[0][i] - 128.0) / 64);
+        b = m_pcmR[j] = (((float) PCMdata[1][i] - 128.0) / 64);
         sum += std::abs(a) + std::abs(b);
         max = std::max(std::max(max, a), b);
     }
-    start = (start + samples) % maxSamples;
-    newSamples += samples;
-    level = leveler.updateLevel(samples, sum / 2, max);
+    m_start = (m_start + samples) % maxSamples;
+    m_newSamples += samples;
+    m_level = m_leveler.UpdateLevel(samples, sum / 2, max);
 }
 
 
-void PCM::addPCM8_512(const uint8_t PCMdata[2][512])
+void Pcm::AddPcm8(const uint8_t PCMdata[2][512])
 {
     const size_t samples = 512;
     float a, b, sum = 0, max = 0;
     for (size_t i = 0; i < samples; i++)
     {
-        size_t j = (i + start) % maxSamples;
-        a = pcmL[j] = (((float) PCMdata[0][i] - 128.0) / 64);
-        b = pcmR[j] = (((float) PCMdata[1][i] - 128.0) / 64);
+        size_t j = (i + m_start) % maxSamples;
+        a = m_pcmL[j] = (((float) PCMdata[0][i] - 128.0) / 64);
+        b = m_pcmR[j] = (((float) PCMdata[1][i] - 128.0) / 64);
         sum += std::abs(a) + std::abs(b);
         max = std::max(std::max(max, a), b);
     }
-    start = (start + samples) % maxSamples;
-    newSamples += samples;
-    level = leveler.updateLevel(samples, sum / 2, max);
+    m_start = (m_start + samples) % maxSamples;
+    m_newSamples += samples;
+    m_level = m_leveler.UpdateLevel(samples, sum / 2, max);
 }
 
 
@@ -210,57 +210,57 @@ void rdft(
 // smoothing does nothing
 // returned values are normalized from -1 to 1
 
-void PCM::getPCM(float* data, CHANNEL channel, size_t samples, float smoothing)
+void Pcm::GetPcm(float* data, CHANNEL channel, size_t samples, float smoothing)
 {
     assert(channel == 0 || channel == 1);
 
-    _copyPCM(data, channel, samples);
+    CopyPcm(data, channel, samples);
     return;
 }
 
 
 /* NOTE: smoothing does nothing */
-void PCM::getSpectrum(float* data, CHANNEL channel, size_t samples, float smoothing)
+void Pcm::GetSpectrum(float* data, CHANNEL channel, size_t samples, float smoothing)
 {
     assert(channel == 0 || channel == 1);
-    _updateFFT();
+    UpdateFFT();
 
-    auto const& spectrum = channel == 0 ? spectrumL : spectrumR;
-    size_t count = samples <= FFT_LENGTH ? samples : FFT_LENGTH;
+    auto const& spectrum = channel == 0 ? m_spectrumL : m_spectrumR;
+    size_t count = samples <= fftLength ? samples : fftLength;
     for (size_t i = 0; i < count; i++)
         data[i] = spectrum[i];
     for (size_t i = count; i < samples; i++)
         data[0] = 0;
 }
 
-void PCM::_updateFFT()
+void Pcm::UpdateFFT()
 {
-    if (newSamples == 0)
+    if (m_newSamples == 0)
     {
         return;
     }
 
-    _updateFFTChannel(0);
-    _updateFFTChannel(1);
-    newSamples = 0;
+    UpdateFFTChannel(0);
+    UpdateFFTChannel(1);
+    m_newSamples = 0;
 }
 
-void PCM::_updateFFTChannel(size_t channel)
+void Pcm::UpdateFFTChannel(size_t channel)
 {
     assert(channel == 0 || channel == 1);
 
-    auto& freq = channel == 0 ? freqL : freqR;
-    _copyPCM(freq.data(), channel, freq.size());
-    rdft(1, freq, ip, w);
+    auto& freq = channel == 0 ? m_freqL : m_freqR;
+    CopyPcm(freq.data(), channel, freq.size());
+    rdft(1, freq, m_ip, m_w);
 
     // compute magnitude data (m^2 actually)
-    auto& spectrum = channel == 0 ? spectrumL : spectrumR;
-    for (size_t i = 1; i < FFT_LENGTH; i++)
+    auto& spectrum = channel == 0 ? m_spectrumL : m_spectrumR;
+    for (size_t i = 1; i < fftLength; i++)
     {
         double m2 = (freq[i * 2] * freq[i * 2] + freq[i * 2 + 1] * freq[i * 2 + 1]);
-        spectrum[i - 1] = m2 * ((double) i) / FFT_LENGTH;
+        spectrum[i - 1] = m2 * ((double) i) / fftLength;
     }
-    spectrum[FFT_LENGTH - 1] = freq[1] * freq[1];
+    spectrum[fftLength - 1] = freq[1] * freq[1];
 }
 
 // CPP17: std::clamp
@@ -271,13 +271,13 @@ inline double clamp(double x, double lo, double hi)
 }
 
 // pull data from circular buffer
-void PCM::_copyPCM(float* to, int channel, size_t count)
+void Pcm::CopyPcm(float* to, int channel, size_t count)
 {
     assert(channel == 0 || channel == 1);
     assert(count < maxSamples);
-    auto const& from = channel == 0 ? pcmL : pcmR;
-    const double volume = 1.0 / level;
-    for (size_t i = 0, pos = start; i < count; i++)
+    auto const& from = channel == 0 ? m_pcmL : m_pcmR;
+    const double volume = 1.0 / m_level;
+    for (size_t i = 0, pos = m_start; i < count; i++)
     {
         if (pos == 0)
             pos = maxSamples;
@@ -285,12 +285,12 @@ void PCM::_copyPCM(float* to, int channel, size_t count)
     }
 }
 
-void PCM::_copyPCM(double* to, int channel, size_t count)
+void Pcm::CopyPcm(double* to, int channel, size_t count)
 {
     assert(channel == 0 || channel == 1);
-    auto const& from = channel == 0 ? pcmL : pcmR;
-    const double volume = 1.0 / level;
-    for (size_t i = 0, pos = start; i < count; i++)
+    auto const& from = channel == 0 ? m_pcmL : m_pcmR;
+    const double volume = 1.0 / m_level;
+    for (size_t i = 0, pos = m_start; i < count; i++)
     {
         if (pos == 0)
             pos = maxSamples;
@@ -328,7 +328,7 @@ public:
     /* smoke test for each addPCM method */
     bool test_addpcm()
     {
-        PCM pcm;
+        Pcm pcm;
 
         // mono float
         {
@@ -337,13 +337,13 @@ public:
             for (size_t i = 0; i < samples; i++)
                 data[i] = ((float) i) / (samples - 1);
             for (size_t i = 0; i < 10; i++)
-                pcm.addPCMfloat(data.data(), samples);
+                pcm.AddPcmFloat(data.data(), samples);
             std::array<float, samples> copy;
-            pcm.level = 1.0;
-            pcm._copyPCM(copy.data(), 0, copy.size());
+            pcm.m_level = 1.0;
+            pcm.CopyPcm(copy.data(), 0, copy.size());
             for (size_t i = 0; i < samples; i++)
                 TEST(eq(copy[i], ((float) samples - 1 - i) / (samples - 1)));
-            pcm._copyPCM(copy.data(), 1, copy.size());
+            pcm.CopyPcm(copy.data(), 1, copy.size());
             for (size_t i = 0; i < samples; i++)
                 TEST(eq(copy[i], ((float) samples - 1 - i) / (samples - 1)));
         }
@@ -358,12 +358,12 @@ public:
                 data[i * 2 + 1] = 1.0 - data[i * 2];
             }
             for (size_t i = 0; i < 10; i++)
-                pcm.addPCMfloat_2ch(data.data(), samples * 2);
+                pcm.AddPcmFloat2Ch(data.data(), samples * 2);
             std::array<float, samples> copy0;
             std::array<float, samples> copy1;
-            pcm.level = 1;
-            pcm._copyPCM(copy0.data(), 0, copy0.size());
-            pcm._copyPCM(copy1.data(), 1, copy1.size());
+            pcm.m_level = 1;
+            pcm.CopyPcm(copy0.data(), 0, copy0.size());
+            pcm.CopyPcm(copy1.data(), 1, copy1.size());
             for (size_t i = 0; i < samples; i++)
                 TEST(eq(1.0, copy0[i] + copy1[i]));
         }
@@ -378,7 +378,7 @@ public:
 
     bool test_fft()
     {
-        PCM pcm;
+        Pcm pcm;
 
         // low frequency
         {
@@ -390,18 +390,18 @@ public:
                 data[i * 2] = sin(f);
                 data[i * 2 + 1] = sin(f + 1.0);// out of phase
             }
-            pcm.addPCMfloat_2ch(data.data(), samples * 2);
-            pcm.addPCMfloat_2ch(data.data(), samples * 2);
-            std::array<float, FFT_LENGTH> freq0;
-            std::array<float, FFT_LENGTH> freq1;
-            pcm.level = 1.0;
-            pcm.getSpectrum(freq0.data(), CHANNEL_0, FFT_LENGTH, 0.0);
-            pcm.getSpectrum(freq1.data(), CHANNEL_1, FFT_LENGTH, 0.0);
+            pcm.AddPcmFloat2Ch(data.data(), samples * 2);
+            pcm.AddPcmFloat2Ch(data.data(), samples * 2);
+            std::array<float, fftLength> freq0;
+            std::array<float, fftLength> freq1;
+            pcm.m_level = 1.0;
+            pcm.GetSpectrum(freq0.data(), CHANNEL_0, fftLength, 0.0);
+            pcm.GetSpectrum(freq1.data(), CHANNEL_1, fftLength, 0.0);
             // freq0 and freq1 should be equal
-            for (size_t i = 0; i < FFT_LENGTH; i++)
+            for (size_t i = 0; i < fftLength; i++)
                 TEST(eq(freq0[i], freq1[i]));
             TEST(freq0[0] > 500);
-            for (size_t i = 1; i < FFT_LENGTH; i++)
+            for (size_t i = 1; i < fftLength; i++)
                 TEST(freq0[i] < 0.1);
         }
 
@@ -410,18 +410,18 @@ public:
             const size_t samples = 2;
             float data[4] = {1.0, 0.0, 0.0, 1.0};
             for (size_t i = 0; i < 1024; i++)
-                pcm.addPCMfloat_2ch(data, samples * 2);
-            std::array<float, FFT_LENGTH> freq0;
-            std::array<float, FFT_LENGTH> freq1;
-            pcm.level = 1.0;
-            pcm.getSpectrum(freq0.data(), CHANNEL_0, FFT_LENGTH, 0.0);
-            pcm.getSpectrum(freq1.data(), CHANNEL_1, FFT_LENGTH, 0.0);
+                pcm.AddPcmFloat2Ch(data, samples * 2);
+            std::array<float, fftLength> freq0;
+            std::array<float, fftLength> freq1;
+            pcm.m_level = 1.0;
+            pcm.GetSpectrum(freq0.data(), CHANNEL_0, fftLength, 0.0);
+            pcm.GetSpectrum(freq1.data(), CHANNEL_1, fftLength, 0.0);
             // freq0 and freq1 should be equal
-            for (size_t i = 0; i < FFT_LENGTH; i++)
+            for (size_t i = 0; i < fftLength; i++)
                 TEST(eq(freq0[i], freq1[i]));
-            for (size_t i = 0; i < FFT_LENGTH - 1; i++)
+            for (size_t i = 0; i < fftLength - 1; i++)
                 TEST(0 == freq0[i]);
-            TEST(freq0[FFT_LENGTH - 1] > 100000);
+            TEST(freq0[fftLength - 1] > 100000);
         }
 
 
@@ -436,7 +436,7 @@ public:
     }
 };
 
-Test* PCM::test()
+Test* Pcm::MakeTest()
 {
     return new PCMTest();
 }

--- a/src/libprojectM/PCM.cpp
+++ b/src/libprojectM/PCM.cpp
@@ -24,9 +24,9 @@
  * Takes sound data from wherever and hands it back out.
  * Returns PCM Data or spectrum data, or the derivative of the PCM data
  */
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
 
 #include "Common.hpp"
 #include "PCM.hpp"

--- a/src/libprojectM/PCM.cpp
+++ b/src/libprojectM/PCM.cpp
@@ -219,7 +219,7 @@ void Pcm::UpdateFFTChannel(size_t channel)
 }
 
 // CPP17: std::clamp
-inline double Clamp(double x, double lo, double hi)
+auto Clamp(double x, double lo, double hi) -> double
 {
     return x > hi ? hi : x < lo ? lo
                                 : x;

--- a/src/libprojectM/PCM.cpp
+++ b/src/libprojectM/PCM.cpp
@@ -46,7 +46,7 @@
  * I don't know if it's necessary to have both sum and max, but that makes
  * it easier to experiment...
  */
-double Pcm::AutoLevel::UpdateLevel(size_t samples, double sum, double max)
+auto Pcm::AutoLevel::UpdateLevel(size_t samples, double sum, double max) -> double
 {
 
     // This is an arbitrary number that helps control
@@ -326,7 +326,7 @@ public:
     }
 
     /* smoke test for each addPCM method */
-    bool TestAddpcm()
+    auto TestAddpcm() -> bool
     {
         Pcm pcm;
 
@@ -376,7 +376,7 @@ public:
         return true;
     }
 
-    bool TestFft()
+    auto TestFft() -> bool
     {
         Pcm pcm;
 
@@ -428,7 +428,7 @@ public:
         return true;
     }
 
-    bool test() override
+    auto test() -> bool override
     {
         TEST(TestAddpcm());
         TEST(TestFft());
@@ -436,7 +436,7 @@ public:
     }
 };
 
-Test* Pcm::MakeTest()
+auto Pcm::MakeTest() -> Test*
 {
     return new PCMTest();
 }

--- a/src/libprojectM/PCM.cpp
+++ b/src/libprojectM/PCM.cpp
@@ -78,9 +78,8 @@ template<int signalAmplitude, int signalOffset, class SampleType>
 void Pcm::AddPcm(
         const SampleType* pcmData,
         size_t lOffset,
-        size_t lStride,
         size_t rOffset,
-        size_t rStride,
+        size_t stride,
         size_t count)
 {
     float sum = 0;
@@ -88,8 +87,8 @@ void Pcm::AddPcm(
     for (size_t i = 0; i < count; i++)
     {
         size_t j = (m_start + i) % maxSamples;
-        m_pcmL[j] = (pcmData[lOffset + i * lStride]-signalOffset)/float(signalAmplitude);
-        m_pcmR[j] = (pcmData[rOffset + i * rStride]-signalOffset)/float(signalAmplitude);
+        m_pcmL[j] = (pcmData[lOffset + i * stride]-signalOffset)/float(signalAmplitude);
+        m_pcmR[j] = (pcmData[rOffset + i * stride]-signalOffset)/float(signalAmplitude);
         sum += std::abs(m_pcmL[j]) + std::abs(m_pcmR[j]);
         max = std::max(std::max(max, std::abs(m_pcmL[j])), std::abs(m_pcmR[j]));
     }
@@ -101,38 +100,38 @@ void Pcm::AddPcm(
 
 void Pcm::AddPcmFloat(const float* pcmData, size_t samples)
 {
-    AddPcm<1, 0>(pcmData, 0, 1, 0, 1, samples);
+    AddPcm<1, 0>(pcmData, 0, 0, 1, samples);
 }
 
 
 /* NOTE: this method expects total samples, not samples per channel */
 void Pcm::AddPcmFloat2Ch(const float* pcmData, size_t samples)
 {
-    AddPcm<1, 0>(pcmData, 0, 2, 1, 2, samples/2);
+    AddPcm<1, 0>(pcmData, 0, 1, 2, samples/2);
 }
 
 
 void Pcm::AddPcm16Data(const int16_t* pcmData, size_t samples)
 {
-    AddPcm<16384, 0>(pcmData, 0, 1, 0, 1, samples);
+    AddPcm<16384, 0>(pcmData, 0, 0, 1, samples);
 }
 
 
 void Pcm::AddPcm16(const int16_t pcmData[2][512])
 {
-    AddPcm<16384, 0>(*pcmData, 0, 1, 512, 1, 512);
+    AddPcm<16384, 0>(*pcmData, 0, 512, 1, 512);
 }
 
 
 void Pcm::AddPcm8(const uint8_t pcmData[2][1024])
 {
-    AddPcm<64, 128>(*pcmData, 0, 1, 1024, 1, 1024);
+    AddPcm<64, 128>(*pcmData, 0, 1024, 1, 1024);
 }
 
 
 void Pcm::AddPcm8(const uint8_t pcmData[2][512])
 {
-    AddPcm<64, 128>(*pcmData, 0, 1, 512, 1, 512);
+    AddPcm<64, 128>(*pcmData, 0, 512, 1, 512);
 }
 
 

--- a/src/libprojectM/PCM.hpp
+++ b/src/libprojectM/PCM.hpp
@@ -36,7 +36,7 @@
 
 // FFT_LENGTH is number of magnitude values available from getSpectrum().
 // Internally this is generated using 2xFFT_LENGTH samples per channel.
-size_t constexpr FFT_LENGTH = 512;
+size_t constexpr fftLength = 512;
 class Test;
 
 enum CHANNEL
@@ -47,33 +47,33 @@ enum CHANNEL
     CHANNEL_1 = 1
 };
 
-class PCM
+class Pcm
 {
 public:
     /* maximum number of sound samples that are actually stored. */
     static constexpr size_t maxSamples = 2048;
 
-    void addPCMfloat(const float* PCMdata, size_t samples);
-    void addPCMfloat_2ch(const float* PCMdata, size_t count);
-    void addPCM16(const int16_t[2][512]);
-    void addPCM16Data(const int16_t* pcm_data, size_t samples);
-    void addPCM8(const uint8_t[2][1024]);
-    void addPCM8_512(const uint8_t[2][512]);
+    void AddPcmFloat(const float* pcmData, size_t samples);
+    void AddPcmFloat2Ch(const float* pcmData, size_t count);
+    void AddPcm16(const int16_t pcmData[2][512]);
+    void AddPcm16Data(const int16_t* pcmData, size_t samples);
+    void AddPcm8(const uint8_t pcmData[2][1024]);
+    void AddPcm8(const uint8_t pcmData[2][512]);
 
     /**
      * PCM data
      * smoothing does nothing
      * The returned data will 'wrap' if more than maxsamples are requested.
      */
-    void getPCM(float* data, CHANNEL channel, size_t samples, float smoothing);
+    void GetPcm(float* data, CHANNEL channel, size_t samples, float smoothing);
 
     /** Spectrum data
      * smoothing does nothing
      * The returned data will be zero padded if more than FFT_LENGTH values are requested
      */
-    void getSpectrum(float* data, CHANNEL channel, size_t samples, float smoothing);
+    void GetSpectrum(float* data, CHANNEL channel, size_t samples, float smoothing);
 
-    static Test* test();
+    static Test* MakeTest();
 
 private:
     // mem-usage:
@@ -85,28 +85,28 @@ private:
     // circular PCM buffer
     // adjust "volume" of PCM data as we go, this simplifies everything downstream...
     // normalize to range [-1.0,1.0]
-    std::array<float, maxSamples> pcmL{0.f};
-    std::array<float, maxSamples> pcmR{0.f};
-    int start{0};
-    size_t newSamples{0};
+    std::array<float, maxSamples> m_pcmL{0.f};
+    std::array<float, maxSamples> m_pcmR{0.f};
+    int m_start{0};
+    size_t m_newSamples{0};
 
     // raw FFT data
-    std::array<double, 2 * FFT_LENGTH> freqL{0.0};
-    std::array<double, 2 * FFT_LENGTH> freqR{0.0};
+    std::array<double, 2 * fftLength> m_freqL{0.0};
+    std::array<double, 2 * fftLength> m_freqR{0.0};
     // magnitude data
-    std::array<float, FFT_LENGTH> spectrumL{0.f};
-    std::array<float, FFT_LENGTH> spectrumR{0.f};
+    std::array<float, fftLength> m_spectrumL{0.f};
+    std::array<float, fftLength> m_spectrumR{0.f};
 
-    std::array<double, FFT_LENGTH> w{0.0};
-    std::array<int, 34> ip{0};
+    std::array<double, fftLength> m_w{0.0};
+    std::array<int, 34> m_ip{0};
 
     // copy data out of the circular PCM buffer
-    void _copyPCM(float* PCMdata, int channel, size_t count);
-    void _copyPCM(double* PCMdata, int channel, size_t count);
+    void CopyPcm(float* pcmData, int channel, size_t count);
+    void CopyPcm(double* pcmData, int channel, size_t count);
 
     // update FFT data if new samples are available.
-    void _updateFFT();
-    void _updateFFTChannel(size_t channel);
+    void UpdateFFT();
+    void UpdateFFTChannel(size_t channel);
 
     friend class PCMTest;
 
@@ -114,22 +114,22 @@ private:
     class AutoLevel
     {
     public:
-        double updateLevel(size_t samples, double sum, double max);
+        double UpdateLevel(size_t samples, double sum, double max);
 
     private:
-        double level{0.01};
+        double m_level{0.01};
         // accumulate sample data
-        size_t level_samples{0};
-        double level_sum{0.0};
-        double level_max{0.0};
-        double l0{-1.0};
-        double l1{-1.0};
-        double l2{-1.0};
+        size_t m_levelSamples{0};
+        double m_levelSum{0.0};
+        double m_levelax{0.0};
+        double m_l0{-1.0};
+        double m_l1{-1.0};
+        double m_l2{-1.0};
     };
 
     // state for tracking audio level
-    double level;
-    AutoLevel leveler;
+    double m_level;
+    AutoLevel m_leveler;
 };
 
 #endif /** !_PCM_H */

--- a/src/libprojectM/PCM.hpp
+++ b/src/libprojectM/PCM.hpp
@@ -80,9 +80,8 @@ private:
     void AddPcm(
         const SampleType* pcmData,
         size_t lOffset,
-        size_t lStride,
         size_t rOffset,
-        size_t rStride,
+        size_t stride,
         size_t count);
 
     // mem-usage:

--- a/src/libprojectM/PCM.hpp
+++ b/src/libprojectM/PCM.hpp
@@ -101,8 +101,8 @@ private:
     std::array<int, 34> m_ip{0};
 
     // copy data out of the circular PCM buffer
-    void CopyPcm(float* pcmData, int channel, size_t count);
-    void CopyPcm(double* pcmData, int channel, size_t count);
+    void CopyPcm(float* to, int channel, size_t count);
+    void CopyPcm(double* to, int channel, size_t count);
 
     // update FFT data if new samples are available.
     void UpdateFFT();

--- a/src/libprojectM/PCM.hpp
+++ b/src/libprojectM/PCM.hpp
@@ -65,7 +65,7 @@ public:
      * smoothing does nothing
      * The returned data will 'wrap' if more than maxsamples are requested.
      */
-    void GetPcm(float* data, CHANNEL channel, size_t samples, float smoothing);
+    void GetPcm(float* data, CHANNEL channel, size_t samples, float smoothing) const;
 
     /** Spectrum data
      * smoothing does nothing
@@ -112,12 +112,12 @@ private:
     std::array<int, 34> m_ip{0};
 
     // copy data out of the circular PCM buffer
-    void CopyPcm(float* to, int channel, size_t count);
-    void CopyPcm(double* to, int channel, size_t count);
+    void CopyPcm(float* to, int channel, size_t count) const;
+    void CopyPcm(double* to, int channel, size_t count) const;
 
     // update FFT data if new samples are available.
     void UpdateFFT();
-    void UpdateFFTChannel(size_t channel);
+    void UpdateFftChannel(size_t channel);
 
     friend class PCMTest;
 

--- a/src/libprojectM/PCM.hpp
+++ b/src/libprojectM/PCM.hpp
@@ -31,7 +31,7 @@
 
 #include <array>
 #include <cstdint>
-#include <stdlib.h>
+#include <cstdlib>
 
 
 // FFT_LENGTH is number of magnitude values available from getSpectrum().
@@ -73,7 +73,7 @@ public:
      */
     void GetSpectrum(float* data, CHANNEL channel, size_t samples, float smoothing);
 
-    static Test* MakeTest();
+    static auto MakeTest() -> Test*;
 
 private:
     // mem-usage:
@@ -114,7 +114,7 @@ private:
     class AutoLevel
     {
     public:
-        double UpdateLevel(size_t samples, double sum, double max);
+        auto UpdateLevel(size_t samples, double sum, double max) -> double;
 
     private:
         double m_level{0.01};
@@ -128,8 +128,8 @@ private:
     };
 
     // state for tracking audio level
-    double m_level;
-    AutoLevel m_leveler;
+    double m_level{1.f};
+    AutoLevel m_leveler{};
 };
 
 #endif /** !_PCM_H */

--- a/src/libprojectM/PCM.hpp
+++ b/src/libprojectM/PCM.hpp
@@ -76,6 +76,15 @@ public:
     static auto MakeTest() -> Test*;
 
 private:
+    template<int signalAmplitude, int signalOffset, class SampleType>
+    void AddPcm(
+        const SampleType* pcmData,
+        size_t lOffset,
+        size_t lStride,
+        size_t rOffset,
+        size_t rStride,
+        size_t count);
+
     // mem-usage:
     // pcmd 2x2048*4b    = 16K
     // vdata 2x512x2*8b  = 16K

--- a/src/libprojectM/PCM.hpp
+++ b/src/libprojectM/PCM.hpp
@@ -76,13 +76,16 @@ public:
     static auto MakeTest() -> Test*;
 
 private:
-    template<int signalAmplitude, int signalOffset, class SampleType>
-    void AddPcm(
-        const SampleType* pcmData,
+    // CPP20: Could use a struct for the first 5 params to clarify on call site
+    // together with designated initializers
+    template<
         size_t lOffset,
         size_t rOffset,
         size_t stride,
-        size_t count);
+        int signalAmplitude,
+        int signalOffset,
+        class SampleType>
+    void AddPcm(const SampleType* pcmData, size_t count);
 
     // mem-usage:
     // pcmd 2x2048*4b    = 16K

--- a/src/libprojectM/PCM.hpp
+++ b/src/libprojectM/PCM.hpp
@@ -53,12 +53,24 @@ public:
     /* maximum number of sound samples that are actually stored. */
     static constexpr size_t maxSamples = 2048;
 
-    void AddPcmFloat(const float* pcmData, size_t count);
-    void AddPcmFloat2Ch(const float* pcmData, size_t count);
-    void AddPcm16(const int16_t pcmData[2][512]);
-    void AddPcm16Data(const int16_t* pcmData, size_t count);
-    void AddPcm8(const uint8_t pcmData[2][1024]);
-    void AddPcm8(const uint8_t pcmData[2][512]);
+    /**
+     * @brief Adds a mono pcm buffer to the storage
+     * @param samples The buffer to be added
+     * @param count The amount of samples in the buffer
+     */
+    void AddMono(const float* samples, size_t count);
+    void AddMono(const uint8_t* samples, size_t count);
+    void AddMono(const int16_t* samples, size_t count);
+
+    /**
+     * @brief Adds a stereo pcm buffer to the storage
+     * @param samples The buffer to be added.
+     * The channels are expected to be interleaved, LRLR.
+     * @param count The amount of samples in each channel (not total samples)
+     */
+    void AddStereo(const float* samples, size_t count);
+    void AddStereo(const uint8_t* samples, size_t count);
+    void AddStereo(const int16_t* samples, size_t count);
 
     /**
      * PCM data
@@ -83,7 +95,7 @@ private:
         int signalAmplitude,
         int signalOffset,
         class SampleType>
-    void AddPcm(const SampleType* pcmData, size_t count);
+    void AddPcm(const SampleType* samples, size_t count);
 
     // mem-usage:
     // pcmd 2x2048*4b    = 16K

--- a/src/libprojectM/PCM.hpp
+++ b/src/libprojectM/PCM.hpp
@@ -53,10 +53,10 @@ public:
     /* maximum number of sound samples that are actually stored. */
     static constexpr size_t maxSamples = 2048;
 
-    void AddPcmFloat(const float* pcmData, size_t samples);
+    void AddPcmFloat(const float* pcmData, size_t count);
     void AddPcmFloat2Ch(const float* pcmData, size_t count);
     void AddPcm16(const int16_t pcmData[2][512]);
-    void AddPcm16Data(const int16_t* pcmData, size_t samples);
+    void AddPcm16Data(const int16_t* pcmData, size_t count);
     void AddPcm8(const uint8_t pcmData[2][1024]);
     void AddPcm8(const uint8_t pcmData[2][512]);
 
@@ -96,7 +96,7 @@ private:
     // normalize to range [-1.0,1.0]
     std::array<float, maxSamples> m_pcmL{0.f};
     std::array<float, maxSamples> m_pcmR{0.f};
-    int m_start{0};
+    size_t m_start{0};
     size_t m_newSamples{0};
 
     // raw FFT data
@@ -110,8 +110,8 @@ private:
     std::array<int, 34> m_ip{0};
 
     // copy data out of the circular PCM buffer
-    void CopyPcm(float* to, int channel, size_t count) const;
-    void CopyPcm(double* to, int channel, size_t count) const;
+    void CopyPcm(float* to, size_t channel, size_t count) const;
+    void CopyPcm(double* to, size_t channel, size_t count) const;
 
     // update FFT data if new samples are available.
     void UpdateFFT();

--- a/src/libprojectM/PCM.hpp
+++ b/src/libprojectM/PCM.hpp
@@ -62,16 +62,14 @@ public:
 
     /**
      * PCM data
-     * smoothing does nothing
      * The returned data will 'wrap' if more than maxsamples are requested.
      */
-    void GetPcm(float* data, CHANNEL channel, size_t samples, float smoothing) const;
+    void GetPcm(float* data, CHANNEL channel, size_t samples) const;
 
     /** Spectrum data
-     * smoothing does nothing
      * The returned data will be zero padded if more than FFT_LENGTH values are requested
      */
-    void GetSpectrum(float* data, CHANNEL channel, size_t samples, float smoothing);
+    void GetSpectrum(float* data, CHANNEL channel, size_t samples);
 
     static auto MakeTest() -> Test*;
 

--- a/src/libprojectM/ProjectMCWrapper.cpp
+++ b/src/libprojectM/ProjectMCWrapper.cpp
@@ -729,41 +729,41 @@ bool projectm_get_error_loading_current_preset(projectm_handle instance)
 
 unsigned int projectm_pcm_get_max_samples()
 {
-    return PCM::maxSamples;
+    return Pcm::maxSamples;
 }
 
 void projectm_pcm_add_float_1ch_data(projectm_handle instance, const float* pcm_data, unsigned int sample_count)
 {
     auto projectMInstance = handle_to_instance(instance);
-    projectMInstance->pcm()->addPCMfloat(pcm_data, sample_count);
+    projectMInstance->pcm()->AddPcmFloat(pcm_data, sample_count);
 }
 
 void projectm_pcm_add_float_2ch_data(projectm_handle instance, const float* pcm_data, unsigned int sample_count)
 {
     auto projectMInstance = handle_to_instance(instance);
-    projectMInstance->pcm()->addPCMfloat_2ch(pcm_data, sample_count);
+    projectMInstance->pcm()->AddPcmFloat2Ch(pcm_data, sample_count);
 }
 
 void projectm_pcm_add_16bit_2ch_512(projectm_handle instance, const short (* pcm_data)[512])
 {
     auto projectMInstance = handle_to_instance(instance);
-    projectMInstance->pcm()->addPCM16(pcm_data);
+    projectMInstance->pcm()->AddPcm16(pcm_data);
 }
 
 void projectm_pcm_add_16bit_2ch_data(projectm_handle instance, const short* pcm_data, unsigned int sample_count)
 {
     auto projectMInstance = handle_to_instance(instance);
-    projectMInstance->pcm()->addPCM16Data(pcm_data, sample_count);
+    projectMInstance->pcm()->AddPcm16Data(pcm_data, sample_count);
 }
 
 void projectm_pcm_add_8bit_2ch_1024(projectm_handle instance, const unsigned char (* pcm_data)[1024])
 {
     auto projectMInstance = handle_to_instance(instance);
-    projectMInstance->pcm()->addPCM8(pcm_data);
+    projectMInstance->pcm()->AddPcm8(pcm_data);
 }
 
 void projectm_pcm_add_8bit_2ch_512(projectm_handle instance, const unsigned char (* pcm_data)[512])
 {
     auto projectMInstance = handle_to_instance(instance);
-    projectMInstance->pcm()->addPCM8_512(pcm_data);
+    projectMInstance->pcm()->AddPcm8(pcm_data);
 }

--- a/src/libprojectM/ProjectMCWrapper.cpp
+++ b/src/libprojectM/ProjectMCWrapper.cpp
@@ -732,38 +732,30 @@ unsigned int projectm_pcm_get_max_samples()
     return Pcm::maxSamples;
 }
 
-void projectm_pcm_add_float_1ch_data(projectm_handle instance, const float* pcm_data, unsigned int sample_count)
+template<class BufferType>
+static auto PcmAdd(projectm_handle instance, const BufferType* samples, unsigned int count, projectm_channels channels) -> void
 {
-    auto projectMInstance = handle_to_instance(instance);
-    projectMInstance->pcm()->AddPcmFloat(pcm_data, sample_count);
+    auto* projectMInstance = handle_to_instance(instance);
+
+    if(channels == PROJECTM_MONO) {
+        projectMInstance->pcm()->AddMono(samples, count);
+    }
+    else {
+        projectMInstance->pcm()->AddStereo(samples, count);
+    }
 }
 
-void projectm_pcm_add_float_2ch_data(projectm_handle instance, const float* pcm_data, unsigned int sample_count)
+auto projectm_pcm_add_float(projectm_handle instance, const float* samples, unsigned int count, projectm_channels channels) -> void
 {
-    auto projectMInstance = handle_to_instance(instance);
-    projectMInstance->pcm()->AddPcmFloat2Ch(pcm_data, sample_count);
+    PcmAdd(instance, samples, count, channels);
 }
 
-void projectm_pcm_add_16bit_2ch_512(projectm_handle instance, const short (* pcm_data)[512])
+auto projectm_pcm_add_int16(projectm_handle instance, const int16_t* samples, unsigned int count, projectm_channels channels) -> void
 {
-    auto projectMInstance = handle_to_instance(instance);
-    projectMInstance->pcm()->AddPcm16(pcm_data);
+    PcmAdd(instance, samples, count, channels);
 }
 
-void projectm_pcm_add_16bit_2ch_data(projectm_handle instance, const short* pcm_data, unsigned int sample_count)
+auto projectm_pcm_add_uint8(projectm_handle instance, const uint8_t* samples, unsigned int count, projectm_channels channels) -> void
 {
-    auto projectMInstance = handle_to_instance(instance);
-    projectMInstance->pcm()->AddPcm16Data(pcm_data, sample_count);
-}
-
-void projectm_pcm_add_8bit_2ch_1024(projectm_handle instance, const unsigned char (* pcm_data)[1024])
-{
-    auto projectMInstance = handle_to_instance(instance);
-    projectMInstance->pcm()->AddPcm8(pcm_data);
-}
-
-void projectm_pcm_add_8bit_2ch_512(projectm_handle instance, const unsigned char (* pcm_data)[512])
-{
-    auto projectMInstance = handle_to_instance(instance);
-    projectMInstance->pcm()->AddPcm8(pcm_data);
+    PcmAdd(instance, samples, count, channels);
 }

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -64,8 +64,8 @@ void BeatDetect::calculateBeatStatistics()
     size_t constexpr fft_length = fftLength;
     float vdataL[fftLength];
     float vdataR[fftLength];
-    pcm.GetSpectrum(vdataL, CHANNEL_0, fftLength, 0.0);
-    pcm.GetSpectrum(vdataR, CHANNEL_1, fftLength, 0.0);
+    pcm.GetSpectrum(vdataL, CHANNEL_0, fftLength);
+    pcm.GetSpectrum(vdataR, CHANNEL_1, fftLength);
 
 
     static_assert(fft_length >= 256, "fft_length too small");

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -39,7 +39,7 @@
 #include <cmath>
 
 
-BeatDetect::BeatDetect(PCM& _pcm)
+BeatDetect::BeatDetect(Pcm& _pcm)
     : pcm(_pcm)
 {
 }
@@ -61,11 +61,11 @@ void BeatDetect::reset()
 
 void BeatDetect::calculateBeatStatistics()
 {
-    size_t constexpr fft_length = FFT_LENGTH;
-    float vdataL[FFT_LENGTH];
-    float vdataR[FFT_LENGTH];
-    pcm.getSpectrum(vdataL, CHANNEL_0, FFT_LENGTH, 0.0);
-    pcm.getSpectrum(vdataR, CHANNEL_1, FFT_LENGTH, 0.0);
+    size_t constexpr fft_length = fftLength;
+    float vdataL[fftLength];
+    float vdataR[fftLength];
+    pcm.GetSpectrum(vdataL, CHANNEL_0, fftLength, 0.0);
+    pcm.GetSpectrum(vdataR, CHANNEL_1, fftLength, 0.0);
 
 
     static_assert(fft_length >= 256, "fft_length too small");

--- a/src/libprojectM/Renderer/BeatDetect.hpp
+++ b/src/libprojectM/Renderer/BeatDetect.hpp
@@ -37,7 +37,7 @@
 class BeatDetect
 {
 public:
-    explicit BeatDetect(PCM& pcm);
+    explicit BeatDetect(Pcm& pcm);
     void reset();
 
     /**
@@ -66,7 +66,7 @@ public:
     float vol{0.f};
     float vol_att{0.f};
 
-    PCM& pcm;
+    Pcm& pcm;
 
 private:
     // this is the size of the buffer used to determine avg levels of the input audio

--- a/src/libprojectM/Renderer/MilkdropWaveform.cpp
+++ b/src/libprojectM/Renderer/MilkdropWaveform.cpp
@@ -255,12 +255,12 @@ void MilkdropWaveform::WaveformMath(RenderContext& context)
 
     if (mode != MilkdropWaveformMode::SpectrumLine)
     {
-        context.beatDetect->pcm.getPCM(pcmDataL.data(), CHANNEL_0, pcmDataL.size(), smoothing);
-        context.beatDetect->pcm.getPCM(pcmDataR.data(), CHANNEL_1, pcmDataL.size(), smoothing);
+        context.beatDetect->pcm.GetPcm(pcmDataL.data(), CHANNEL_0, pcmDataL.size(), smoothing);
+        context.beatDetect->pcm.GetPcm(pcmDataR.data(), CHANNEL_1, pcmDataL.size(), smoothing);
     }
     else
     {
-        context.beatDetect->pcm.getSpectrum(pcmDataL.data(), CHANNEL_0, pcmDataL.size(), smoothing);
+        context.beatDetect->pcm.GetSpectrum(pcmDataL.data(), CHANNEL_0, pcmDataL.size(), smoothing);
     }
 
     // tie size of waveform to beatSensitivity

--- a/src/libprojectM/Renderer/MilkdropWaveform.cpp
+++ b/src/libprojectM/Renderer/MilkdropWaveform.cpp
@@ -255,12 +255,12 @@ void MilkdropWaveform::WaveformMath(RenderContext& context)
 
     if (mode != MilkdropWaveformMode::SpectrumLine)
     {
-        context.beatDetect->pcm.GetPcm(pcmDataL.data(), CHANNEL_0, pcmDataL.size(), smoothing);
-        context.beatDetect->pcm.GetPcm(pcmDataR.data(), CHANNEL_1, pcmDataL.size(), smoothing);
+        context.beatDetect->pcm.GetPcm(pcmDataL.data(), CHANNEL_0, pcmDataL.size());
+        context.beatDetect->pcm.GetPcm(pcmDataR.data(), CHANNEL_1, pcmDataL.size());
     }
     else
     {
-        context.beatDetect->pcm.GetSpectrum(pcmDataL.data(), CHANNEL_0, pcmDataL.size(), smoothing);
+        context.beatDetect->pcm.GetSpectrum(pcmDataL.data(), CHANNEL_0, pcmDataL.size());
     }
 
     // tie size of waveform to beatSensitivity

--- a/src/libprojectM/Renderer/MilkdropWaveform.hpp
+++ b/src/libprojectM/Renderer/MilkdropWaveform.hpp
@@ -52,7 +52,7 @@ public:
 	bool modulateAlphaByVolume{ false };
 	bool maximizeColors{ false };
 	float scale{ 10.0f };
-	float smoothing{ 0.0f };
+	float smoothing{ 0.0f }; // DOES NOTHING
 
 	float modOpacityStart{ 0.0f };
 	float modOpacityEnd{ 1.0f };

--- a/src/libprojectM/Renderer/Waveform.cpp
+++ b/src/libprojectM/Renderer/Waveform.cpp
@@ -39,13 +39,13 @@ void Waveform::Draw(RenderContext &context)
 
     if (spectrum)
     {
-        context.beatDetect->pcm.GetSpectrum(pcmL, CHANNEL_0, sampleCount, 0.0f );
-        context.beatDetect->pcm.GetSpectrum(pcmR, CHANNEL_1, sampleCount, 0.0f );
+        context.beatDetect->pcm.GetSpectrum(pcmL, CHANNEL_0, sampleCount);
+        context.beatDetect->pcm.GetSpectrum(pcmR, CHANNEL_1, sampleCount);
     }
     else
     {
-        context.beatDetect->pcm.GetPcm(pcmL, CHANNEL_0, sampleCount, 0.0f );
-        context.beatDetect->pcm.GetPcm(pcmR, CHANNEL_1, sampleCount, 0.0f );
+        context.beatDetect->pcm.GetPcm(pcmL, CHANNEL_0, sampleCount);
+        context.beatDetect->pcm.GetPcm(pcmR, CHANNEL_1, sampleCount);
     }
 
     const float mult = scaling * vol_scale * (spectrum ? 0.05f : 1.0f);

--- a/src/libprojectM/Renderer/Waveform.cpp
+++ b/src/libprojectM/Renderer/Waveform.cpp
@@ -39,13 +39,13 @@ void Waveform::Draw(RenderContext &context)
 
     if (spectrum)
     {
-        context.beatDetect->pcm.getSpectrum(pcmL, CHANNEL_0, sampleCount, 0.0f );
-        context.beatDetect->pcm.getSpectrum(pcmR, CHANNEL_1, sampleCount, 0.0f );
+        context.beatDetect->pcm.GetSpectrum(pcmL, CHANNEL_0, sampleCount, 0.0f );
+        context.beatDetect->pcm.GetSpectrum(pcmR, CHANNEL_1, sampleCount, 0.0f );
     }
     else
     {
-        context.beatDetect->pcm.getPCM(pcmL, CHANNEL_0, sampleCount, 0.0f );
-        context.beatDetect->pcm.getPCM(pcmR, CHANNEL_1, sampleCount, 0.0f );
+        context.beatDetect->pcm.GetPcm(pcmL, CHANNEL_0, sampleCount, 0.0f );
+        context.beatDetect->pcm.GetPcm(pcmR, CHANNEL_1, sampleCount, 0.0f );
     }
 
     const float mult = scaling * vol_scale * (spectrum ? 0.05f : 1.0f);

--- a/src/libprojectM/TestRunner.cpp
+++ b/src/libprojectM/TestRunner.cpp
@@ -27,7 +27,7 @@ bool TestRunner::run()
         tests.push_back(Param::test());
         tests.push_back(Parser::test());
         tests.push_back(Expr::test());
-        tests.push_back(PCM::test());
+        tests.push_back(Pcm::MakeTest());
     }
 
     int count = 0;

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -592,7 +592,7 @@ void projectM::projectM_init(int gx, int gy, int fps, int texsize, int width, in
 
     if (!_pcm)
     {
-        _pcm = new PCM();
+        _pcm = new Pcm();
     }
     assert(pcm());
     beatDetect = new BeatDetect(*_pcm);

--- a/src/libprojectM/projectM.h
+++ b/src/libprojectM/projectM.h
@@ -80,6 +80,14 @@ enum projectm_flags
 };
 
 /**
+ * For specifying audio data format.
+ */
+enum projectm_channels {
+    PROJECTM_MONO = 1,
+    PROJECTM_STEREO = 2
+};
+
+/**
  * Rating types supported by projectM. Used to control preset selection for different types
  * of transitions (hard/soft).
  */
@@ -967,100 +975,56 @@ PROJECTM_EXPORT bool projectm_get_error_loading_current_preset(projectm_handle i
 PROJECTM_EXPORT unsigned int projectm_pcm_get_max_samples();
 
 /**
- * @brief Adds 1-channel 32-bit floating-point audio samples.
+ * @brief Adds 32-bit floating-point audio samples.
  *
- * <p>This function is used to add new audio data to projectM's internal audio buffer. It is internally converted
- * to 2-channel float data, duplicating the channel.</p>
+ * This function is used to add new audio data to projectM's internal audio buffer. It is internally converted
+ * to 2-channel float data, duplicating the channel.
  *
- * <p>If possible, always use projectm_pcm_add_float_2ch_data() for best performance and quality.</p>
+ * If stereo, the channel order in samples is LRLRLR.
  *
  * @param instance The projectM instance handle.
- * @param pcm_data An array of PCM samples.
- * @param sample_count The number of audio samples in pcm_data.
+ * @param samples An array of PCM samples.
+ * Each sample is expected to be within the range -1 to 1.
+ * @param count The number of audio samples in a channel.
+ * @param channels If the buffer is mono or stereo.
+ * Can be PROJECTM_MONO or PROJECTM_STEREO.
  */
-PROJECTM_EXPORT void projectm_pcm_add_float_1ch_data(projectm_handle instance, const float* pcm_data,
-                                                     unsigned int sample_count);
+PROJECTM_EXPORT void projectm_pcm_add_float(projectm_handle instance, const float* samples,
+                                                     unsigned int count, projectm_channels channels);
 
 /**
- * @brief Adds 2-channel 32-bit floating-point audio samples.
+ * @brief Adds 16-bit integer audio samples.
  *
- * <p>This function is used to add new audio data to projectM's internal audio buffer.</p>
+ * This function is used to add new audio data to projectM's internal audio buffer. It is internally converted
+ * to 2-channel float data, duplicating the channel.
  *
- * <p>This function represents projectM's internal audio data format. If possible, always use this function for best
- * performance and quality.</p>
- *
- * <p>Channel order in pcm_data is LRLRLR.</p>
+ * If stereo, the channel order in samples is LRLRLR.
  *
  * @param instance The projectM instance handle.
- * @param pcm_data An array of PCM samples, two floats per sample.
- * @param sample_count The number of audio samples in pcm_data. Half the actual size of pcm_data.
+ * @param samples An array of PCM samples.
+ * @param count The number of audio samples in a channel.
+ * @param channels If the buffer is mono or stereo.
+ * Can be PROJECTM_MONO or PROJECTM_STEREO.
  */
-PROJECTM_EXPORT void projectm_pcm_add_float_2ch_data(projectm_handle instance, const float* pcm_data,
-                                                     unsigned int sample_count);
+PROJECTM_EXPORT void projectm_pcm_add_int16(projectm_handle instance, const int16_t* samples,
+                                                     unsigned int count, projectm_channels channels);
 
 /**
- * @brief Adds 512 2-channel 16-bit integer audio samples.
+ * @brief Adds 8-bit unsigned integer audio samples.
  *
- * <p>This function is used to add new audio data to projectM's internal audio buffer. It is internally converted
- * to 2-channel float data.</p>
+ * This function is used to add new audio data to projectM's internal audio buffer. It is internally converted
+ * to 2-channel float data, duplicating the channel.
  *
- * <p>If possible, always use projectm_pcm_add_float_2ch_data() for best performance and quality.</p>
- *
- * <p>Channel indices are 0 for the left channel and 1 for the right channel. Use the projectm_pcm_channel
- * enum values instead of numerical indices for readability.</p>
+ * If stereo, the channel order in samples is LRLRLR.
  *
  * @param instance The projectM instance handle.
- * @param pcm_data The audio data.
+ * @param samples An array of PCM samples.
+ * @param count The number of audio samples in a channel.
+ * @param channels If the buffer is mono or stereo.
+ * Can be PROJECTM_MONO or PROJECTM_STEREO.
  */
-PROJECTM_EXPORT void projectm_pcm_add_16bit_2ch_512(projectm_handle instance, const short pcm_data[2][512]);
-
-/**
- * @brief Adds 2-channel 16-bit integer audio samples.</p>
- *
- * <p>This function is used to add new audio data to projectM's internal audio buffer. It is internally converted
- * to 2-channel float data.</p>
- *
- * <p>If possible, always use projectm_pcm_add_float_2ch_data() for best performance and quality.</p>
- *
- * <p>Channel order in pcm_data is LRLRLR.</p>
- *
- * @param instance The projectM instance handle.
- * @param pcm_data The audio data.
- */
-PROJECTM_EXPORT void projectm_pcm_add_16bit_2ch_data(projectm_handle instance, const short* pcm_data,
-                                                     unsigned int sample_count);
-
-/**
- * @brief Adds 1024 2-channel 8-bit integer audio samples.
- *
- * <p>This function is used to add new audio data to projectM's internal audio buffer. It is internally converted
- * to 2-channel float data.</p>
- *
- * <p>If possible, always use projectm_pcm_add_float_2ch_data() for best performance and quality.</p>
- *
- * <p>Channel indices are 0 for the left channel and 1 for the right channel. Use the projectm_pcm_channel
- * enum values instead of numerical indices for readability.</p>
- *
- * @param instance The projectM instance handle.
- * @param pcm_data The audio data.
- */
-PROJECTM_EXPORT void projectm_pcm_add_8bit_2ch_1024(projectm_handle instance, const unsigned char pcm_data[2][1024]);
-
-/**
- * @brief Adds 512 2-channel 8-bit integer audio samples.
- *
- * <p>This function is used to add new audio data to projectM's internal audio buffer. It is internally converted
- * to 2-channel float data.</p>
- *
- * <p>If possible, always use projectm_pcm_add_float_2ch_data() for best performance and quality.</p>
- *
- * <p>Channel indices are 0 for the left channel and 1 for the right channel. Use the projectm_pcm_channel
- * enum values instead of numerical indices for readability.</p>
- *
- * @param instance The projectM instance handle.
- * @param pcm_data The audio data.
- */
-PROJECTM_EXPORT void projectm_pcm_add_8bit_2ch_512(projectm_handle instance, const unsigned char pcm_data[2][512]);
+PROJECTM_EXPORT void projectm_pcm_add_uint8(projectm_handle instance, const uint8_t* samples,
+                                                     unsigned int count, projectm_channels channels);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/libprojectM/projectM.hpp
+++ b/src/libprojectM/projectM.hpp
@@ -77,7 +77,7 @@ class PipelineContext;
 
 class BeatDetect;
 
-class PCM;
+class Pcm;
 
 class Func;
 
@@ -260,7 +260,6 @@ public:
     /// Writes a settings configuration to the specified file
     static bool writeConfig(const std::string& configFile, const Settings& settings);
 
-
     /// Sets preset iterator position to the passed in index
     void selectPresetPosition(unsigned int index);
 
@@ -382,7 +381,7 @@ public:
     };
 
 
-    inline PCM* pcm()
+    inline Pcm* pcm()
     {
         return _pcm;
     }
@@ -432,10 +431,9 @@ public:
     Renderer* renderer;
 
 private:
-    PCM* _pcm;
+    Pcm* _pcm;
 
     double sampledPresetDuration();
-
     BeatDetect* beatDetect;
     PipelineContext* _pipelineContext;
     PipelineContext* _pipelineContext2;

--- a/src/sdl-test-ui/audioCapture.cpp
+++ b/src/sdl-test-ui/audioCapture.cpp
@@ -52,26 +52,13 @@ void projectMSDL::audioInputCallbackF32(void *userdata, unsigned char *stream, i
 //        printf("%X ", stream[i]);
     // stream is (i think) samples*channels floats (native byte order) of len BYTES
     if (app->audioChannelsCount == 1)
-        projectm_pcm_add_float_1ch_data(app->_projectM, reinterpret_cast<float*>(stream), len/sizeof(float));
+        projectm_pcm_add_float(app->_projectM, reinterpret_cast<float*>(stream), len/sizeof(float)/2, PROJECTM_MONO);
     else if (app->audioChannelsCount == 2)
-        projectm_pcm_add_float_2ch_data(app->_projectM, reinterpret_cast<float*>(stream), len/sizeof(float));
+        projectm_pcm_add_float(app->_projectM, reinterpret_cast<float*>(stream), len/sizeof(float)/2, PROJECTM_STEREO);
     else {
         SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, "Multichannel audio not supported");
         SDL_Quit();
     }
-}
-
-void projectMSDL::audioInputCallbackS16(void *userdata, unsigned char *stream, int len) {
-    //    printf("LEN: %i\n", len);
-    projectMSDL *app = (projectMSDL *) userdata;
-    short pcm16[2][512];
-
-    for (int i = 0; i < 512; i++) {
-        for (int j = 0; j < app->audioChannelsCount; j++) {
-            pcm16[j][i] = stream[i+j];
-        }
-    }
-    projectm_pcm_add_16bit_2ch_512(app->_projectM, pcm16);
 }
 
 int projectMSDL::toggleAudioInput() {

--- a/src/sdl-test-ui/pmSDL.cpp
+++ b/src/sdl-test-ui/pmSDL.cpp
@@ -312,29 +312,29 @@ void projectMSDL::keyHandler(SDL_Event* sdl_evt)
 void projectMSDL::addFakePCM()
 {
     int i;
-    short pcm_data[2][512];
+    int16_t pcm_data[2*512];
     /** Produce some fake PCM data to stuff into projectM */
     for (i = 0; i < 512; i++)
     {
         if (i % 2 == 0)
         {
-            pcm_data[0][i] = (float) (rand() / ((float) RAND_MAX) * (pow(2, 14)));
-            pcm_data[1][i] = (float) (rand() / ((float) RAND_MAX) * (pow(2, 14)));
+            pcm_data[2*i] = (float) (rand() / ((float) RAND_MAX) * (pow(2, 14)));
+            pcm_data[2*i+1] = (float) (rand() / ((float) RAND_MAX) * (pow(2, 14)));
         }
         else
         {
-            pcm_data[0][i] = (float) (rand() / ((float) RAND_MAX) * (pow(2, 14)));
-            pcm_data[1][i] = (float) (rand() / ((float) RAND_MAX) * (pow(2, 14)));
+            pcm_data[2*i] = (float) (rand() / ((float) RAND_MAX) * (pow(2, 14)));
+            pcm_data[2*i+1] = (float) (rand() / ((float) RAND_MAX) * (pow(2, 14)));
         }
         if (i % 2 == 1)
         {
-            pcm_data[0][i] = -pcm_data[0][i];
-            pcm_data[1][i] = -pcm_data[1][i];
+            pcm_data[2*i] = -pcm_data[2*i];
+            pcm_data[2*i+1] = -pcm_data[2*i+1];
         }
     }
 
     /** Add the waveform data */
-    projectm_pcm_add_16bit_2ch_512(_projectM, pcm_data);
+    projectm_pcm_add_int16(_projectM, pcm_data, 512, PROJECTM_STEREO);
 }
 
 void projectMSDL::resize(unsigned int width_, unsigned int height_)


### PR DESCRIPTION
There is a bit of a mix between doubles and floats,
e.g. m_freqL vs m_spectrumL.
Is there some fundamental reason we wouldn't want to use doubles across the
board?

This depends on #595