### PR TITLE
Control debug frame saving via API

### DIFF
--- a/src/libprojectM/KeyHandler.cpp
+++ b/src/libprojectM/KeyHandler.cpp
@@ -113,9 +113,6 @@ void ProjectM::DefaultKeyHandler(projectMEvent event, projectMKeycode keycode) {
 		    break;
 	    case PROJECTM_K_i:
 	        break;
-		case PROJECTM_K_d:	// d stands for write DEBUG output.
-            m_renderer->writeNextFrameToFile = true;
-			break;
 	    case PROJECTM_K_EQUALS:
 	    case PROJECTM_K_PLUS:
 

--- a/src/libprojectM/ProjectM.cpp
+++ b/src/libprojectM/ProjectM.cpp
@@ -184,6 +184,13 @@ void ProjectM::ReadSettings(const class Settings& settings)
     Initialize();
 }
 
+
+void ProjectM::DumpDebugImageOnNextFrame()
+{
+    m_renderer->writeNextFrameToFile = true;
+}
+
+
 #if USE_THREADS
 
 void ProjectM::ThreadWorker()

--- a/src/libprojectM/ProjectM.hpp
+++ b/src/libprojectM/ProjectM.hpp
@@ -270,6 +270,13 @@ public:
 
     void DefaultKeyHandler(projectMEvent event, projectMKeycode keycode);
 
+    /**
+     * @brief Dumps a debug image to the working dir when the next frame is rendered.
+     *
+     * The main texture is dumped after render pass 1, e.g. before shaders are applied.
+     */
+    void DumpDebugImageOnNextFrame();
+
 private:
     void EvaluateSecondPreset();
 

--- a/src/libprojectM/ProjectMCWrapper.cpp
+++ b/src/libprojectM/ProjectMCWrapper.cpp
@@ -674,3 +674,10 @@ auto projectm_pcm_add_uint8(projectm_handle instance, const uint8_t* samples, un
 {
     PcmAdd(instance, samples, count, channels);
 }
+
+auto projectm_write_debug_image_on_next_frame(projectm_handle instance) -> void
+{
+    auto* projectMInstance = handle_to_instance(instance);
+
+    projectMInstance->DumpDebugImageOnNextFrame();
+}

--- a/src/libprojectM/Renderer/Renderer.hpp
+++ b/src/libprojectM/Renderer/Renderer.hpp
@@ -102,7 +102,7 @@ public:
     bool correction{ true };
 
     bool noSwitch{ false };
-    bool writeNextFrameToFile;
+    bool writeNextFrameToFile{ false };
 
     milliseconds lastTimeFPS{ nowMilliseconds() };
     milliseconds currentTimeFPS{ nowMilliseconds() };

--- a/src/libprojectM/projectM.h
+++ b/src/libprojectM/projectM.h
@@ -923,6 +923,15 @@ PROJECTM_EXPORT void projectm_pcm_add_int16(projectm_handle instance, const int1
 PROJECTM_EXPORT void projectm_pcm_add_uint8(projectm_handle instance, const uint8_t* samples,
                                                      unsigned int count, projectm_channels channels);
 
+/**
+ * @brief Writes a .bmp framedump after rendering the next main texture, before shaders are applied.
+ *
+ * The image is written to the current working directory and is named "frame_texture_contents-[date].bmp".
+ *
+ * @param instance The projectM instance handle.
+ */
+PROJECTM_EXPORT void projectm_write_debug_image_on_next_frame(projectm_handle instance);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif


### PR DESCRIPTION
Fixed a bug with an uninitialized member, removed the "d" hotkey and added an API function which can be used to write debug images if required. The filename and path can't be controlled, the file is written to the current working directory with a fixed filename containing a timestamp.

For proper render debugging I suggest using [RenderDoc](https://renderdoc.org/) anyway, as this reveals all GL draw calls and state changes.

Fixes issue #656