### PR TITLE
Fix memory leaks

### DIFF
--- a/vendor/hlslparser/src/HLSLParser.cpp
+++ b/vendor/hlslparser/src/HLSLParser.cpp
@@ -3467,7 +3467,7 @@ bool HLSLParser::ParsePreprocessorDefine()
         value.erase(0, 1);
     }
 
-    macro->value = value;
+    macro->value = m_tree->AddString(value.c_str());
 
     return true;
 }
@@ -3495,7 +3495,7 @@ bool HLSLParser::ApplyPreprocessor(const char* fileName, const char* buffer, siz
     while (index <  m_macros.GetSize())
     {
         HLSLMacro * macro = m_macros[index];
-        m_tokenizer = HLSLTokenizer(fileName, macro->value.c_str(), macro->value.length());
+        m_tokenizer = HLSLTokenizer(fileName, macro->value, strlen(macro->value));
         std::string valueProcessed;
 
         while (m_tokenizer.GetToken() != HLSLToken_EndOfStream)
@@ -3533,7 +3533,7 @@ bool HLSLParser::ApplyPreprocessor(const char* fileName, const char* buffer, siz
         {
             // Define value referenced another define, it was replaced
             // try again until there is no replacement
-            macro->value = valueProcessed;
+            macro->value = m_tree->AddString(valueProcessed.c_str());
 
         }
         else
@@ -3747,7 +3747,7 @@ bool HLSLParser::ProcessMacroArguments(HLSLMacro* macro, std::string & sourcePre
     unsigned index = 0;
     std::string arg;
     bool argFound = false;
-    while(index < macro->value.length())
+    while(index < strlen(macro->value))
     {
         if (macro->value[index] == '#' && !argFound)
         {

--- a/vendor/hlslparser/src/HLSLTree.h
+++ b/vendor/hlslparser/src/HLSLTree.h
@@ -577,18 +577,12 @@ struct HLSLArgument : public HLSLNode
 struct HLSLMacro : public HLSLStatement
 {
     static const HLSLNodeType s_type = HLSLNodeType_Macro;
-    HLSLMacro()
-    {
-        name            = NULL;
-        argument        = NULL;
-        numArguments    = 0;
-        macroAliased    = NULL;
-    }
-    const char*         name;
-    HLSLArgument*       argument;
-    unsigned int        numArguments;
-    std::string         value;
-    HLSLMacro*          macroAliased;
+
+    const char*         name{};
+    HLSLArgument*       argument{};
+    unsigned int        numArguments{};
+    const char*         value{};
+    HLSLMacro*          macroAliased{};
 };
 
 /** A expression which forms a complete statement. */


### PR DESCRIPTION
Checked projectM with valgrind and found a few small memory leaks:
- In projectm-eval, a wring destroy function was caleld to free a memory buffer.
- In hlslparser, the internal Array implementation was leaking its buffer as it was never freed.
- Also in hlslparser, a std::string instance was store in a C-malloc'd struct, so the destructor was never called and thus the stored string never released.