### PR TITLE
A few fixes for emscripten and GLES support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,8 +52,8 @@ option(ENABLE_NATIVE_PRESETS "Build and install native preset loading support an
 option(BUILD_TESTING "Build the libprojectM test suite" OFF)
 cmake_dependent_option(ENABLE_SDL_UI "Build the SDL2-based developer test UI" OFF "NOT ENABLE_EMSCRIPTEN" OFF)
 cmake_dependent_option(ENABLE_GLES "Enable OpenGL ES support" OFF "NOT ENABLE_EMSCRIPTEN" ON)
-cmake_dependent_option(ENABLE_OPENMP "Enable OpenMP support if available" ON "NOT ENABLE_EMSCRIPTEN" ON)
-option(ENABLE_THREADING "Enable multithreading support. Use with care with emscripten." ON)
+cmake_dependent_option(ENABLE_OPENMP "Enable OpenMP support if available" ON "NOT ENABLE_EMSCRIPTEN" OFF)
+cmake_dependent_option(ENABLE_THREADING "Enable multithreading support." ON "NOT ENABLE_EMSCRIPTEN" OFF)
 cmake_dependent_option(ENABLE_LLVM "Enable LLVM JIT support" OFF "NOT ENABLE_EMSCRIPTEN" OFF)
 option(ENABLE_SYSTEM_GLM "Enable use of system-install GLM library" OFF)
 

--- a/src/libprojectM/ProjectM.cpp
+++ b/src/libprojectM/ProjectM.cpp
@@ -323,7 +323,7 @@ auto ProjectM::RenderFrameOnlyPass1(Pipeline* pipeline) -> Pipeline*
         // FIXME: Instead of waiting after a single render pass, check every frame if it's done.
         m_workerSync.WaitForBackgroundTaskToFinish();
 #else
-        evaluateSecondPreset();
+        EvaluateSecondPreset();
 #endif
 
         pipeline->setStaticPerPixel(Settings().meshX, Settings().meshY);

--- a/src/libprojectM/Renderer/MilkdropWaveform.cpp
+++ b/src/libprojectM/Renderer/MilkdropWaveform.cpp
@@ -42,7 +42,9 @@ void MilkdropWaveform::Draw(RenderContext& context)
     // so this member variable is just being set in WaveformMath and used here
     assert(samples <= NumWaveformSamples);
 
+#if USE_GLES == 0
     glDisable(GL_LINE_SMOOTH);
+#endif
     glLineWidth(1);
 
     for (int waveIndex = 0; waveIndex < 2; waveIndex++)

--- a/src/libprojectM/Renderer/Shape.cpp
+++ b/src/libprojectM/Renderer/Shape.cpp
@@ -100,7 +100,7 @@ void Shape::Draw(RenderContext& context)
         }
         else
         {
-            auto texture = context.textureManager->getTexture(image, GL_CLAMP_TO_BORDER, GL_LINEAR);
+            auto texture = context.textureManager->getTexture(image, GL_CLAMP_TO_EDGE, GL_LINEAR);
             if (texture.first)
             {
                 glBindTexture(GL_TEXTURE_2D, texture.first->texID);
@@ -177,7 +177,9 @@ void Shape::Draw(RenderContext& context)
                            glm::value_ptr(context.mat_ortho));
         glVertexAttrib4f(1, border_r, border_g, border_b, border_a * masterAlpha);
         glLineWidth(1);
+#if USE_GLES == 0
         glEnable(GL_LINE_SMOOTH);
+#endif
 
         glBindVertexArray(m_vaoID);
         glBindBuffer(GL_ARRAY_BUFFER, m_vboID);
@@ -227,6 +229,8 @@ void Shape::Draw(RenderContext& context)
         glBindVertexArray(0);
     }
 
+#if USE_GLES == 0
     glDisable(GL_LINE_SMOOTH);
+#endif
     glUseProgram(0);
 }

--- a/src/libprojectM/Renderer/TextureManager.cpp
+++ b/src/libprojectM/Renderer/TextureManager.cpp
@@ -86,7 +86,7 @@ TextureManager::TextureManager(const std::string _presetsURL, const int texsizeX
     GLuint noise_texture_lq_lite;
     glGenTextures(1, &noise_texture_lq_lite);
     glBindTexture(GL_TEXTURE_2D, noise_texture_lq_lite);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 32, 32, 0, NOISE_INTERNAL_DATA_FORMAT, GL_UNSIGNED_INT_8_8_8_8, noise->noise_lq_lite);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 32, 32, 0, NOISE_INTERNAL_DATA_FORMAT, GL_UNSIGNED_INT, noise->noise_lq_lite);
     Texture * textureNoise_lq_lite = new Texture("noise_lq_lite", noise_texture_lq_lite, GL_TEXTURE_2D, 32, 32, false);
     textureNoise_lq_lite->getSampler(GL_REPEAT, GL_LINEAR);
     textures["noise_lq_lite"] = textureNoise_lq_lite;
@@ -94,7 +94,7 @@ TextureManager::TextureManager(const std::string _presetsURL, const int texsizeX
     GLuint noise_texture_lq;
     glGenTextures(1, &noise_texture_lq);
     glBindTexture(GL_TEXTURE_2D, noise_texture_lq);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 256, 0, NOISE_INTERNAL_DATA_FORMAT, GL_UNSIGNED_INT_8_8_8_8, noise->noise_lq);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 256, 0, NOISE_INTERNAL_DATA_FORMAT, GL_UNSIGNED_INT, noise->noise_lq);
     Texture * textureNoise_lq = new Texture("noise_lq", noise_texture_lq, GL_TEXTURE_2D, 256, 256, false);
     textureNoise_lq->getSampler(GL_REPEAT, GL_LINEAR);
     textures["noise_lq"] = textureNoise_lq;
@@ -102,7 +102,7 @@ TextureManager::TextureManager(const std::string _presetsURL, const int texsizeX
     GLuint noise_texture_mq;
     glGenTextures(1, &noise_texture_mq);
     glBindTexture(GL_TEXTURE_2D, noise_texture_mq);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 256, 0, NOISE_INTERNAL_DATA_FORMAT, GL_UNSIGNED_INT_8_8_8_8, noise->noise_mq);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 256, 0, NOISE_INTERNAL_DATA_FORMAT, GL_UNSIGNED_INT, noise->noise_mq);
     Texture * textureNoise_mq = new Texture("noise_mq", noise_texture_mq, GL_TEXTURE_2D, 256, 256, false);
     textureNoise_mq->getSampler(GL_REPEAT, GL_LINEAR);
     textures["noise_mq"] = textureNoise_mq;
@@ -110,7 +110,7 @@ TextureManager::TextureManager(const std::string _presetsURL, const int texsizeX
     GLuint noise_texture_hq;
     glGenTextures(1, &noise_texture_hq);
     glBindTexture(GL_TEXTURE_2D, noise_texture_hq);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 256, 0, NOISE_INTERNAL_DATA_FORMAT, GL_UNSIGNED_INT_8_8_8_8, noise->noise_hq);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 256, 0, NOISE_INTERNAL_DATA_FORMAT, GL_UNSIGNED_INT, noise->noise_hq);
     Texture * textureNoise_hq = new Texture("noise_hq", noise_texture_hq, GL_TEXTURE_2D, 256, 256, false);
     textureNoise_hq->getSampler(GL_REPEAT, GL_LINEAR);
     textures["noise_hq"] = textureNoise_hq;
@@ -118,7 +118,7 @@ TextureManager::TextureManager(const std::string _presetsURL, const int texsizeX
     GLuint noise_texture_lq_vol;
     glGenTextures( 1, &noise_texture_lq_vol );
     glBindTexture( GL_TEXTURE_3D, noise_texture_lq_vol );
-    glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA, 32 ,32 ,32 ,0 ,NOISE_INTERNAL_DATA_FORMAT, GL_UNSIGNED_INT_8_8_8_8 ,noise->noise_lq_vol);
+    glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA, 32 ,32 ,32 ,0 ,NOISE_INTERNAL_DATA_FORMAT, GL_UNSIGNED_INT ,noise->noise_lq_vol);
     Texture * textureNoise_lq_vol = new Texture("noisevol_lq", noise_texture_lq_vol, GL_TEXTURE_3D, 32, 32, false);
     textureNoise_lq_vol->getSampler(GL_REPEAT, GL_LINEAR);
     textures["noisevol_lq"] = textureNoise_lq_vol;
@@ -126,7 +126,7 @@ TextureManager::TextureManager(const std::string _presetsURL, const int texsizeX
     GLuint noise_texture_hq_vol;
     glGenTextures( 1, &noise_texture_hq_vol );
     glBindTexture( GL_TEXTURE_3D, noise_texture_hq_vol );
-    glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA, 32, 32, 32, 0, NOISE_INTERNAL_DATA_FORMAT, GL_UNSIGNED_INT_8_8_8_8, noise->noise_hq_vol);
+    glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA, 32, 32, 32, 0, NOISE_INTERNAL_DATA_FORMAT, GL_UNSIGNED_INT, noise->noise_hq_vol);
 
     Texture * textureNoise_hq_vol = new Texture("noisevol_hq", noise_texture_hq_vol, GL_TEXTURE_3D, 32, 32, false);
     textureNoise_hq_vol->getSampler(GL_REPEAT, GL_LINEAR);

--- a/src/libprojectM/Renderer/Waveform.cpp
+++ b/src/libprojectM/Renderer/Waveform.cpp
@@ -104,7 +104,9 @@ void Waveform::Draw(RenderContext &context)
 	if (additive)  glBlendFunc(GL_SRC_ALPHA, GL_ONE);
 	else glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
+#if USE_GLES == 0
     glDisable(GL_LINE_SMOOTH);
+#endif
     glLineWidth(1);
 
     // Additive wave drawing (vice overwrite)


### PR DESCRIPTION
Also fixed a typo in a function call when threading was disabled.

Emscripten builds will now no longer use OpenMP or threads, as the WebAssembly platform doesn't really support multithreading anyways.

Also had to change a few GL constants introduces in recent refactorings which aren't defined in OpenGL ES headers. Line smoothing is not supported by GLES, so the `glDisable` calls are now wrapped in preprocessor `#ìf` blocks.