### PR TITLE
Fix unused variable warnings in release mode

### DIFF
--- a/src/libprojectM/Renderer/hlslparser/src/HLSLTree.cpp
+++ b/src/libprojectM/Renderer/hlslparser/src/HLSLTree.cpp
@@ -2035,6 +2035,7 @@ struct StatementList {
                 // @@ Output function as is?
                 // @@ We have to flatten function arguments! This is tricky, need to handle input/output arguments.
                 assert(!NeedsFlattening(functionCall->argument));
+                (void)functionCall;
                 
                 return AddExpressionStatement(expr, statements, wantIdent);
             }


### PR DESCRIPTION
The assert()'s are removed in release mode causing unused variable warning noise.