### PR TITLE
Fix generator expressions showing up in pkgconfig files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,11 @@ else()
             )
 endif()
 
+if(NOT BUILD_SHARED_LIBS AND CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    # Add "lib" in front of static library files to allow installing both shared and static libs in the same dir.
+    set(CMAKE_STATIC_LIBRARY_PREFIX lib)
+endif()
+
 if(ENABLE_EMSCRIPTEN)
     message(STATUS "${CMAKE_C_COMPILER} on ${CMAKE_SYSTEM_NAME}")
     check_symbol_exists(__EMSCRIPTEN__ "" HAVE_EMSCRIPTEN)

--- a/src/libprojectM/CMakeLists.txt
+++ b/src/libprojectM/CMakeLists.txt
@@ -129,7 +129,7 @@ else()
             )
 
     set_target_properties(projectM PROPERTIES
-            OUTPUT_NAME $<IF:$<PLATFORM_ID:Windows>,lib${PROJECTM_LIBRARY_BASE_OUTPUT_NAME},${PROJECTM_LIBRARY_BASE_OUTPUT_NAME}>
+            OUTPUT_NAME ${PROJECTM_LIBRARY_BASE_OUTPUT_NAME}
             FOLDER libprojectM
             )
 endif()

--- a/src/playlist/CMakeLists.txt
+++ b/src/playlist/CMakeLists.txt
@@ -75,7 +75,7 @@ else()
             )
 
     set_target_properties(projectM_playlist PROPERTIES
-            OUTPUT_NAME $<IF:$<PLATFORM_ID:Windows>,lib${PROJECTM_LIBRARY_BASE_OUTPUT_NAME}-playlist,${PROJECTM_LIBRARY_BASE_OUTPUT_NAME}-playlist>
+            OUTPUT_NAME ${PROJECTM_LIBRARY_BASE_OUTPUT_NAME}-playlist
             FOLDER libprojectM
             )
 endif()


### PR DESCRIPTION
Instead of using these expressions, adding "lib" in fron of static libs is now done via CMAKE_STATIC_LIBRARY_PREFIX when building static libs on Windows.

Fixes issue #702 