### PR TITLE
Fix shading language version detection when using WebGL

### DIFF
--- a/src/libprojectM/Renderer/Shader.cpp
+++ b/src/libprojectM/Renderer/Shader.cpp
@@ -184,7 +184,7 @@ GLuint Shader::CompileShader(const std::string& source, GLenum type)
     GLint shaderCompiled{};
 
     auto shader = glCreateShader(type);
-    const auto *shaderSourceCStr = source.c_str();
+    const auto* shaderSourceCStr = source.c_str();
     glShaderSource(shader, 1, &shaderSourceCStr, nullptr);
 
     glCompileShader(shader);
@@ -214,6 +214,14 @@ auto Shader::GetShaderLanguageVersion() -> Shader::GlslVersion
     }
 
     std::string shaderLanguageVersionString(shaderLanguageVersion);
+
+    // Some OpenGL implementations add non-standard-conforming text in front, e.g. WebGL, which returns "OpenGL ES GLSL ES 3.00 ..."
+    // Find the first digit and start there.
+    auto firstDigit = shaderLanguageVersionString.find_first_of("0123456789");
+    if (firstDigit != std::string::npos && firstDigit != 0)
+    {
+        shaderLanguageVersionString = shaderLanguageVersionString.substr(firstDigit);
+    }
 
     // Cut off the vendor-specific information, if any
     auto spacePos = shaderLanguageVersionString.find(' ');


### PR DESCRIPTION
WebGL doesn't follow the OpenGL standard format for the glGetString(GL_SHADING_LANGUAGE_VERSION) return value. Chrome for example will return "OpenGL ES GLSL ES 3.00 (WebGL GLSL ES 3.00 (OpenGL ES GLSL ES 3.0 Chromium))", which does not start with the version number as the standard suggests.

This fix will simply cut off any text preceding the first digit found in the string, if any.