### PR TITLE
Tweak pmSDL header and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ to_sync/
 src/projectM-sdl/build/
 src/libprojectM/build/
 *.pkg
+./vcpkg_installed
 
 # CLion
 cmake-build-*

--- a/src/sdl-test-ui/pmSDL.hpp
+++ b/src/sdl-test-ui/pmSDL.hpp
@@ -61,13 +61,16 @@
 #include <sys/stat.h>
 
 #ifdef WASAPI_LOOPBACK
-#include <audioclient.h>
-#include <avrt.h>
-#include <functiondiscoverykeys_devpkey.h>
+#include <windows.h>
 #include <mmdeviceapi.h>
+#include <audioclient.h>
+
+#include <functiondiscoverykeys_devpkey.h>
+#include <avrt.h>
+
 #include <mmsystem.h>
 #include <stdio.h>
-#include <windows.h>
+
 
 #define LOG(format, ...) wprintf(format L"\n", __VA_ARGS__)
 #define ERR(format, ...) LOG(L"Error: " format, __VA_ARGS__)


### PR DESCRIPTION
Fixed-up branch for PR #650 per @serjykalstryke.

> I was having trouble building the library in totality due to some errors in the projectm-test-ui project. I was able to trace the errors to the includes in the file pmSDL.hpp. By tweaking the order to go in the order at which matches the call stack (this is I think the source of the issue. D needs C needs B needs A, so I set it to A, B, C, D, if that makes sense)
> 
> I also used vcpkg to install dependencies, so I added the ./vcpkg-install directory to .gitignore so that people who also use vcpkg don't accidentally push their dependencies to their own or the main repo.
> 
> --David Stinnett
