### PR TITLE
Let developers provide an optional filename for dumping main texture contents.

### DIFF
--- a/src/api/include/libprojectM/debug.h
+++ b/src/api/include/libprojectM/debug.h
@@ -32,13 +32,23 @@ extern "C" {
 #endif
 
 /**
- * @brief Writes a .bmp framedump after rendering the next main texture, before shaders are applied.
+ * @brief Writes a .bmp main texture dump after rendering the next main texture, before shaders are applied.
  *
- * The image is written to the current working directory and is named "frame_texture_contents-[date].bmp".
+ * If no file name is given, the image is written to the current working directory
+ * and will be named named "frame_texture_contents-YYYY-mm-dd-HH:MM:SS-frame.bmp".
+ *
+ * Note this is the main texture contents, not the final rendering result. If the active preset
+ * uses a composite shader, the dumped image will not have it applied. The main texture is what is
+ * passed over to the next frame, the composite shader is only applied to the display framebuffer
+ * after updating the main texture.
+ *
+ * To capture the actual output, dump the contents of the main framebuffer after calling
+ * @a projectm_render_frame() on the application side.
  *
  * @param instance The projectM instance handle.
+ * @param output_file The filename to write the dump to or NULL.
  */
-PROJECTM_EXPORT void projectm_write_debug_image_on_next_frame(projectm_handle instance);
+PROJECTM_EXPORT void projectm_write_debug_image_on_next_frame(projectm_handle instance, const char* output_file);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/libprojectM/ProjectM.cpp
+++ b/src/libprojectM/ProjectM.cpp
@@ -115,8 +115,9 @@ void ProjectM::ResetTextures()
     m_renderer->ResetTextures();
 }
 
-void ProjectM::DumpDebugImageOnNextFrame()
+void ProjectM::DumpDebugImageOnNextFrame(const std::string& outputFile)
 {
+    m_renderer->frameDumpOutputFile = outputFile;
     m_renderer->writeNextFrameToFile = true;
 }
 

--- a/src/libprojectM/ProjectM.hpp
+++ b/src/libprojectM/ProjectM.hpp
@@ -208,7 +208,7 @@ public:
      *
      * The main texture is dumped after render pass 1, e.g. before shaders are applied.
      */
-    void DumpDebugImageOnNextFrame();
+    void DumpDebugImageOnNextFrame(const std::string& outputFile);
 
 private:
     void EvaluateSecondPreset();

--- a/src/libprojectM/ProjectMCWrapper.cpp
+++ b/src/libprojectM/ProjectMCWrapper.cpp
@@ -388,9 +388,15 @@ auto projectm_pcm_add_uint8(projectm_handle instance, const uint8_t* samples, un
     PcmAdd(instance, samples, count, channels);
 }
 
-auto projectm_write_debug_image_on_next_frame(projectm_handle instance) -> void
+auto projectm_write_debug_image_on_next_frame(projectm_handle instance, const char* output_file) -> void
 {
     auto* projectMInstance = handle_to_instance(instance);
 
-    projectMInstance->DumpDebugImageOnNextFrame();
+    std::string outputFile;
+    if (output_file)
+    {
+        outputFile = output_file;
+    }
+
+    projectMInstance->DumpDebugImageOnNextFrame(outputFile);
 }

--- a/src/libprojectM/Renderer/Renderer.hpp
+++ b/src/libprojectM/Renderer/Renderer.hpp
@@ -104,6 +104,7 @@ public:
     bool correction{ true };
 
     bool writeNextFrameToFile{ false };
+    std::string frameDumpOutputFile;
 
     milliseconds lastTimeFPS{ nowMilliseconds() };
     milliseconds currentTimeFPS{ nowMilliseconds() };


### PR DESCRIPTION
Application developers can now pass a specific filename for dumping the next frame instead of having to iterate the current working dir and search for the latest file themselves. If NULL is passed, the file will be written with the same generated filename as before.