### PR TITLE
CMake: set ENABLE_SHARED_LINKING to ON when ENABLE_SHARED_LIB is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 # Feature options, including dependencies.
 option(ENABLE_STATIC_LIB "Build and install libprojectM as a static library" ON)
 cmake_dependent_option(ENABLE_SHARED_LIB "Build and install libprojectM as a shared library" ON "NOT ENABLE_EMSCRIPTEN" OFF)
-cmake_dependent_option(ENABLE_SHARED_LINKING "Link the SDL test UI against the shared library." OFF "ENABLE_SHARED_LIB" OFF)
+cmake_dependent_option(ENABLE_SHARED_LINKING "Link the SDL test UI against the shared library." ON "ENABLE_SHARED_LIB" OFF)
 option(ENABLE_DOXYGEN "Build and install Doxygen source code documentation in PROJECTM_DATADIR_PATH/docs." OFF)
 option(ENABLE_CXX_INTERFACE "Enable exporting all C++ symbols, not only the C API, in the shared library. Warning: This is not very portable." OFF)
 option(ENABLE_PRESETS "Build and install bundled presets" ON)


### PR DESCRIPTION
This fixes the following CMake error when configuring with just -DENABLE_STATIC_LIB=OFF:

CMake Error at src/libprojectM/CMakeLists.txt:130 (add_library):
  add_library cannot create ALIAS target "projectM::libprojectM" because
  target "projectM_static" does not already exist.

In this case, static linking is disabled, thus the "projectM_static" CMake target doesn't exist. Previously, ENABLE_SHARED_LINKING was always false, and because of that, "projectM::libprojectM" was added as as an alias to "projectM_static", which didn't exist.

Now, ENABLE_SHARED_LINKING is set to true only when ENABLE_SHARED_LIB is enabled, otherwise it will be false.