### PR TITLE
Renderer: Fix build with GCC 12

### DIFF
--- a/src/libprojectM/Renderer/Renderer.hpp
+++ b/src/libprojectM/Renderer/Renderer.hpp
@@ -16,6 +16,7 @@
 #include <ctime>
 #include <iostream>
 #include <list>
+#include <memory>
 #include <set>
 #include <string>
 


### PR DESCRIPTION
```
In file included from /projectm/src/libprojectM/Renderer/Renderer.cpp:1:
/projectm/src/libprojectM/Renderer/Renderer.hpp:191:10: error: ‘unique_ptr’ in namespace ‘std’ does not name a template type
  191 |     std::unique_ptr<TextureManager> m_textureManager;
      |          ^~~~~~~~~~
```