### PR TITLE
More BeatDetect cleanup (and one bugfix)

### DIFF
--- a/src/libprojectM/MilkdropPresetFactory/PresetFrameIO.cpp
+++ b/src/libprojectM/MilkdropPresetFactory/PresetFrameIO.cpp
@@ -24,9 +24,9 @@ void PresetInputs::update(const BeatDetect & music, const PipelineContext & cont
     this->bass = music.bass * music.beatSensitivity;
     this->mid = music.mid * music.beatSensitivity;
     this->treb = music.treb * music.beatSensitivity;
-    this->bass_att = music.bass_att * music.beatSensitivity;
-    this->mid_att = music.mid_att * music.beatSensitivity;
-    this->treb_att = music.treb_att * music.beatSensitivity;
+    this->bass_att = music.bassAtt * music.beatSensitivity;
+    this->mid_att = music.midAtt * music.beatSensitivity;
+    this->treb_att = music.trebAtt * music.beatSensitivity;
 
     // Reflect new values from the pipeline context
     this->fps = context.fps;

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -92,19 +92,6 @@ void BeatDetect::CalculateBeatStatistics()
     treb = trebInstant / std::max(0.0001f, trebSmoothed.Get());
     vol = volInstant / std::max(0.0001f, volSmoothed.Get());
 
-    if (std::isnan(treb))
-    {
-        treb = 0.0;
-    }
-    if (std::isnan(mid))
-    {
-        mid = 0.0;
-    }
-    if (std::isnan(bass))
-    {
-        bass = 0.0;
-    }
-
     trebAtt = .6f * trebAtt + .4f * treb;
     midAtt = .6f * midAtt + .4f * mid;
     bassAtt = .6f * bassAtt + .4f * bass;

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -61,6 +61,8 @@ void BeatDetect::reset()
 
 void BeatDetect::calculateBeatStatistics()
 {
+    vol_old = vol;
+
     size_t constexpr fft_length = fftLength;
     float vdataL[fftLength];
     float vdataR[fftLength];

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -59,6 +59,12 @@ void BeatDetect::Reset()
 }
 
 
+float BeatDetect::GetPCMScale()
+{
+    return beatSensitivity;
+}
+
+
 void BeatDetect::CalculateBeatStatistics()
 {
     volOld = vol;
@@ -97,4 +103,21 @@ void BeatDetect::CalculateBeatStatistics()
 
     float const volIntensity = bassIntensity + midIntensity + trebIntensity;
     updateBand(vol, volAtt, volSmoothed, volIntensity);
+}
+
+
+auto BeatDetect::LowPassFilter::Update(float nextValue) noexcept -> void
+{
+    m_current -= m_buffer[m_bufferPos] / bufferLength;
+    m_current += nextValue / bufferLength;
+    m_buffer[m_bufferPos] = nextValue;
+
+    ++m_bufferPos;
+    m_bufferPos %= bufferLength;
+}
+
+
+auto BeatDetect::LowPassFilter::Get() const noexcept -> float
+{
+    return m_current;
 }

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -46,22 +46,22 @@ BeatDetect::BeatDetect(Pcm& _pcm)
 }
 
 
-void BeatDetect::reset()
+void BeatDetect::Reset()
 {
     this->treb = 0;
     this->mid = 0;
     this->bass = 0;
-    this->treb_att = 0;
-    this->mid_att = 0;
-    this->bass_att = 0;
-    this->vol_att = 0;
-    this->vol_old = 0;
+    this->trebAtt = 0;
+    this->midAtt = 0;
+    this->bassAtt = 0;
+    this->volAtt = 0;
+    this->volOld = 0;
 }
 
 
-void BeatDetect::calculateBeatStatistics()
+void BeatDetect::CalculateBeatStatistics()
 {
-    vol_old = vol;
+    volOld = vol;
 
     std::array<float, fftLength> vdataL{};
     std::array<float, fftLength> vdataR{};
@@ -77,20 +77,20 @@ void BeatDetect::calculateBeatStatistics()
     static_assert(fftLength >= 256, "fftLength too small");
     std::array<size_t, 4> constexpr ranges{0, 3, 23, 255};
 
-    float const bass_instant = intensityBetween(ranges[0], ranges[1]);
-    float const mid_instant = intensityBetween(ranges[1], ranges[2]);
-    float const treb_instant = intensityBetween(ranges[2], ranges[3]);
-    float const vol_instant = (bass_instant + mid_instant + treb_instant) / 3.0f;
+    float const bassInstant = intensityBetween(ranges[0], ranges[1]);
+    float const midInstant = intensityBetween(ranges[1], ranges[2]);
+    float const trebInstant = intensityBetween(ranges[2], ranges[3]);
+    float const volInstant = (bassInstant + midInstant + trebInstant) / 3.0f;
 
-    bass_history.Update(bass_instant);
-    mid_history.Update(mid_instant);
-    treb_history.Update(treb_instant);
-    vol_history.Update(vol_instant);
+    bassSmoothed.Update(bassInstant);
+    midSmoothed.Update(midInstant);
+    trebSmoothed.Update(trebInstant);
+    volSmoothed.Update(volInstant);
 
-    bass = bass_instant / std::max(0.0001f, bass_history.Get());
-    mid = mid_instant / std::max(0.0001f, mid_history.Get());
-    treb = treb_instant / std::max(0.0001f, treb_history.Get());
-    vol = vol_instant / std::max(0.0001f, vol_history.Get());
+    bass = bassInstant / std::max(0.0001f, bassSmoothed.Get());
+    mid = midInstant / std::max(0.0001f, midSmoothed.Get());
+    treb = trebInstant / std::max(0.0001f, trebSmoothed.Get());
+    vol = volInstant / std::max(0.0001f, volSmoothed.Get());
 
     if (std::isnan(treb))
     {
@@ -105,17 +105,17 @@ void BeatDetect::calculateBeatStatistics()
         bass = 0.0;
     }
 
-    treb_att = .6f * treb_att + .4f * treb;
-    mid_att = .6f * mid_att + .4f * mid;
-    bass_att = .6f * bass_att + .4f * bass;
-    vol_att = .6f * vol_att + .4f * vol;
+    trebAtt = .6f * trebAtt + .4f * treb;
+    midAtt = .6f * midAtt + .4f * mid;
+    bassAtt = .6f * bassAtt + .4f * bass;
+    volAtt = .6f * volAtt + .4f * vol;
 
-    bass_att = std::min(bass_att, 100.f);
+    bassAtt = std::min(bassAtt, 100.f);
     bass = std::min(bass, 100.f);
-    mid_att = std::min(mid_att, 100.f);
+    midAtt = std::min(midAtt, 100.f);
     mid = std::min(mid, 100.f);
-    treb_att = std::min(treb_att, 100.f);
+    trebAtt = std::min(trebAtt, 100.f);
     treb = std::min(treb, 100.f);
-    vol_att = std::min(vol_att, 100.f);
+    volAtt = std::min(volAtt, 100.f);
     vol = std::min(vol, 100.f);
 }

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -56,7 +56,6 @@ void BeatDetect::reset()
     this->bass_att = 0;
     this->vol_att = 0;
     this->vol_old = 0;
-    this->vol_instant = 0;
 }
 
 

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -78,8 +78,7 @@ void BeatDetect::calculateBeatStatistics()
             size_t const from,
             size_t const to,
             float& instant,
-            float& history,
-            std::array<float, BEAT_HISTORY_LENGTH>& buffer) {
+            LowPassFilter& history) {
             instant = 0.f;
 
             for (unsigned i = from; i < to; i++)
@@ -87,22 +86,20 @@ void BeatDetect::calculateBeatStatistics()
                 instant += vdataL[i] + vdataR[i];
             }
 
-            history -= buffer[beat_buffer_pos] / static_cast<float>(buffer.size());
-            history += instant / static_cast<float>(buffer.size());
-            buffer[beat_buffer_pos] = instant;
+            history.Update(instant);
         };
 
-    updateFrequency(ranges[0], ranges[1], bass_instant, bass_history, bass_buffer);
-    updateFrequency(ranges[1], ranges[2], mid_instant, mid_history, mid_buffer);
-    updateFrequency(ranges[2], ranges[3], treb_instant, treb_history, treb_buffer);
+    updateFrequency(ranges[0], ranges[1], bass_instant, bass_history);
+    updateFrequency(ranges[1], ranges[2], mid_instant, mid_history);
+    updateFrequency(ranges[2], ranges[3], treb_instant, treb_history);
 
     vol_instant = (bass_instant + mid_instant + treb_instant) / 3.0f;
-    vol_history = (bass_history + mid_history + treb_history) / 3.0f;
+    vol_history.Update(vol_instant);
 
-    bass = bass_instant / std::max(0.0001f, bass_history);
-    mid = mid_instant / std::max(0.0001f, mid_history);
-    treb = treb_instant / std::max(0.0001f, treb_history);
-    vol = vol_instant / std::max(0.0001f, vol_history);
+    bass = bass_instant / std::max(0.0001f, bass_history.Get());
+    mid = mid_instant / std::max(0.0001f, mid_history.Get());
+    treb = treb_instant / std::max(0.0001f, treb_history.Get());
+    vol = vol_instant / std::max(0.0001f, vol_history.Get());
 
     if (std::isnan(treb))
     {
@@ -130,8 +127,4 @@ void BeatDetect::calculateBeatStatistics()
     treb = std::min(treb, 100.f);
     vol_att = std::min(vol_att, 100.f);
     vol = std::min(vol, 100.f);
-
-    beat_buffer_pos++;
-    if (beat_buffer_pos > 79)
-        beat_buffer_pos = 0;
 }

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -71,35 +71,34 @@ void BeatDetect::calculateBeatStatistics()
 
     static_assert(fftLength >= 256, "fft_length too small");
 
-    unsigned ranges[4] = {0, 3, 23, 255};
+    size_t constexpr ranges[4] = {0, 3, 23, 255};
 
-    bass_instant = 0;
-    for (unsigned i = ranges[0]; i < ranges[1]; i++)
-        bass_instant += vdataL[i] + vdataR[i];
-    bass_history -= bass_buffer[beat_buffer_pos] * (1.0 / bass_buffer.size());
-    bass_buffer[beat_buffer_pos] = bass_instant;
-    bass_history += bass_instant * (1.0 / bass_buffer.size());
+    auto const updateFrequency =
+        [&vdataL, &vdataR, this](
+            size_t const from,
+            size_t const to,
+            float& instant,
+            float& history,
+            std::array<float, BEAT_HISTORY_LENGTH>& buffer) {
+            instant = 0.f;
 
-    mid_instant = 0;
-    for (unsigned i = ranges[1]; i < ranges[2]; i++)
-        mid_instant += vdataL[i] + vdataR[i];
-    mid_history -= mid_buffer[beat_buffer_pos] * (1.0 / mid_buffer.size());
-    mid_buffer[beat_buffer_pos] = mid_instant;
-    mid_history += mid_instant * (1.0 / mid_buffer.size());
+            for (unsigned i = from; i < to; i++)
+            {
+                instant += vdataL[i] + vdataR[i];
+            }
 
-    treb_instant = 0;
-    for (unsigned i = ranges[2]; i < ranges[3]; i++)
-        treb_instant += vdataL[i] + vdataR[i];
-    treb_history -= treb_buffer[beat_buffer_pos] * (1.0 / treb_buffer.size());
-    treb_buffer[beat_buffer_pos] = treb_instant;
-    treb_history += treb_instant * (1.0 / treb_buffer.size());
+            history -= buffer[beat_buffer_pos] / static_cast<float>(buffer.size());
+            history += instant / static_cast<float>(buffer.size());
+            buffer[beat_buffer_pos] = instant;
+        };
+
+    updateFrequency(ranges[0], ranges[1], bass_instant, bass_history, bass_buffer);
+    updateFrequency(ranges[1], ranges[2], mid_instant, mid_history, mid_buffer);
+    updateFrequency(ranges[2], ranges[3], treb_instant, treb_history, treb_buffer);
 
     vol_instant = (bass_instant + mid_instant + treb_instant) / 3.0f;
-    vol_history -= (vol_buffer[beat_buffer_pos]) * (1.0 / vol_buffer.size());
-    vol_buffer[beat_buffer_pos] = vol_instant;
-    vol_history += vol_instant * (1.0 / vol_buffer.size());
+    vol_history = (bass_history + mid_history + treb_history) / 3.0f;
 
-    //    fprintf(stderr, "%6.3f %6.2f %6.3f\n", bass_history/vol_history, mid_history/vol_history, treb_history/vol_history);
     bass = bass_instant / std::max(0.0001f, bass_history);
     mid = mid_instant / std::max(0.0001f, mid_history);
     treb = treb_instant / std::max(0.0001f, treb_history);

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -63,10 +63,10 @@ void BeatDetect::calculateBeatStatistics()
 {
     vol_old = vol;
 
-    float vdataL[fftLength];
-    float vdataR[fftLength];
-    pcm.GetSpectrum(vdataL, CHANNEL_0, fftLength);
-    pcm.GetSpectrum(vdataR, CHANNEL_1, fftLength);
+    std::array<float, fftLength> vdataL{};
+    std::array<float, fftLength> vdataR{};
+    pcm.GetSpectrum(vdataL.data(), CHANNEL_0, fftLength);
+    pcm.GetSpectrum(vdataR.data(), CHANNEL_1, fftLength);
 
     auto const intensityBetween =
         [&vdataL, &vdataR](size_t const from, size_t const to) {
@@ -75,7 +75,7 @@ void BeatDetect::calculateBeatStatistics()
         };
 
     static_assert(fftLength >= 256, "fftLength too small");
-    size_t constexpr ranges[4] = {0, 3, 23, 255};
+    std::array<size_t, 4> constexpr ranges{0, 3, 23, 255};
 
     float const bass_instant = intensityBetween(ranges[0], ranges[1]);
     float const mid_instant = intensityBetween(ranges[1], ranges[2]);

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -63,14 +63,14 @@ void BeatDetect::calculateBeatStatistics()
 {
     vol_old = vol;
 
-    size_t constexpr fft_length = fftLength;
     float vdataL[fftLength];
     float vdataR[fftLength];
     pcm.GetSpectrum(vdataL, CHANNEL_0, fftLength);
     pcm.GetSpectrum(vdataR, CHANNEL_1, fftLength);
 
 
-    static_assert(fft_length >= 256, "fft_length too small");
+    static_assert(fftLength >= 256, "fft_length too small");
+
     unsigned ranges[4] = {0, 3, 23, 255};
 
     bass_instant = 0;

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -69,22 +69,22 @@ auto BeatDetect::CalculateBeatStatistics() -> void
 {
     volOld = vol;
 
-    std::array<float, fftLength> const vdataL =
+    std::array<float, fftLength> const freqL =
         [this]() {
-            std::array<float, fftLength> vdataL{};
-            pcm.GetSpectrum(vdataL.data(), CHANNEL_0, fftLength);
-            return vdataL;
+            std::array<float, fftLength> freqL{};
+            pcm.GetSpectrum(freqL.data(), CHANNEL_L, fftLength);
+            return freqL;
         }();
-    std::array<float, fftLength> const vdataR =
+    std::array<float, fftLength> const freqR =
         [this]() {
-            std::array<float, fftLength> vdataR{};
-            pcm.GetSpectrum(vdataR.data(), CHANNEL_1, fftLength);
-            return vdataR;
+            std::array<float, fftLength> freqR{};
+            pcm.GetSpectrum(freqR.data(), CHANNEL_R, fftLength);
+            return freqR;
         }();
 
-    auto const intensityBetween = [&vdataL, &vdataR](size_t const from, size_t const to) {
-        return std::accumulate(&vdataL[from], &vdataL[to], 0.f) +
-               std::accumulate(&vdataR[from], &vdataR[to], 0.f);
+    auto const intensityBetween = [&freqL, &freqR](size_t const from, size_t const to) {
+        return std::accumulate(&freqL[from], &freqL[to], 0.f) +
+               std::accumulate(&freqR[from], &freqR[to], 0.f);
     };
 
     auto const& updateBand =

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -74,35 +74,27 @@ void BeatDetect::CalculateBeatStatistics()
                    std::accumulate(&vdataR[from], &vdataR[to], 0.f);
         };
 
+    auto const& updateBand =
+        [](float& band, float& bandAtt, LowPassFilter& bandSmoothed, float const bandIntensity) {
+            bandSmoothed.Update(bandIntensity);
+            band = bandIntensity / std::max(0.0001f, bandSmoothed.Get());
+            bandAtt = .6f * bandAtt + .4f * band;
+            bandAtt = std::min(bandAtt, 100.f);
+            band = std::min(band, 100.f);
+        };
+
     static_assert(fftLength >= 256, "fftLength too small");
     std::array<size_t, 4> constexpr ranges{0, 3, 23, 255};
 
-    float const bassInstant = intensityBetween(ranges[0], ranges[1]);
-    float const midInstant = intensityBetween(ranges[1], ranges[2]);
-    float const trebInstant = intensityBetween(ranges[2], ranges[3]);
-    float const volInstant = (bassInstant + midInstant + trebInstant) / 3.0f;
+    float const bassIntensity = intensityBetween(ranges[0], ranges[1]);
+    updateBand(bass, bassAtt, bassSmoothed, bassIntensity);
 
-    bassSmoothed.Update(bassInstant);
-    midSmoothed.Update(midInstant);
-    trebSmoothed.Update(trebInstant);
-    volSmoothed.Update(volInstant);
+    float const midIntensity = intensityBetween(ranges[1], ranges[2]);
+    updateBand(mid, midAtt, midSmoothed, midIntensity);
 
-    bass = bassInstant / std::max(0.0001f, bassSmoothed.Get());
-    mid = midInstant / std::max(0.0001f, midSmoothed.Get());
-    treb = trebInstant / std::max(0.0001f, trebSmoothed.Get());
-    vol = volInstant / std::max(0.0001f, volSmoothed.Get());
+    float const trebIntensity = intensityBetween(ranges[2], ranges[3]);
+    updateBand(treb, trebAtt, trebSmoothed, trebIntensity);
 
-    trebAtt = .6f * trebAtt + .4f * treb;
-    midAtt = .6f * midAtt + .4f * mid;
-    bassAtt = .6f * bassAtt + .4f * bass;
-    volAtt = .6f * volAtt + .4f * vol;
-
-    bassAtt = std::min(bassAtt, 100.f);
-    bass = std::min(bass, 100.f);
-    midAtt = std::min(midAtt, 100.f);
-    mid = std::min(mid, 100.f);
-    trebAtt = std::min(trebAtt, 100.f);
-    treb = std::min(treb, 100.f);
-    volAtt = std::min(volAtt, 100.f);
-    vol = std::min(vol, 100.f);
+    float const volIntensity = bassIntensity + midIntensity + trebIntensity;
+    updateBand(vol, volAtt, volSmoothed, volIntensity);
 }

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -46,7 +46,7 @@ BeatDetect::BeatDetect(Pcm& _pcm)
 }
 
 
-void BeatDetect::Reset()
+auto BeatDetect::Reset() noexcept -> void
 {
     this->treb = 0;
     this->mid = 0;
@@ -59,26 +59,33 @@ void BeatDetect::Reset()
 }
 
 
-float BeatDetect::GetPCMScale()
+auto BeatDetect::GetPCMScale() const noexcept -> float
 {
     return beatSensitivity;
 }
 
 
-void BeatDetect::CalculateBeatStatistics()
+auto BeatDetect::CalculateBeatStatistics() -> void
 {
     volOld = vol;
 
-    std::array<float, fftLength> vdataL{};
-    std::array<float, fftLength> vdataR{};
-    pcm.GetSpectrum(vdataL.data(), CHANNEL_0, fftLength);
-    pcm.GetSpectrum(vdataR.data(), CHANNEL_1, fftLength);
+    std::array<float, fftLength> const vdataL =
+        [this]() {
+            std::array<float, fftLength> vdataL{};
+            pcm.GetSpectrum(vdataL.data(), CHANNEL_0, fftLength);
+            return vdataL;
+        }();
+    std::array<float, fftLength> const vdataR =
+        [this]() {
+            std::array<float, fftLength> vdataR{};
+            pcm.GetSpectrum(vdataR.data(), CHANNEL_1, fftLength);
+            return vdataR;
+        }();
 
-    auto const intensityBetween =
-        [&vdataL, &vdataR](size_t const from, size_t const to) {
-            return std::accumulate(&vdataL[from], &vdataL[to], 0.f) +
-                   std::accumulate(&vdataR[from], &vdataR[to], 0.f);
-        };
+    auto const intensityBetween = [&vdataL, &vdataR](size_t const from, size_t const to) {
+        return std::accumulate(&vdataL[from], &vdataL[to], 0.f) +
+               std::accumulate(&vdataR[from], &vdataR[to], 0.f);
+    };
 
     auto const& updateBand =
         [](float& band, float& bandAtt, LowPassFilter& bandSmoothed, float const bandIntensity) {

--- a/src/libprojectM/Renderer/BeatDetect.hpp
+++ b/src/libprojectM/Renderer/BeatDetect.hpp
@@ -96,19 +96,10 @@ private:
         float m_current{0.f};
     };
 
-    size_t beat_buffer_pos{0};
-
     LowPassFilter bass_history;
-    float bass_instant{0.f};
-
     LowPassFilter mid_history;
-    float mid_instant{0.f};
-
     LowPassFilter treb_history;
-    float treb_instant{0.f};
-
     LowPassFilter vol_history;
-    float vol_instant{0.f};
 };
 
 #endif /** !_BEAT_DETECT_H */

--- a/src/libprojectM/Renderer/BeatDetect.hpp
+++ b/src/libprojectM/Renderer/BeatDetect.hpp
@@ -38,17 +38,19 @@ class BeatDetect
 {
 public:
     explicit BeatDetect(Pcm& pcm);
-    void Reset();
+
+    auto Reset() noexcept -> void;
 
     /**
      * Calculates and updates information about the beat
      */
-    void CalculateBeatStatistics();
+    auto CalculateBeatStatistics() -> void;
 
     // getPCMScale() was added to address https://github.com/projectM-visualizer/projectm/issues/161
     // Returning 1.0 results in using the raw PCM data, which can make the presets look pretty unresponsive
     // if the application volume is low.
-    float GetPCMScale();
+    [[nodiscard]]
+    auto GetPCMScale() const noexcept -> float;
 
     float beatSensitivity{1.f};
 

--- a/src/libprojectM/Renderer/BeatDetect.hpp
+++ b/src/libprojectM/Renderer/BeatDetect.hpp
@@ -38,17 +38,17 @@ class BeatDetect
 {
 public:
     explicit BeatDetect(Pcm& pcm);
-    void reset();
+    void Reset();
 
     /**
      * Calculates and updates information about the beat
      */
-    void calculateBeatStatistics();
+    void CalculateBeatStatistics();
 
     // getPCMScale() was added to address https://github.com/projectM-visualizer/projectm/issues/161
     // Returning 1.0 results in using the raw PCM data, which can make the presets look pretty unresponsive
     // if the application volume is low.
-    float getPCMScale()
+    float GetPCMScale()
     {
         return beatSensitivity;
     }
@@ -58,13 +58,13 @@ public:
     float treb{0.f};
     float mid{0.f};
     float bass{0.f};
-    float vol_old{0.f};
+    float volOld{0.f};
 
-    float treb_att{0.f};
-    float mid_att{0.f};
-    float bass_att{0.f};
+    float trebAtt{0.f};
+    float midAtt{0.f};
+    float bassAtt{0.f};
     float vol{0.f};
-    float vol_att{0.f};
+    float volAtt{0.f};
 
     Pcm& pcm;
 
@@ -96,10 +96,10 @@ private:
         float m_current{0.f};
     };
 
-    LowPassFilter bass_history;
-    LowPassFilter mid_history;
-    LowPassFilter treb_history;
-    LowPassFilter vol_history;
+    LowPassFilter bassSmoothed;
+    LowPassFilter midSmoothed;
+    LowPassFilter trebSmoothed;
+    LowPassFilter volSmoothed;
 };
 
 #endif /** !_BEAT_DETECT_H */

--- a/src/libprojectM/Renderer/BeatDetect.hpp
+++ b/src/libprojectM/Renderer/BeatDetect.hpp
@@ -48,10 +48,7 @@ public:
     // getPCMScale() was added to address https://github.com/projectM-visualizer/projectm/issues/161
     // Returning 1.0 results in using the raw PCM data, which can make the presets look pretty unresponsive
     // if the application volume is low.
-    float GetPCMScale()
-    {
-        return beatSensitivity;
-    }
+    float GetPCMScale();
 
     float beatSensitivity{1.f};
 
@@ -73,21 +70,10 @@ private:
     {
     public:
         auto
-        Update(float nextValue) noexcept -> void
-        {
-            m_current -= m_buffer[m_bufferPos] / bufferLength;
-            m_current += nextValue / bufferLength;
-            m_buffer[m_bufferPos] = nextValue;
-
-            ++m_bufferPos;
-            m_bufferPos %= bufferLength;
-        }
+        Update(float nextValue) noexcept -> void;
 
         [[nodiscard]] auto
-        Get() const noexcept -> float
-        {
-            return m_current;
-        }
+        Get() const noexcept -> float;
 
     private:
         static size_t constexpr bufferLength{80};

--- a/src/libprojectM/Renderer/BeatDetect.hpp
+++ b/src/libprojectM/Renderer/BeatDetect.hpp
@@ -37,6 +37,8 @@
 class BeatDetect
 {
 public:
+    // We should probably remove pcm from the constructor,
+    // and just pass it as an argument to CalculateBeatStatistics.
     explicit BeatDetect(Pcm& pcm);
 
     auto Reset() noexcept -> void;

--- a/src/libprojectM/Renderer/BeatDetect.hpp
+++ b/src/libprojectM/Renderer/BeatDetect.hpp
@@ -69,26 +69,45 @@ public:
     Pcm& pcm;
 
 private:
-    // this is the size of the buffer used to determine avg levels of the input audio
-    // the actual time represented in the history depends on FPS
-    static size_t constexpr BEAT_HISTORY_LENGTH{80};
+    class LowPassFilter
+    {
+    public:
+        auto
+        Update(float nextValue) noexcept -> void
+        {
+            m_current -= m_buffer[m_bufferPos] / bufferLength;
+            m_current += nextValue / bufferLength;
+            m_buffer[m_bufferPos] = nextValue;
+
+            ++m_bufferPos;
+            m_bufferPos %= bufferLength;
+        }
+
+        [[nodiscard]] auto
+        Get() const noexcept -> float
+        {
+            return m_current;
+        }
+
+    private:
+        static size_t constexpr bufferLength{80};
+        size_t m_bufferPos{0};
+        std::array<float, bufferLength> m_buffer{0.f};
+        float m_current{0.f};
+    };
 
     size_t beat_buffer_pos{0};
 
-    std::array<float, BEAT_HISTORY_LENGTH> bass_buffer{0.f};
-    float bass_history{0.f};
+    LowPassFilter bass_history;
     float bass_instant{0.f};
 
-    std::array<float, BEAT_HISTORY_LENGTH> mid_buffer{0.f};
-    float mid_history{0.f};
+    LowPassFilter mid_history;
     float mid_instant{0.f};
 
-    std::array<float, BEAT_HISTORY_LENGTH> treb_buffer{0.f};
-    float treb_history{0.f};
+    LowPassFilter treb_history;
     float treb_instant{0.f};
 
-    std::array<float, BEAT_HISTORY_LENGTH> vol_buffer{0.f};
-    float vol_history{0.f};
+    LowPassFilter vol_history;
     float vol_instant{0.f};
 };
 

--- a/src/libprojectM/Renderer/MilkdropWaveform.cpp
+++ b/src/libprojectM/Renderer/MilkdropWaveform.cpp
@@ -264,7 +264,7 @@ void MilkdropWaveform::WaveformMath(RenderContext& context)
     }
 
     // tie size of waveform to beatSensitivity
-    const float vol_scale = context.beatDetect->getPCMScale();
+    const float vol_scale = context.beatDetect->GetPCMScale();
     if (vol_scale != 1.0)
     {
         for (int i = 0; i < pcmDataL.size(); i++)

--- a/src/libprojectM/Renderer/ShaderEngine.cpp
+++ b/src/libprojectM/Renderer/ShaderEngine.cpp
@@ -440,7 +440,7 @@ void ShaderEngine::SetupShaderVariables(GLuint program, const Pipeline &pipeline
     glUniform4f(glGetUniformLocation(program, "_c1"), 0.0, 0.0, 0.0, 0.0);
     glUniform4f(glGetUniformLocation(program, "_c2"), time_since_preset_start_wrapped, context.fps,  context.frame, context.progress);
     glUniform4f(glGetUniformLocation(program, "_c3"), beatDetect->bass/100, beatDetect->mid/100, beatDetect->treb/100, beatDetect->vol/100);
-    glUniform4f(glGetUniformLocation(program, "_c4"), beatDetect->bass_att/100, beatDetect->mid_att/100, beatDetect->treb_att/100, beatDetect->vol_att/100);
+    glUniform4f(glGetUniformLocation(program, "_c4"), beatDetect->bassAtt/100, beatDetect->midAtt/100, beatDetect->trebAtt/100, beatDetect->volAtt/100);
     glUniform4f(glGetUniformLocation(program, "_c5"), pipeline.blur1x-pipeline.blur1n, pipeline.blur1n, pipeline.blur2x-pipeline.blur2n, pipeline.blur2n);
     glUniform4f(glGetUniformLocation(program, "_c6"), pipeline.blur3x-pipeline.blur3n, pipeline.blur3n, pipeline.blur1n, pipeline.blur1x);
     glUniform4f(glGetUniformLocation(program, "_c7"), texsizeX, texsizeY, 1 / (float) texsizeX, 1 / (float) texsizeY);

--- a/src/libprojectM/Renderer/Waveform.cpp
+++ b/src/libprojectM/Renderer/Waveform.cpp
@@ -29,7 +29,7 @@ void Waveform::InitVertexAttrib() {
 void Waveform::Draw(RenderContext &context)
 {
     // scale PCM data based on vol_history to make it more or less independent of the application output volume
-    const float vol_scale = context.beatDetect->getPCMScale();
+    const float vol_scale = context.beatDetect->GetPCMScale();
 
 	// Make sure samples<=points.size().  We could reallocate points, but 512 is probably big enough.
     int sampleCount{ std::min(this->samples, static_cast<int>(this->points.size())) };

--- a/src/libprojectM/projectM.cpp
+++ b/src/libprojectM/projectM.cpp
@@ -23,7 +23,6 @@
 #include "RenderItemMatcher.hpp"
 #include "RenderItemMergeFunction.hpp"
 #include "fatal.h"
-#include "Common.hpp"
 
 #ifdef WIN32
 #include "dirent.h"
@@ -360,7 +359,7 @@ Pipeline* projectM::renderFrameOnlyPass1(
     context.progress = timeKeeper->PresetProgressA();
     renderer->UpdateContext(context);
 
-    beatDetect->calculateBeatStatistics();
+    beatDetect->CalculateBeatStatistics();
 
     //m_activePreset->evaluateFrame();
 
@@ -379,7 +378,7 @@ Pipeline* projectM::renderFrameOnlyPass1(
                 selectNext(false);
             }
         }
-        else if (settings().hardCutEnabled && (beatDetect->vol - beatDetect->vol_old > settings().hardCutSensitivity) &&
+        else if (settings().hardCutEnabled && (beatDetect->vol - beatDetect->volOld > settings().hardCutSensitivity) &&
                  timeKeeper->CanHardCut())
         {
             // Hard Cuts must be enabled, must have passed the hardcut duration, and the volume must be a greater difference than the hardcut sensitivity.
@@ -599,7 +598,7 @@ void projectM::projectM_resetengine()
 
     if (beatDetect != NULL)
     {
-        beatDetect->reset();
+        beatDetect->Reset();
         beatDetect->beatSensitivity = _settings.beatSensitivity;
     }
 


### PR DESCRIPTION
This started as just simply fixing a small bug from an earlier PR.
Then I got bored and tried to make the logic a bit clearer,
in addition to some cleanup to satisfy clang-tidy
and also improve const-correctness.

I still don't really see the point of the `*Att` variables.
They simply look like a lowpass filter on a given band intensity value,
which already is lowpass filtered.
If `Att` stands for attenuated, I think this usage is a bit
[misleading](https://en.wikipedia.org/wiki/Attenuator_(electronics)).
I'm not sure if these are really necessary.
In what context are they used?

Please tell if something here made the logic less clear than it previously was
:)
