### PR TITLE
Add vcpkg.json

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json",
+  "default-registry": {
+    "kind": "git",
+    "baseline": "638b1588be3a265a9c7ad5b212cef72a1cad336a",
+    "repository": "https://github.com/microsoft/vcpkg"
+  }
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "dependencies": [
+    "glew",
+    "sdl2"
+  ]
+}


### PR DESCRIPTION
Use vcpkg in (the recommended) `manifest mode`.

This allows the library to be build by running the following commands in the `Developer PowerShell for VS 2022`:

```PowerShell
cd projectm
cmake . -B build -DCMAKE_BUILD_TYPE=Release "-DCMAKE_INSTALL_PREFIX=$PWD/dist" "-DCMAKE_TOOLCHAIN_FILE=$Env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
cmake --build build --target install --config Release
```