### PR TITLE
Windows build improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 if(CMAKE_VERSION VERSION_LESS 3.19 AND CMAKE_GENERATOR STREQUAL "Xcode")
     message(AUTHOR_WARNING "Using a CMake version before 3.19 with a recent Xcode SDK and the Xcode generator "
@@ -140,7 +140,12 @@ else()
         endif()
         if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
             find_package(GLEW REQUIRED)
-            list(APPEND PROJECTM_OPENGL_LIBRARIES GLEW::glew)
+            # Prefer shared, but check for static lib if shared is not available.
+            if(TARGET GLEW::glew)
+                list(APPEND PROJECTM_OPENGL_LIBRARIES GLEW::glew)
+            elseif(TARGET GLEW::glew_s)
+                list(APPEND PROJECTM_OPENGL_LIBRARIES GLEW::glew_s)
+            endif()
         endif()
     endif()
 

--- a/cmake/SDL2Target.cmake
+++ b/cmake/SDL2Target.cmake
@@ -55,9 +55,17 @@ endif()
 
 # Temporary fix to deal with wrong include dir set by SDL2's CMake configuration.
 get_target_property(_SDL2_INCLUDE_DIR SDL2::SDL2 INTERFACE_INCLUDE_DIRECTORIES)
-if(_SDL2_INCLUDE_DIR MATCHES "(.+)/SDL2\$")
+if(_SDL2_INCLUDE_DIR MATCHES "(.+)/SDL2\$" AND _SDL2_TARGET_TYPE STREQUAL STATIC_LIBRARY)
+    # Check if SDL2::SDL2 is aliased to SDL2::SDL2-static (will be the case for static-only builds)
+    get_target_property(_SDL2_ALIASED_TARGET SDL2::SDL2 ALIASED_TARGET)
+    if(_SDL2_ALIASED_TARGET)
+        set(_sdl2_target ${_SDL2_ALIASED_TARGET})
+    else()
+        set(_sdl2_target SDL2::SDL2)
+    endif()
+
     message(STATUS "SDL2 include dir contains \"SDL2\" subdir (SDL bug #4004) - fixing to \"${CMAKE_MATCH_1}\".")
-    set_target_properties(SDL2::SDL2 PROPERTIES
+    set_target_properties(${_sdl2_target} PROPERTIES
             INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_MATCH_1}"
             )
 endif()

--- a/src/libprojectM/projectM.h
+++ b/src/libprojectM/projectM.h
@@ -25,6 +25,7 @@
 #include "event.h"
 
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Similar changes as in the SDL2 frontend. Increased minimum CMake version to 3.15, as this is required for some crucial Windows build settings. Also improved SDL2 target "fixing", as the `SDL2::SDL2` might be an alias to `SDL2::SDL2-static`and the fix fails. It'll now apply the property fix to the original target in this case.

Basically, these changes were done to be able to build projectM and downstream apps using the static runtime on Windows (`/MT[d]`).