### PR TITLE
Fix CMake's find_package(libprojectM) with Emscripten and GLES builds

### DIFF
--- a/src/libprojectM/CMakeLists.txt
+++ b/src/libprojectM/CMakeLists.txt
@@ -182,6 +182,14 @@ install(FILES
         COMPONENT Devel
         )
 
+if(NOT ENABLE_EMSCRIPTEN AND ENABLE_GLES)
+    install(FILES
+            "${CMAKE_SOURCE_DIR}/cmake/gles/FindOpenGL.cmake"
+            DESTINATION "${PROJECTM_LIB_DIR}/cmake/libprojectM"
+            COMPONENT Devel
+            )
+endif()
+
 install(EXPORT libprojectMTargets
         FILE libprojectMTargets.cmake
         NAMESPACE libprojectM::

--- a/src/libprojectM/libprojectMConfig.cmake.in
+++ b/src/libprojectM/libprojectMConfig.cmake.in
@@ -4,7 +4,14 @@ set(libprojectM_VERSION @PROJECT_VERSION@)
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(OpenGL)
+if(NOT "@ENABLE_EMSCRIPTEN@") # ENABLE_EMSCRIPTEN
+    if("@ENABLE_GLES@") # ENABLE_GLES
+        list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+        find_dependency(OpenGL COMPONENTS GLES3)
+    else()
+        find_dependency(OpenGL)
+    endif()
+endif()
 if("@ENABLE_OPENMP@") # ENABLE_OPENMP
    find_dependency(OpenMP)
 endif()


### PR DESCRIPTION
Basically don't search for the OpenGL package with Emscripten, and provide projectM's fixed FindOpenGL script to find the GLES3 target.