### PR TITLE
Fix file type string

### DIFF
--- a/src/libprojectM/ProjectM.cpp
+++ b/src/libprojectM/ProjectM.cpp
@@ -95,7 +95,7 @@ void ProjectM::LoadPresetData(std::istream& presetData, bool smoothTransition)
 
     try
     {
-        StartPresetTransition(m_presetFactoryManager.CreatePresetFromStream("milk", presetData), !smoothTransition);
+        StartPresetTransition(m_presetFactoryManager.CreatePresetFromStream(".milk", presetData), !smoothTransition);
     }
     catch (const PresetFactoryException& ex)
     {


### PR DESCRIPTION
Quick fix for function: LoadPresetData()

The file type string was missing the "." before "milk", causing the load to fail.