### PR TITLE
Constrain/clamp per-pixel mesh size to [8,300] and even values.

### DIFF
--- a/src/api/include/projectM-4/parameters.h
+++ b/src/api/include/projectM-4/parameters.h
@@ -159,7 +159,8 @@ PROJECTM_EXPORT double projectm_get_preset_duration(projectm_handle instance);
 
 /**
  * @brief Sets the per-pixel equation mesh size in units.
- * @note This will currently remove any active presets and reload the default "idle" preset.
+ * Will internally be clamped to [8,300] in each axis. If any dimension is set to an odd value, it will be incremented by 1
+ * so only multiples of two are used.
  * @param instance The projectM instance handle.
  * @param width The new width of the mesh.
  * @param height The new height of the mesh.

--- a/src/libprojectM/ProjectM.cpp
+++ b/src/libprojectM/ProjectM.cpp
@@ -429,6 +429,21 @@ void ProjectM::SetMeshSize(size_t meshResolutionX, size_t meshResolutionY)
     m_meshX = meshResolutionX;
     m_meshY = meshResolutionY;
 
+    // Need multiples of two, otherwise will not render a horizontal and/or vertical bar in the center of the warp mesh.
+    if (m_meshX % 2 == 1)
+    {
+        m_meshX++;
+    }
+
+    if (m_meshY % 2 == 1)
+    {
+        m_meshY++;
+    }
+
+    // Constrain per-pixel mesh size to sensible limits
+    m_meshX = std::max(static_cast<size_t>(8), std::min(static_cast<size_t>(400), m_meshX));
+    m_meshY = std::max(static_cast<size_t>(8), std::min(static_cast<size_t>(400), m_meshY));
+
     // Update mesh size in all sorts of classes.
     //m_renderer->SetPerPixelMeshSize(m_meshX, m_meshY);
     m_presetFactoryManager->initialize();

--- a/src/libprojectM/ProjectM.cpp
+++ b/src/libprojectM/ProjectM.cpp
@@ -443,15 +443,6 @@ void ProjectM::SetMeshSize(size_t meshResolutionX, size_t meshResolutionY)
     // Constrain per-pixel mesh size to sensible limits
     m_meshX = std::max(static_cast<size_t>(8), std::min(static_cast<size_t>(400), m_meshX));
     m_meshY = std::max(static_cast<size_t>(8), std::min(static_cast<size_t>(400), m_meshY));
-
-    // Update mesh size in all sorts of classes.
-    //m_renderer->SetPerPixelMeshSize(m_meshX, m_meshY);
-    m_presetFactoryManager->initialize();
-
-    // Unload all presets and reload idle preset
-    m_activePreset.reset();
-    m_transitioningPreset.reset();
-    LoadIdlePreset();
 }
 
 auto ProjectM::PCM() -> libprojectM::Audio::PCM&

--- a/src/libprojectM/ProjectM.cpp
+++ b/src/libprojectM/ProjectM.cpp
@@ -487,16 +487,16 @@ auto ProjectM::GetRenderContext() -> RenderContext
     RenderContext ctx{};
     ctx.viewportSizeX = m_windowWidth;
     ctx.viewportSizeY = m_windowHeight;
-    ctx.time = m_timeKeeper->GetRunningTime();
-    ctx.progress = m_timeKeeper->PresetProgressA();
-    ctx.fps = m_targetFps;
+    ctx.time = static_cast<float>(m_timeKeeper->GetRunningTime());
+    ctx.progress = static_cast<float>(m_timeKeeper->PresetProgressA());
+    ctx.fps = static_cast<float>(m_targetFps);
     ctx.frame = m_frameCount;
     ctx.aspectX = (m_windowHeight > m_windowWidth) ? static_cast<float>(m_windowWidth) / static_cast<float>(m_windowHeight) : 1.0f;
     ctx.aspectY = (m_windowWidth > m_windowHeight) ? static_cast<float>(m_windowHeight) / static_cast<float>(m_windowWidth) : 1.0f;
     ctx.invAspectX = 1.0f / ctx.aspectX;
     ctx.invAspectY = 1.0f / ctx.aspectY;
-    ctx.perPixelMeshX = m_meshX;
-    ctx.perPixelMeshY = m_meshY;
+    ctx.perPixelMeshX = static_cast<int>(m_meshX);
+    ctx.perPixelMeshY = static_cast<int>(m_meshY);
     ctx.textureManager = m_textureManager.get();
 
     return ctx;


### PR DESCRIPTION
The per-mixel mesh size needs to be a mutiple of two to avoid "bars" being rendered in each axis if the resolution is an odd number.

Also now clamping the value range from 8 to 300 (inclusive) on each axis, with 300 being well above anyone would need (Milkdrop's default of 64x48 is totally sufficient even in 4K).

The third commit just fixes a few compiler warnings by making the casts explicit.