### PR TITLE
Removed a filename that was added automatically to the wrong target by the IDE.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 if(ENABLE_SYSTEM_GLM)
     find_package(GLM REQUIRED)
 else()
-    add_library(GLM::GLM INTERFACE IMPORTED tests/FileParserTest.cpp)
+    add_library(GLM::GLM INTERFACE IMPORTED)
     set_target_properties(GLM::GLM PROPERTIES
             INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR}/vendor"
             )


### PR DESCRIPTION
Had no build implications as it's an interface target.