### PR TITLE
Fix filenames of static libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,9 @@ project(libprojectM
 # functions. Adding new function should be okay if documented.
 set(PROJECTM_SO_VERSION "4")
 
+# Base filename of all installed libraries. Also used as package name in pkgconfig.
+set(PROJECTM_LIBRARY_BASE_OUTPUT_NAME "projectM-${PROJECT_VERSION_MAJOR}")
+
 # The actual (full) library version of projectM
 set(PROJECTM_LIB_VERSION "${CMAKE_PROJECT_VERSION}")
 

--- a/src/libprojectM/CMakeLists.txt
+++ b/src/libprojectM/CMakeLists.txt
@@ -135,7 +135,7 @@ else()
             )
 
     set_target_properties(projectM PROPERTIES
-            OUTPUT_NAME $<IF:$<PLATFORM_ID:Windows>,libprojectM,projectM>
+            OUTPUT_NAME $<IF:$<PLATFORM_ID:Windows>,libprojectM-4,projectM-4>
             FOLDER libprojectM
             )
 endif()

--- a/src/libprojectM/CMakeLists.txt
+++ b/src/libprojectM/CMakeLists.txt
@@ -115,7 +115,7 @@ set_target_properties(projectM PROPERTIES
         VERSION "${PROJECTM_LIB_VERSION}"
         SOVERSION "${PROJECTM_SO_VERSION}"
         FOLDER libprojectM
-        OUTPUT_NAME projectM-4
+        OUTPUT_NAME ${PROJECTM_LIBRARY_BASE_OUTPUT_NAME}
         )
 
 if(BUILD_SHARED_LIBS)
@@ -135,7 +135,7 @@ else()
             )
 
     set_target_properties(projectM PROPERTIES
-            OUTPUT_NAME $<IF:$<PLATFORM_ID:Windows>,libprojectM-4,projectM-4>
+            OUTPUT_NAME $<IF:$<PLATFORM_ID:Windows>,lib${PROJECTM_LIBRARY_BASE_OUTPUT_NAME},${PROJECTM_LIBRARY_BASE_OUTPUT_NAME}>
             FOLDER libprojectM
             )
 endif()
@@ -251,11 +251,11 @@ if(ENABLE_INSTALL)
             endforeach()
         endif()
 
-        set(PKGCONFIG_PACKAGE_NAME "projectM-4")
+        set(PKGCONFIG_PACKAGE_NAME "${PROJECTM_LIBRARY_BASE_OUTPUT_NAME}")
         set(PKGCONFIG_PACKAGE_DESCRIPTION "projectM Music Visualizer")
         set(PKGCONFIG_PACKAGE_REQUIREMENTS_ALL "opengl")
 
-        generate_pkg_config_files(projectM projectM-4)
+        generate_pkg_config_files(projectM ${PROJECTM_LIBRARY_BASE_OUTPUT_NAME})
 
     endif()
 

--- a/src/playlist/CMakeLists.txt
+++ b/src/playlist/CMakeLists.txt
@@ -43,7 +43,7 @@ set_target_properties(projectM_playlist PROPERTIES
         SOVERSION "${PROJECTM_SO_VERSION}"
         EXPORT_NAME playlist
         FOLDER libprojectM
-        OUTPUT_NAME projectM-4-playlist
+        OUTPUT_NAME ${PROJECTM_LIBRARY_BASE_OUTPUT_NAME}-playlist
         )
 
 target_include_directories(projectM_playlist
@@ -75,7 +75,7 @@ else()
             )
 
     set_target_properties(projectM_playlist PROPERTIES
-            OUTPUT_NAME $<IF:$<PLATFORM_ID:Windows>,libprojectM-4-playlist,projectM-4-playlist>
+            OUTPUT_NAME $<IF:$<PLATFORM_ID:Windows>,lib${PROJECTM_LIBRARY_BASE_OUTPUT_NAME}-playlist,${PROJECTM_LIBRARY_BASE_OUTPUT_NAME}-playlist>
             FOLDER libprojectM
             )
 endif()
@@ -149,12 +149,12 @@ if(ENABLE_INSTALL)
     if(UNIX)
         include(GeneratePkgConfigFiles)
 
-        set(PKGCONFIG_PACKAGE_NAME "projectM-4-playlist")
+        set(PKGCONFIG_PACKAGE_NAME "${PROJECTM_LIBRARY_BASE_OUTPUT_NAME}-playlist")
         set(PKGCONFIG_PACKAGE_DESCRIPTION "projectM Playlist Library")
-        set(PKGCONFIG_PACKAGE_REQUIREMENTS_RELEASE "projectM-4")
-        set(PKGCONFIG_PACKAGE_REQUIREMENTS_DEBUG "projectM-4-debug")
+        set(PKGCONFIG_PACKAGE_REQUIREMENTS_RELEASE "${PROJECTM_LIBRARY_BASE_OUTPUT_NAME}")
+        set(PKGCONFIG_PACKAGE_REQUIREMENTS_DEBUG "${PROJECTM_LIBRARY_BASE_OUTPUT_NAME}-debug")
 
-        generate_pkg_config_files(projectM_playlist projectM-4-playlist)
+        generate_pkg_config_files(projectM_playlist ${PROJECTM_LIBRARY_BASE_OUTPUT_NAME}-playlist)
     endif()
 
 endif()

--- a/src/playlist/CMakeLists.txt
+++ b/src/playlist/CMakeLists.txt
@@ -75,7 +75,7 @@ else()
             )
 
     set_target_properties(projectM_playlist PROPERTIES
-            OUTPUT_NAME $<IF:$<PLATFORM_ID:Windows>,libprojectM_playlist,projectM_playlist>
+            OUTPUT_NAME $<IF:$<PLATFORM_ID:Windows>,libprojectM-4-playlist,projectM-4-playlist>
             FOLDER libprojectM
             )
 endif()


### PR DESCRIPTION
These were missing the "-4" suffix, and the static playlist library also used underscores instead of dashes.