### PR TITLE
Playlist API improvements

### DIFF
--- a/src/playlist/PlaylistCWrapper.cpp
+++ b/src/playlist/PlaylistCWrapper.cpp
@@ -380,6 +380,13 @@ uint32_t projectm_playlist_remove_presets(projectm_playlist_handle instance, uin
 }
 
 
+bool projectm_playlist_get_shuffle(projectm_playlist_handle instance)
+{
+    auto* playlist = playlist_handle_to_instance(instance);
+    return playlist->Shuffle();
+}
+
+
 void projectm_playlist_set_shuffle(projectm_playlist_handle instance, bool shuffle)
 {
     auto* playlist = playlist_handle_to_instance(instance);

--- a/src/playlist/PlaylistCWrapper.cpp
+++ b/src/playlist/PlaylistCWrapper.cpp
@@ -218,21 +218,26 @@ void projectm_playlist_clear(projectm_playlist_handle instance)
 }
 
 
-auto projectm_playlist_items(projectm_playlist_handle instance) -> char**
+auto projectm_playlist_items(projectm_playlist_handle instance, uint32_t start, uint32_t count) -> char**
 {
     auto* playlist = playlist_handle_to_instance(instance);
 
-    auto& items = playlist->Items();
+    const auto& items = playlist->Items();
 
-    auto* array = new char* [items.size() + 1] {};
-
-    int index{0};
-    for (const auto& item : items)
+    if (start >= items.size())
     {
-        auto filename = item.Filename();
-        array[index] = new char[filename.length() + 1]{};
-        filename.copy(array[index], filename.length());
-        index++;
+        auto* array = new char* [1] {};
+        return array;
+    }
+
+    size_t endPos = std::min(static_cast<size_t>(start + count), items.size());
+    auto* array = new char* [endPos - start + 1] {};
+
+    for (size_t index{start}; index < endPos; index++)
+    {
+        auto filename = items[index].Filename();
+        array[index - start] = new char[filename.length() + 1]{};
+        filename.copy(array[index - start], filename.length());
     }
 
     return array;

--- a/src/playlist/playlist.h
+++ b/src/playlist/playlist.h
@@ -332,6 +332,13 @@ uint32_t projectm_playlist_remove_presets(projectm_playlist_handle instance, uin
                                           uint32_t count);
 
 /**
+ * @brief Retrieves the current state of shuffle mode.
+ * @param instance The playlist manager instance.
+ * @return True if shuffle mode is enabled, false otherwise.
+ */
+bool projectm_playlist_get_shuffle(projectm_playlist_handle instance);
+
+/**
  * @brief Enable or disable shuffle mode.
  * @param instance The playlist manager instance.
  * @param shuffle True to enable random shuffling, false to play presets in playlist order.

--- a/src/playlist/playlist.h
+++ b/src/playlist/playlist.h
@@ -172,15 +172,23 @@ uint32_t projectm_playlist_size(projectm_playlist_handle instance);
 void projectm_playlist_clear(projectm_playlist_handle instance);
 
 /**
- * @brief Returns a list of all preset files in the current playlist, in order.
+ * @brief Returns a list of preset files inside the given range of the current playlist, in order.
+ *
+ * This function can be used to return the whole playlist to save it to a file, or just a part of
+ * it for use in virtual lists. If less elements than given in @a count are available, only the
+ * remainder of items after the starting index are returned. If the starting index equals or exceeds
+ * the playlist size, an empty list is returned.
+ *
  * @note Call projectm_playlist_free_string_array() when you're done using the list.
- * @note Ideally, don't rely on the playlist size to iterate over the filenames. Instead, look for
- *       the terminating null pointer to abort the loop.
+ * @note Ideally, don't rely on the value provided as count to iterate over the filenames.
+ *       Instead, look for the terminating null pointer to abort the loop.
  * @param instance The playlist manager instance.
+ * @param start The zero-based starting index of the range to return.
+ * @param count The maximum number if items to return.
  * @return A pointer to a list of char pointers, each containing a single preset. The last entry
  *         is denoted by a null pointer.
  */
-char** projectm_playlist_items(projectm_playlist_handle instance);
+char** projectm_playlist_items(projectm_playlist_handle instance, uint32_t start, uint32_t count);
 
 /**
  * @brief Returns the name of a preset at the given index in the current playlist.

--- a/tests/playlist/APITest.cpp
+++ b/tests/playlist/APITest.cpp
@@ -270,6 +270,18 @@ TEST(projectMPlaylistAPI, RemovePresets)
 }
 
 
+TEST(projectMPlaylistAPI, GetShuffle)
+{
+    PlaylistCWrapperMock mockPlaylist;
+
+    EXPECT_CALL(mockPlaylist, Shuffle())
+        .Times(1)
+        .WillOnce(Return(true));
+
+    EXPECT_TRUE(projectm_playlist_get_shuffle(reinterpret_cast<projectm_playlist_handle>(&mockPlaylist)));
+}
+
+
 TEST(projectMPlaylistAPI, SetShuffle)
 {
     PlaylistCWrapperMock mockPlaylist;

--- a/tests/playlist/PlaylistCWrapperMock.h
+++ b/tests/playlist/PlaylistCWrapperMock.h
@@ -21,6 +21,7 @@ public:
     MOCK_METHOD(bool, AddItem, (const std::string&, uint32_t, bool) );
     MOCK_METHOD(uint32_t, AddPath, (const std::string&, uint32_t, bool, bool) );
     MOCK_METHOD(bool, RemoveItem, (uint32_t));
+    MOCK_METHOD(bool, Shuffle, (), (const));
     MOCK_METHOD(void, SetShuffle, (bool) );
     MOCK_METHOD(void, Sort, (uint32_t, uint32_t, SortPredicate, SortOrder));
     MOCK_METHOD(uint32_t, RetryCount, ());


### PR DESCRIPTION
Two small additions to the playlist API for more convenience:
- Added missing getter methd to return shuffle mode.
- Added start/count parameters to `projectm_playlist_items()` to enable returning only a range of items in the playlist if needed.