### PR TITLE
Update mymindstorm/setup-emsdk GitHub Action to v13

### DIFF
--- a/.github/workflows/build_emscripten.yml
+++ b/.github/workflows/build_emscripten.yml
@@ -22,7 +22,7 @@ jobs:
           submodules: 'recursive'
       
       - name: Setup emsdk
-        uses: mymindstorm/setup-emsdk@v11
+        uses: mymindstorm/setup-emsdk@v13
         with:
           # Make sure to set a version number!
           version: 3.1.27

--- a/.github/workflows/build_emscripten.yml
+++ b/.github/workflows/build_emscripten.yml
@@ -25,7 +25,7 @@ jobs:
         uses: mymindstorm/setup-emsdk@v13
         with:
           # Make sure to set a version number!
-          version: 3.1.27
+          version: 3.1.51
           # This is the name of the cache folder.
           # The cache folder will be placed in the build directory,
           #  so make sure it doesn't conflict with anything!

--- a/.github/workflows/build_emscripten.yml
+++ b/.github/workflows/build_emscripten.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build GoogleTest From Source
         run: |
-          git clone https://github.com/anomievision/build-gtest.git ${{ github.workspace }}/build-gtest
+          git clone https://github.com/projectM-visualizer/build-gtest.git ${{ github.workspace }}/build-gtest
           cd ${{ github.workspace }}/build-gtest && ./setup.sh && ./build-emscripten.sh
 
       - name: Configure Build


### PR DESCRIPTION
GitHub Action mymindstorm/setup-emsdk@v11 used the now outdated/insecure Node12 runner, v13 now uses Node16.