### PR TITLE
changed order of includes in projectM-Test-UI so that it could be built

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build_logs/
 
+.gitmodules
 xcuserdata
 src/libprojectM/config.inp
 src/libprojectM/config.inp.b

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ src/projectM-sdl/build/
 src/libprojectM/build/
 *.pkg
 
+./vcpkg_installed
+
 # CLion
 cmake-build-*
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ to_sync/
 src/projectM-sdl/build/
 src/libprojectM/build/
 *.pkg
+./fontend-qt
 
 ./vcpkg_installed
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "vendor/projectm-eval"]
 	path = vendor/projectm-eval
 	url = https://github.com/projectM-visualizer/projectm-eval.git
+[submodule "frontend-qt"]
+	path = frontend-qt
+	url = https://github.com/serjykalstryke/projectm

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "vendor/projectm-eval"]
-	path = vendor/projectm-eval
-	url = https://github.com/projectM-visualizer/projectm-eval.git
-[submodule "frontend-qt"]
-	path = frontend-qt
-	url = https://github.com/serjykalstryke/projectm

--- a/src/sdl-test-ui/pmSDL.hpp
+++ b/src/sdl-test-ui/pmSDL.hpp
@@ -61,13 +61,16 @@
 #include <sys/stat.h>
 
 #ifdef WASAPI_LOOPBACK
-#include <audioclient.h>
-#include <avrt.h>
-#include <functiondiscoverykeys_devpkey.h>
+#include <windows.h>
 #include <mmdeviceapi.h>
+#include <audioclient.h>
+
+#include <functiondiscoverykeys_devpkey.h>
+#include <avrt.h>
+
 #include <mmsystem.h>
 #include <stdio.h>
-#include <windows.h>
+
 
 #define LOG(format, ...) wprintf(format L"\n", __VA_ARGS__)
 #define ERR(format, ...) LOG(L"Error: " format, __VA_ARGS__)


### PR DESCRIPTION
I was having trouble building the entire project from the given code, and I was able to track down the issue with building the test UI project to the order the includes were in. It was calling windows libraries in an order that wasn't working with the newest SDK

Error I was encountering:

Severity	Code	Description	Project	File	Line	Suppression State	Details
Error	C2065	'PKEY_NAME': undeclared identifier	projectM-Test-UI	C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\um\functiondiscoverykeys_devpkey.h	47		

This error was repeated for every use of PKEY_NAME in that devkey.h file. 

Again, changing the order of the includes fixes this issue. 