### PR TITLE
Remove obsolete defines from the buildsystem

### DIFF
--- a/features.cmake
+++ b/features.cmake
@@ -83,7 +83,6 @@ unset(_std_c_headers)
 file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/include")
 configure_file(config.h.cmake.in "${CMAKE_BINARY_DIR}/include/config.h")
 include_directories("${CMAKE_BINARY_DIR}/include")
-add_compile_definitions(HAVE_CONFIG_H)
 
 # Force-include the file in all targets
 if(MSVC)

--- a/src/libprojectM/CMakeLists.txt
+++ b/src/libprojectM/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_compile_definitions(
         DATADIR_PATH="${PROJECTM_DATADIR_PATH}"
-        GL_SILENCE_DEPRECATION
+        $<IF:$<PLATFORM_ID:Darwin>,GL_SILENCE_DEPRECATION,>
 )
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")

--- a/src/libprojectM/CMakeLists.txt
+++ b/src/libprojectM/CMakeLists.txt
@@ -1,19 +1,15 @@
 add_compile_definitions(
         DATADIR_PATH="${PROJECTM_DATADIR_PATH}"
         $<IF:$<PLATFORM_ID:Darwin>,GL_SILENCE_DEPRECATION,>
+        $<IF:$<PLATFORM_ID:Windows>,NOMINMAX,>
+        $<IF:$<PLATFORM_ID:Windows>,WIN32_LEAN_AND_MEAN,>
+        $<IF:$<PLATFORM_ID:Windows>,STBI_NO_DDS,>
 )
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     # dirent.h support
     set(MSVC_EXTRA_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/msvc")
     include_directories("${MSVC_EXTRA_INCLUDE_DIR}")
-
-    # Additional preprocessor definitions for Windows builds
-    add_compile_definitions(
-            NOMINMAX
-            WIN32_LEAN_AND_MEAN
-            STBI_NO_DDS
-    )
 endif()
 
 # List of targets used in export().

--- a/src/libprojectM/CMakeLists.txt
+++ b/src/libprojectM/CMakeLists.txt
@@ -12,11 +12,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     add_compile_definitions(
             NOMINMAX
             WIN32_LEAN_AND_MEAN
-            USE_FTGL
-            USE_NATIVE_GLEW
             STBI_NO_DDS
-            projectM_FONT_MENU="${CMAKE_SOURCE_DIR}/fonts/VeraMono.ttf"
-            projectM_FONT_TITLE="${CMAKE_SOURCE_DIR}/fonts/Vera.ttf"
     )
 endif()
 


### PR DESCRIPTION
None of these defines are used anywhere in the code, so they should be safe to delete.