### PR TITLE
Remove unused texture size setter and render-to-texture function.

### DIFF
--- a/src/api/include/libprojectM/parameters.h
+++ b/src/api/include/libprojectM/parameters.h
@@ -46,21 +46,6 @@ PROJECTM_EXPORT void projectm_set_texture_search_paths(projectm_handle instance,
                                                        size_t count);
 
 /**
- * @brief Changes the size of the internal render texture.
- * @note This will recreate the internal renderer.
- * @param instance The projectM instance handle.
- * @param size The new size of the render texture. Must be a power of 2.
- */
-PROJECTM_EXPORT void projectm_set_texture_size(projectm_handle instance, size_t size);
-
-/**
- * @brief Returns the size of the internal render texture.
- * @param instance The projectM instance handle.
- * @return The size of the internal rendering texture.
- */
-PROJECTM_EXPORT size_t projectm_get_texture_size(projectm_handle instance);
-
-/**
  * @brief Sets the beat sensitivity.
  *
  * The beat sensitivity to be used.

--- a/src/api/include/libprojectM/render_opengl.h
+++ b/src/api/include/libprojectM/render_opengl.h
@@ -41,17 +41,6 @@ extern "C" {
  */
 PROJECTM_EXPORT void projectm_opengl_render_frame(projectm_handle instance);
 
-/**
- * @brief Enables render-to-texture.
- *
- * Useful if projectM output will be part of a more complex OpenGL scene. The size of the texture is determined by the
- * given viewport size and the dimensions should be a power of 2.
- *
- * @param instance The projectM instance handle.
- * @return A GLuint value with the texture ID projectM will render to.
- */
-PROJECTM_EXPORT unsigned int projectm_opengl_init_render_to_texture(projectm_handle instance);
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/libprojectM/ProjectM.cpp
+++ b/src/libprojectM/ProjectM.cpp
@@ -99,11 +99,6 @@ void ProjectM::LoadPresetData(std::istream& presetData, bool smoothTransition)
     }
 }
 
-auto ProjectM::InitRenderToTexture() -> unsigned
-{
-    return m_renderer->initRenderToTexture();
-}
-
 void ProjectM::SetTexturePaths(std::vector<std::string> texturePaths)
 {
     m_textureSearchPaths = std::move(texturePaths);

--- a/src/libprojectM/ProjectM.cpp
+++ b/src/libprojectM/ProjectM.cpp
@@ -411,18 +411,6 @@ auto ProjectM::PresetLocked() const -> bool
     return m_presetLocked;
 }
 
-void ProjectM::SetTextureSize(size_t size)
-{
-    m_textureSize = size;
-
-    RecreateRenderer();
-}
-
-auto ProjectM::TextureSize() const -> size_t
-{
-    return m_textureSize;
-}
-
 void ProjectM::SetBeatSensitivity(float sensitivity)
 {
     m_beatDetect->beatSensitivity = std::min(std::max(0.0f, sensitivity), 2.0f);

--- a/src/libprojectM/ProjectM.hpp
+++ b/src/libprojectM/ProjectM.hpp
@@ -125,8 +125,6 @@ public:
 
     void RenderFrame();
 
-    auto InitRenderToTexture() -> unsigned;
-
     void SetBeatSensitivity(float sensitivity);
 
     auto GetBeatSensitivity() const -> float;

--- a/src/libprojectM/ProjectM.hpp
+++ b/src/libprojectM/ProjectM.hpp
@@ -127,10 +127,6 @@ public:
 
     auto InitRenderToTexture() -> unsigned;
 
-    void SetTextureSize(size_t size);
-
-    auto TextureSize() const -> size_t;
-
     void SetBeatSensitivity(float sensitivity);
 
     auto GetBeatSensitivity() const -> float;
@@ -251,7 +247,6 @@ private:
     size_t m_meshX{32};              //!< Per-point mesh horizontal resolution.
     size_t m_meshY{24};              //!< Per-point mesh vertical resolution.
     size_t m_targetFps{35};          //!< Target frames per second.
-    size_t m_textureSize{512};       //!< Render texture size.
     size_t m_windowWidth{0};         //!< Render window width. If 0, nothing is rendered.
     size_t m_windowHeight{0};        //!< Render window height. If 0, nothing is rendered.
     double m_presetDuration{30.0};   //!< Preset duration in seconds.

--- a/src/libprojectM/ProjectMCWrapper.cpp
+++ b/src/libprojectM/ProjectMCWrapper.cpp
@@ -166,12 +166,6 @@ void projectm_opengl_render_frame(projectm_handle instance)
     projectMInstance->RenderFrame();
 }
 
-unsigned int projectm_opengl_init_render_to_texture(projectm_handle instance)
-{
-    auto projectMInstance = handle_to_instance(instance);
-    return projectMInstance->InitRenderToTexture();
-}
-
 void projectm_set_beat_sensitivity(projectm_handle instance, float sensitivity)
 {
     auto projectMInstance = handle_to_instance(instance);

--- a/src/libprojectM/ProjectMCWrapper.cpp
+++ b/src/libprojectM/ProjectMCWrapper.cpp
@@ -172,18 +172,6 @@ unsigned int projectm_opengl_init_render_to_texture(projectm_handle instance)
     return projectMInstance->InitRenderToTexture();
 }
 
-size_t projectm_get_texture_size(projectm_handle instance)
-{
-    auto projectMInstance = handle_to_instance(instance);
-    return projectMInstance->TextureSize();
-}
-
-void projectm_set_texture_size(projectm_handle instance, size_t size)
-{
-    auto projectMInstance = handle_to_instance(instance);
-    projectMInstance->SetTextureSize(size);
-}
-
 void projectm_set_beat_sensitivity(projectm_handle instance, float sensitivity)
 {
     auto projectMInstance = handle_to_instance(instance);

--- a/src/libprojectM/Renderer/Renderer.cpp
+++ b/src/libprojectM/Renderer/Renderer.cpp
@@ -408,25 +408,6 @@ void Renderer::reset(int viewportWidth, int viewportHeight)
 	glClear(GL_COLOR_BUFFER_BIT);
 }
 
-GLuint Renderer::initRenderToTexture()
-{
-	if (textureRenderToTexture == 0)
-	{
-		glGenTextures(1, &textureRenderToTexture);
-		glBindTexture(GL_TEXTURE_2D, textureRenderToTexture);
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, m_textureSizeX, m_textureSizeY, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-		glBindTexture(GL_TEXTURE_2D, 0);
-	}
-
-	return textureRenderToTexture;
-}
-
-float title_y;
-
 bool Renderer::timeCheck(const milliseconds currentTime, const milliseconds lastTime, const double difference) {
 	milliseconds ms = std::chrono::duration_cast<std::chrono::milliseconds>(currentTime - lastTime);
 	double diff = ms.count();

--- a/src/libprojectM/Renderer/Renderer.cpp
+++ b/src/libprojectM/Renderer/Renderer.cpp
@@ -352,8 +352,6 @@ Renderer::~Renderer()
 
 	glDeleteBuffers(1, &m_vboCompositeOutput);
 	glDeleteVertexArrays(1, &m_vaoCompositeOutput);
-
-	glDeleteTextures(1, &textureRenderToTexture);
 }
 
 void Renderer::reset(int viewportWidth, int viewportHeight)

--- a/src/libprojectM/Renderer/Renderer.cpp
+++ b/src/libprojectM/Renderer/Renderer.cpp
@@ -134,8 +134,8 @@ void Renderer::SetPipeline(Pipeline& pipeline)
 
 void Renderer::ResetTextures()
 {
-    m_textureManager = std::make_unique<TextureManager>(m_textureSearchPaths, m_textureSizeX, m_textureSizeY);
-    m_shaderEngine.setParams(m_textureSizeX, m_textureSizeY, m_fAspectX, m_fAspectY, m_beatDetect, m_textureManager.get());
+    m_textureManager = std::make_unique<TextureManager>(m_textureSearchPaths, m_mainTextureSizeX, m_mainTextureSizeY);
+    m_shaderEngine.setParams(m_mainTextureSizeX, m_mainTextureSizeY, m_fAspectX, m_fAspectY, m_beatDetect, m_textureManager.get());
 }
 
 void Renderer::SetTextureSearchPaths(std::vector<std::string>& textureSearchPaths)
@@ -154,7 +154,7 @@ void Renderer::SetupPass1(const Pipeline& pipeline, const PipelineContext& pipel
 {
 	totalframes++;
 
-	glViewport(0, 0, m_textureSizeX, m_textureSizeY);
+	glViewport(0, 0, m_mainTextureSizeX, m_mainTextureSizeY);
 
     m_renderContext.mat_ortho = glm::ortho(0.0f, 1.0f, 0.0f, 1.0f, -40.0f, 40.0f);
 }
@@ -162,7 +162,7 @@ void Renderer::SetupPass1(const Pipeline& pipeline, const PipelineContext& pipel
 void Renderer::RenderItems(const Pipeline& pipeline, const PipelineContext& pipelineContext)
 {
     m_renderContext.time = pipelineContext.time;
-    m_renderContext.texsize = nearestPower2(std::max(m_textureSizeX, m_textureSizeY));
+    m_renderContext.texsize = nearestPower2(std::max(m_mainTextureSizeX, m_mainTextureSizeY));
     m_renderContext.viewportSizeX = m_viewportWidth;
     m_renderContext.viewportSizeY = m_viewportHeight;
     m_renderContext.aspectX = m_fAspectX;
@@ -371,15 +371,15 @@ void Renderer::reset(int viewportWidth, int viewportHeight)
 
 	glEnable(GL_BLEND);
 
-    m_textureSizeX = viewportWidth;
-    m_textureSizeY = viewportHeight;
+    m_mainTextureSizeX = viewportWidth;
+    m_mainTextureSizeY = viewportHeight;
 
 	// snap to 16x16 blocks
-    m_textureSizeX = ((m_textureSizeX - 15) / 16) * 16;
-    m_textureSizeY = ((m_textureSizeY - 15) / 16) * 16;
+    m_mainTextureSizeX = ((m_mainTextureSizeX - 15) / 16) * 16;
+    m_mainTextureSizeY = ((m_mainTextureSizeY - 15) / 16) * 16;
 
-	m_fAspectX = (m_textureSizeY > m_textureSizeX) ? static_cast<float>(m_textureSizeX) / static_cast<float>(m_textureSizeY) : 1.0f;
-	m_fAspectY = (m_textureSizeX > m_textureSizeY) ? static_cast<float>(m_textureSizeY) / static_cast<float>(m_textureSizeX) : 1.0f;
+	m_fAspectX = (m_mainTextureSizeY > m_mainTextureSizeX) ? static_cast<float>(m_mainTextureSizeX) / static_cast<float>(m_mainTextureSizeY) : 1.0f;
+	m_fAspectY = (m_mainTextureSizeX > m_mainTextureSizeY) ? static_cast<float>(m_mainTextureSizeY) / static_cast<float>(m_mainTextureSizeX) : 1.0f;
 
     m_fInvAspectX = 1.0f / m_fAspectX;
     m_fInvAspectY = 1.0f / m_fAspectY;

--- a/src/libprojectM/Renderer/Renderer.hpp
+++ b/src/libprojectM/Renderer/Renderer.hpp
@@ -165,8 +165,8 @@ private:
 
     std::vector<MilkdropWaveform> m_waveformList;
 
-    int m_textureSizeX{0};
-    int m_textureSizeY{0};
+    int m_mainTextureSizeX{0};
+    int m_mainTextureSizeY{0};
 
     float m_fAspectX{1.0};
     float m_fAspectY{1.0};

--- a/src/libprojectM/Renderer/Renderer.hpp
+++ b/src/libprojectM/Renderer/Renderer.hpp
@@ -123,11 +123,7 @@ private:
     void CompositeShaderOutput(const Pipeline& pipeline, const PipelineContext& pipelineContext);
     void CompositeOutput(const Pipeline& pipeline, const PipelineContext& pipelineContext);
     void ResetPerPointMeshBuffer();
-
     int nearestPower2(int value);
-
-    GLuint textureRenderToTexture{0};
-
     void InitCompositeShaderVertex();
     float SquishToCenter(float x, float fExp);
     void UvToMathSpace(float u, float v, float* rad, float* ang);

--- a/src/libprojectM/Renderer/Renderer.hpp
+++ b/src/libprojectM/Renderer/Renderer.hpp
@@ -72,7 +72,6 @@ public:
   void SetTextureSearchPaths(std::vector<std::string>& textureSearchPaths);
   void SetPerPixelMeshSize(int meshX, int meshY);
   void reset(int viewportWidth, int viewportHeight);
-  GLuint initRenderToTexture();
 
   bool timeCheck(const milliseconds currentTime, const milliseconds lastTime, const double difference);
 


### PR DESCRIPTION
These function never did anything useful. FBO rendering support as mentiond in issue #659 will take care of this in a more compatible way.