### PR TITLE
Fixed some warnings

### DIFF
--- a/src/libprojectM/ProjectM.cpp
+++ b/src/libprojectM/ProjectM.cpp
@@ -907,6 +907,14 @@ auto ProjectM::ShuffleEnabled() const -> bool
     return m_settings.shuffleEnabled;
 }
 
+void ProjectM::PresetSwitchedEvent(bool hardCut, size_t index) const {}
+
+void ProjectM::ShuffleEnabledValueChanged(bool enabled) const {}
+
+void ProjectM::PresetSwitchFailedEvent(bool hardCut, unsigned int index, const std::string& message) const {}
+
+void ProjectM::PresetRatingChanged(unsigned int index, int rating, PresetRatingType ratingType) const {}
+
 void ProjectM::ChangePresetRating(unsigned int index, int rating, const PresetRatingType ratingType)
 {
     m_presetLoader->setRating(index, rating, ratingType);

--- a/src/libprojectM/ProjectM.cpp
+++ b/src/libprojectM/ProjectM.cpp
@@ -875,7 +875,6 @@ void ProjectM::SelectPresetPosition(unsigned int index)
 
 auto ProjectM::SelectedPresetIndex(unsigned int& index) const -> bool
 {
-
     if (*m_presetPos == m_presetChooser->end())
     {
         return false;
@@ -888,7 +887,6 @@ auto ProjectM::SelectedPresetIndex(unsigned int& index) const -> bool
 
 auto ProjectM::PresetPositionValid() const -> bool
 {
-
     return (*m_presetPos != m_presetChooser->end());
 }
 
@@ -907,13 +905,13 @@ auto ProjectM::ShuffleEnabled() const -> bool
     return m_settings.shuffleEnabled;
 }
 
-void ProjectM::PresetSwitchedEvent(bool hardCut, size_t index) const {}
+void ProjectM::PresetSwitchedEvent(bool, size_t) const {}
 
-void ProjectM::ShuffleEnabledValueChanged(bool enabled) const {}
+void ProjectM::ShuffleEnabledValueChanged(bool) const {}
 
-void ProjectM::PresetSwitchFailedEvent(bool hardCut, unsigned int index, const std::string& message) const {}
+void ProjectM::PresetSwitchFailedEvent(bool, unsigned int, const std::string&) const {}
 
-void ProjectM::PresetRatingChanged(unsigned int index, int rating, PresetRatingType ratingType) const {}
+void ProjectM::PresetRatingChanged(unsigned int, int, PresetRatingType) const {}
 
 void ProjectM::ChangePresetRating(unsigned int index, int rating, const PresetRatingType ratingType)
 {

--- a/src/libprojectM/ProjectM.hpp
+++ b/src/libprojectM/ProjectM.hpp
@@ -278,14 +278,14 @@ public:
     auto ShuffleEnabled() const -> bool;
 
     /// Occurs when active preset has switched. Switched to index is returned
-    virtual void PresetSwitchedEvent(bool hardCut, size_t index) const {};
+    virtual void PresetSwitchedEvent(bool hardCut, size_t index) const;
 
-    virtual void ShuffleEnabledValueChanged(bool enabled) const {};
+    virtual void ShuffleEnabledValueChanged(bool enabled) const;
 
-    virtual void PresetSwitchFailedEvent(bool hardCut, unsigned int index, const std::string& message) const {};
+    virtual void PresetSwitchFailedEvent(bool hardCut, unsigned int index, const std::string& message) const;
 
     /// Occurs whenever preset rating has changed via ChangePresetRating() method
-    virtual void PresetRatingChanged(unsigned int index, int rating, PresetRatingType ratingType) const {};
+    virtual void PresetRatingChanged(unsigned int index, int rating, PresetRatingType ratingType) const;
 
     auto Pcm() -> class Pcm&;
 

--- a/src/libprojectM/ProjectM.hpp
+++ b/src/libprojectM/ProjectM.hpp
@@ -27,12 +27,15 @@
 #include "fatal.h"
 
 #ifdef WIN32
+
+#ifdef _MSC_VER
 // libs required for win32
 #pragma comment(lib, "psapi.lib")
 #pragma comment(lib, "kernel32.lib")
 
 #pragma warning(disable : 4244)
 #pragma warning(disable : 4305)
+#endif /* _MSC_VER */
 
 #include <windows.h>
 #else

--- a/src/libprojectM/Renderer/BeatDetect.cpp
+++ b/src/libprojectM/Renderer/BeatDetect.cpp
@@ -70,15 +70,15 @@ auto BeatDetect::CalculateBeatStatistics() -> void
 
     std::array<float, fftLength> const freqL =
         [this]() {
-            std::array<float, fftLength> freqL{};
-            pcm.GetSpectrum(freqL.data(), CHANNEL_L, fftLength);
-            return freqL;
+            std::array<float, fftLength> freq{};
+            pcm.GetSpectrum(freq.data(), CHANNEL_L, fftLength);
+            return freq;
         }();
     std::array<float, fftLength> const freqR =
         [this]() {
-            std::array<float, fftLength> freqR{};
-            pcm.GetSpectrum(freqR.data(), CHANNEL_R, fftLength);
-            return freqR;
+            std::array<float, fftLength> freq{};
+            pcm.GetSpectrum(freq.data(), CHANNEL_R, fftLength);
+            return freq;
         }();
 
     auto const intensityBetween = [&freqL, &freqR](size_t const from, size_t const to) {

--- a/src/libprojectM/Renderer/Renderer.cpp
+++ b/src/libprojectM/Renderer/Renderer.cpp
@@ -374,7 +374,7 @@ void Renderer::Interpolation(const Pipeline& pipeline, const PipelineContext& pi
 	}
 	else
 	{
-        m_perPixelMesh.Reset();
+		m_perPixelMesh.Reset();
 		Pipeline *cp = m_currentPipeline;
 		omptl::transform(m_perPixelMesh.p.begin(), m_perPixelMesh.p.end(), m_perPixelMesh.identity.begin(), m_perPixelMesh.p.begin(),
 			[cp](PixelPoint point, PerPixelContext &context) {
@@ -391,11 +391,11 @@ void Renderer::Interpolation(const Pipeline& pipeline, const PipelineContext& pi
 				int index = j * m_perPixelMesh.width + i;
 				int index2 = (j + 1) * m_perPixelMesh.width + i;
 
-                m_perPointMeshBuffer[strip + 2] = m_perPixelMesh.p[index].x;
-                m_perPointMeshBuffer[strip + 3] = m_perPixelMesh.p[index].y;
+				m_perPointMeshBuffer[strip + 2] = m_perPixelMesh.p[index].x;
+				m_perPointMeshBuffer[strip + 3] = m_perPixelMesh.p[index].y;
 
-                m_perPointMeshBuffer[strip + 6] = m_perPixelMesh.p[index2].x;
-                m_perPointMeshBuffer[strip + 7] = m_perPixelMesh.p[index2].y;
+				m_perPointMeshBuffer[strip + 6] = m_perPixelMesh.p[index2].x;
+				m_perPointMeshBuffer[strip + 7] = m_perPixelMesh.p[index2].y;
 			}
 		}
 	}


### PR DESCRIPTION
- Use #pragma warning on MSVC only; again this fixes some warnings in client applications
- Fix -Wshadow warnings
- De-inline event function stubs, this fixes some unused parameter warnings, now both when building the library and using the library

The only change which could potentially break ABI (?) is the de-inlining of the event stubs? I wasn't sure what was the best way to solve these warnings. I noticed that, in the past, the names of these parameters have been commented out in ProjectM.hpp, but that was then reverted for some reason?... But then again with a new major release ABI breakage is excepted (4.0?), so let me know what to do about that.