### PR TITLE
Got the texture format wrong on a previous commit. Fixed to use the proper format.

### DIFF
--- a/src/libprojectM/ProjectM.cpp
+++ b/src/libprojectM/ProjectM.cpp
@@ -157,16 +157,7 @@ void ProjectM::ReadConfig(const std::string& configurationFilename)
     // Preset authors have developed their visualizations with the default of 1.0.
     m_settings.beatSensitivity = config.read<float>("Beat Sensitivity", 1.0);
 
-    if (config.read("Aspect Correction", true))
-    {
-        m_settings.aspectCorrection = true;
-        m_renderer->correction = true;
-    }
-    else
-    {
-        m_settings.aspectCorrection = false;
-        m_renderer->correction = false;
-    }
+    m_settings.aspectCorrection = config.read<bool>("Aspect Correction", true);
 
     Initialize();
 }

--- a/src/libprojectM/Renderer/TextureManager.cpp
+++ b/src/libprojectM/Renderer/TextureManager.cpp
@@ -9,7 +9,6 @@
 #include "Texture.hpp"
 
 #include "MilkdropNoise.hpp"
-#define NOISE_INTERNAL_DATA_FORMAT GL_RGBA
 
 #define NUM_BLUR_TEX    6
 
@@ -67,10 +66,17 @@ TextureManager::TextureManager(std::vector<std::string>& textureSearchPaths, int
 
     auto noise = std::make_unique<MilkdropNoise>();
 
+    GLint preferredInternalFormat{GL_BGRA};
+#if !USE_GLES
+    // Query preferred internal texture format. GLES 3 only supports GL_RENDERBUFFER here, no texture targets.
+    // That's why we use GL_BGRA as default, as this is the best general-use format according to Khronos.
+    glGetInternalformativ(GL_TEXTURE_2D, GL_RGBA8, GL_TEXTURE_IMAGE_FORMAT, sizeof(preferredInternalFormat), &preferredInternalFormat);
+#endif
+
     GLuint noise_texture_lq_lite;
     glGenTextures(1, &noise_texture_lq_lite);
     glBindTexture(GL_TEXTURE_2D, noise_texture_lq_lite);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 32, 32, 0, NOISE_INTERNAL_DATA_FORMAT, GL_UNSIGNED_INT, noise->noise_lq_lite);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, 32, 32, 0, preferredInternalFormat, GL_UNSIGNED_BYTE, noise->noise_lq_lite);
     Texture * textureNoise_lq_lite = new Texture("noise_lq_lite", noise_texture_lq_lite, GL_TEXTURE_2D, 32, 32, false);
     textureNoise_lq_lite->getSampler(GL_REPEAT, GL_LINEAR);
     m_textures["noise_lq_lite"] = textureNoise_lq_lite;
@@ -78,7 +84,7 @@ TextureManager::TextureManager(std::vector<std::string>& textureSearchPaths, int
     GLuint noise_texture_lq;
     glGenTextures(1, &noise_texture_lq);
     glBindTexture(GL_TEXTURE_2D, noise_texture_lq);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 256, 0, NOISE_INTERNAL_DATA_FORMAT, GL_UNSIGNED_INT, noise->noise_lq);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, 256, 256, 0, preferredInternalFormat, GL_UNSIGNED_BYTE, noise->noise_lq);
     Texture * textureNoise_lq = new Texture("noise_lq", noise_texture_lq, GL_TEXTURE_2D, 256, 256, false);
     textureNoise_lq->getSampler(GL_REPEAT, GL_LINEAR);
     m_textures["noise_lq"] = textureNoise_lq;
@@ -86,7 +92,7 @@ TextureManager::TextureManager(std::vector<std::string>& textureSearchPaths, int
     GLuint noise_texture_mq;
     glGenTextures(1, &noise_texture_mq);
     glBindTexture(GL_TEXTURE_2D, noise_texture_mq);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 256, 0, NOISE_INTERNAL_DATA_FORMAT, GL_UNSIGNED_INT, noise->noise_mq);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, 256, 256, 0, preferredInternalFormat, GL_UNSIGNED_BYTE, noise->noise_mq);
     Texture * textureNoise_mq = new Texture("noise_mq", noise_texture_mq, GL_TEXTURE_2D, 256, 256, false);
     textureNoise_mq->getSampler(GL_REPEAT, GL_LINEAR);
     m_textures["noise_mq"] = textureNoise_mq;
@@ -94,7 +100,7 @@ TextureManager::TextureManager(std::vector<std::string>& textureSearchPaths, int
     GLuint noise_texture_hq;
     glGenTextures(1, &noise_texture_hq);
     glBindTexture(GL_TEXTURE_2D, noise_texture_hq);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 256, 0, NOISE_INTERNAL_DATA_FORMAT, GL_UNSIGNED_INT, noise->noise_hq);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, 256, 256, 0, preferredInternalFormat, GL_UNSIGNED_BYTE, noise->noise_hq);
     Texture * textureNoise_hq = new Texture("noise_hq", noise_texture_hq, GL_TEXTURE_2D, 256, 256, false);
     textureNoise_hq->getSampler(GL_REPEAT, GL_LINEAR);
     m_textures["noise_hq"] = textureNoise_hq;
@@ -102,7 +108,7 @@ TextureManager::TextureManager(std::vector<std::string>& textureSearchPaths, int
     GLuint noise_texture_lq_vol;
     glGenTextures( 1, &noise_texture_lq_vol );
     glBindTexture( GL_TEXTURE_3D, noise_texture_lq_vol );
-    glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA, 32 ,32 ,32 ,0 ,NOISE_INTERNAL_DATA_FORMAT, GL_UNSIGNED_INT ,noise->noise_lq_vol);
+    glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA8, 32, 32, 32, 0, preferredInternalFormat, GL_UNSIGNED_BYTE, noise->noise_lq_vol);
     Texture * textureNoise_lq_vol = new Texture("noisevol_lq", noise_texture_lq_vol, GL_TEXTURE_3D, 32, 32, false);
     textureNoise_lq_vol->getSampler(GL_REPEAT, GL_LINEAR);
     m_textures["noisevol_lq"] = textureNoise_lq_vol;
@@ -110,7 +116,7 @@ TextureManager::TextureManager(std::vector<std::string>& textureSearchPaths, int
     GLuint noise_texture_hq_vol;
     glGenTextures( 1, &noise_texture_hq_vol );
     glBindTexture( GL_TEXTURE_3D, noise_texture_hq_vol );
-    glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA, 32, 32, 32, 0, NOISE_INTERNAL_DATA_FORMAT, GL_UNSIGNED_INT, noise->noise_hq_vol);
+    glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA8, 32, 32, 32, 0, preferredInternalFormat, GL_UNSIGNED_BYTE, noise->noise_hq_vol);
 
     Texture * textureNoise_hq_vol = new Texture("noisevol_hq", noise_texture_hq_vol, GL_TEXTURE_3D, 32, 32, false);
     textureNoise_hq_vol->getSampler(GL_REPEAT, GL_LINEAR);

--- a/src/libprojectM/Renderer/TextureManager.cpp
+++ b/src/libprojectM/Renderer/TextureManager.cpp
@@ -10,6 +10,11 @@
 
 #include "MilkdropNoise.hpp"
 
+// Missing in macOS SDK. Query will most certainly fail, but then use the default format.
+#ifndef GL_TEXTURE_IMAGE_FORMAT
+#define GL_TEXTURE_IMAGE_FORMAT 0x828F
+#endif
+
 #define NUM_BLUR_TEX    6
 
 


### PR DESCRIPTION
Also query the optimal internal format on desktop GL implementations and use a sensible default for GLES as it doesn't support the query target.