### PR TITLE
Removed GLM dependency from shared & static library targets.

### DIFF
--- a/src/libprojectM/libprojectM_shared.cmake
+++ b/src/libprojectM/libprojectM_shared.cmake
@@ -38,8 +38,6 @@ target_include_directories(projectM_shared
         )
 
 target_link_libraries(projectM_shared
-        PRIVATE
-        GLM::GLM
         PUBLIC
         ${PROJECTM_OPENGL_LIBRARIES}
         ${CMAKE_DL_LIBS}

--- a/src/libprojectM/libprojectM_static.cmake
+++ b/src/libprojectM/libprojectM_static.cmake
@@ -36,8 +36,6 @@ target_include_directories(projectM_static
         )
 
 target_link_libraries(projectM_static
-        PRIVATE
-        GLM::GLM
         PUBLIC
         ${PROJECTM_OPENGL_LIBRARIES}
         )


### PR DESCRIPTION
These targets do not compile any source and thus don't need the include dir, but CMake exports a link-only dependency for the static library, which is also not required as GLM is header-only.