### PR TITLE
Various OpenGL ES Fixes

### DIFF
--- a/EMSCRIPTEN.md
+++ b/EMSCRIPTEN.md
@@ -1,0 +1,58 @@
+# Using libprojectM in Emscripten
+
+projectM supports OpenGL ES rendering, and can be compiled into WebAssembly for use in browsers. WebGL is similar to
+OpenGL ES, but not identical, so a few additional considerations apply to get projectM running with Emscripten.
+
+## Additional Build Settings
+
+A few additional build settings will be required when building an Emscripten wrapper. Pass these flags/parameterrs to
+the Emscripten linker:
+
+- `-sUSE_SDL=2`: It is highly recommended to use Emscripten's built-in SDL2 port to set up the rendering context. This
+  flag will link the appropriate library.
+- `-sMIN_WEBGL_VERSION=2 -sMAX_WEBGL_VERSION=2`: Forces the use of WebGL 2, which is required for OpenGL ES 3 emulation.
+- `-sFULL_ES2=1 -sFULL_ES3=1`: Enables full emulation support for both OpenGL ES 2.0 and 3.0 variants.
+- `-sALLOW_MEMORY_GROWTH=1`: Allows allocating additional memory if necessary. This may be required to load additional
+  textures etc. in projectM.
+
+## Initializing Emscripten's OpenGL Context
+
+In addition to the above linker flags, some additional initialization steps must be performed to set up the OpenGL
+rendering context for projectM. Specifically, the `OES_texture_float` WenGL extension must be loaded explicitly to
+support the required texture format for the motion vector grid. The following code template can be used to set up a
+proper SDL2/WebGL context for projectM:
+
+```c
+
+#include <emscripten.h>
+#include <emscripten/html5_webgl.h>
+
+#include <GL/gl.h>
+
+#include <SDL.h>
+
+int main(void)
+{
+    // Init SDL's video and audio subsystems
+    SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO);
+
+    // Create the SDL window (will be tied to the Emscripten HTML5 canvas)
+    SDL_window* window = NULL;
+    SDL_renderer* renderer = NULL;
+    SDL_CreateWindowAndRenderer(1024, 768, SDL_WINDOW_OPENGL, &window, &renderer);
+    if (window == NULL || renderer == NULL)
+    {
+        fprintf(stderr, "Failed to create SDL renderer: %s\n", SDL_GetError());
+        return 1;
+    }
+
+    // Enable floating-point texture support for motion vector grid.
+    auto webGlContext = emscripten_webgl_get_current_context();
+    emscripten_webgl_enable_extension(webGlContext, "OES_texture_float");
+
+    // Initialize projectM and put all other stuff below.
+    
+    return 0;
+}
+
+```

--- a/config.h.cmake.in
+++ b/config.h.cmake.in
@@ -64,7 +64,7 @@
 #cmakedefine STDC_HEADERS
 
 /* Define USE_GLES */
-#cmakedefine01 USE_GLES
+#cmakedefine USE_GLES
 
 /* Define PROJECTM_USE_THREADS */
 #cmakedefine01 PROJECTM_USE_THREADS

--- a/src/libprojectM/MilkdropPreset/CustomShape.cpp
+++ b/src/libprojectM/MilkdropPreset/CustomShape.cpp
@@ -262,7 +262,7 @@ void CustomShape::Draw()
                              static_cast<float>(*m_perFrameContext.border_b),
                              static_cast<float>(*m_perFrameContext.border_a));
             glLineWidth(1);
-#if USE_GLES == 0
+#ifndef USE_GLES
             glEnable(GL_LINE_SMOOTH);
 #endif
 
@@ -315,7 +315,7 @@ void CustomShape::Draw()
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glBindVertexArray(0);
 
-#if USE_GLES == 0
+#ifndef USE_GLES
     glDisable(GL_LINE_SMOOTH);
 #endif
     glDisable(GL_BLEND);

--- a/src/libprojectM/MilkdropPreset/CustomWaveform.cpp
+++ b/src/libprojectM/MilkdropPreset/CustomWaveform.cpp
@@ -168,7 +168,7 @@ void CustomWaveform::Draw(const PerFrameContext& presetPerFrameContext)
     std::vector<ColoredPoint> pointsSmoothed(sampleCount * 2);
     auto smoothedVertexCount = SmoothWave(pointsTransformed.data(), sampleCount, pointsSmoothed.data());
 
-#if USE_GLES == 0
+#ifndef USE_GLES
     glDisable(GL_LINE_SMOOTH);
 #endif
     glLineWidth(1);

--- a/src/libprojectM/MilkdropPreset/MilkdropStaticShaders.hpp.in
+++ b/src/libprojectM/MilkdropPreset/MilkdropStaticShaders.hpp.in
@@ -25,7 +25,7 @@ public:
     static std::shared_ptr<MilkdropStaticShaders> Get()
     {
         bool useGLES = false;
-#if USE_GLES
+#ifdef USE_GLES
         useGLES = true;
 #endif
 

--- a/src/libprojectM/MilkdropPreset/MotionVectors.cpp
+++ b/src/libprojectM/MilkdropPreset/MotionVectors.cpp
@@ -108,7 +108,7 @@ void MotionVectors::Draw(const PerFrameContext& presetPerFrameContext, std::shar
     glBindBuffer(GL_ARRAY_BUFFER, m_vboID);
 
     glLineWidth(1);
-#if USE_GLES == 0
+#ifndef USE_GLES
     glEnable(GL_LINE_SMOOTH);
 #endif
 
@@ -145,7 +145,7 @@ void MotionVectors::Draw(const PerFrameContext& presetPerFrameContext, std::shar
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glBindVertexArray(0);
 
-#if USE_GLES == 0
+#ifndef USE_GLES
     glDisable(GL_LINE_SMOOTH);
 #endif
 

--- a/src/libprojectM/MilkdropPreset/Waveform.cpp
+++ b/src/libprojectM/MilkdropPreset/Waveform.cpp
@@ -45,7 +45,7 @@ void Waveform::Draw(const PerFrameContext& presetPerFrameContext)
         }
     }
 
-#if USE_GLES == 0
+#ifndef USE_GLES
     glDisable(GL_LINE_SMOOTH);
 #endif
     glLineWidth(1);

--- a/src/libprojectM/Renderer/Framebuffer.cpp
+++ b/src/libprojectM/Renderer/Framebuffer.cpp
@@ -315,7 +315,7 @@ void Framebuffer::MaskDrawBuffer(int bufferIndex, bool masked)
 {
     // Invert the flag, as "true" means the color channel *will* be written.
     auto glMasked = static_cast<GLboolean>(!masked);
-#if USE_GLES
+#ifdef USE_GLES
     glColorMask(glMasked, glMasked, glMasked, glMasked);
 #else
     glColorMaski(bufferIndex, glMasked, glMasked, glMasked, glMasked);

--- a/src/libprojectM/Renderer/TextureManager.cpp
+++ b/src/libprojectM/Renderer/TextureManager.cpp
@@ -94,14 +94,14 @@ void TextureManager::Preload()
 
     auto noise = std::make_unique<MilkdropNoise>();
 
-#if !USE_GLES
+#ifdef USE_GLES
+    // GLES only supports GL_RGB and GL_RGBA, so we always use the latter.
+    GLint preferredInternalFormat{GL_RGBA};
+#else
     // Query preferred internal texture format. GLES 3 only supports GL_RENDERBUFFER here, no texture targets.
     // That's why we use GL_BGRA as default, as this is the best general-use format according to Khronos.
     GLint preferredInternalFormat{GL_BGRA};
     glGetInternalformativ(GL_TEXTURE_2D, GL_RGBA8, GL_TEXTURE_IMAGE_FORMAT, sizeof(preferredInternalFormat), &preferredInternalFormat);
-#else
-    // GLES only supports GL_RGB and GL_RGBA, so we always use the latter.
-    GLint preferredInternalFormat{GL_RGBA};
 #endif
 
     GLuint noise_texture_lq_lite;

--- a/src/libprojectM/Renderer/TransitionShaderManager.cpp
+++ b/src/libprojectM/Renderer/TransitionShaderManager.cpp
@@ -31,8 +31,8 @@ auto TransitionShaderManager::RandomTransition() -> std::shared_ptr<Shader>
 auto TransitionShaderManager::CompileTransitionShader(const std::string& shaderBodyCode) -> std::shared_ptr<Shader>
 {
 #if USE_GLES
-    // GLES also requires a precision specifier
-    constexpr char versionHeader[] = "#version 300 es\n\nprecision mediump float;\n";
+    // GLES also requires a precision specifier for variables and 3D samplers
+    constexpr char versionHeader[] = "#version 300 es\n\nprecision mediump float;\nprecision mediump sampler3D;\n";
 #else
     constexpr char versionHeader[] = "#version 330\n\n";
 #endif

--- a/src/libprojectM/Renderer/TransitionShaderManager.cpp
+++ b/src/libprojectM/Renderer/TransitionShaderManager.cpp
@@ -31,7 +31,8 @@ auto TransitionShaderManager::RandomTransition() -> std::shared_ptr<Shader>
 auto TransitionShaderManager::CompileTransitionShader(const std::string& shaderBodyCode) -> std::shared_ptr<Shader>
 {
 #if USE_GLES
-    constexpr char versionHeader[] = "#version 300 es\n\n";
+    // GLES also requires a precision specifier
+    constexpr char versionHeader[] = "#version 300 es\n\nprecision mediump float;\n";
 #else
     constexpr char versionHeader[] = "#version 330\n\n";
 #endif

--- a/src/libprojectM/Renderer/TransitionShaderManager.cpp
+++ b/src/libprojectM/Renderer/TransitionShaderManager.cpp
@@ -30,7 +30,7 @@ auto TransitionShaderManager::RandomTransition() -> std::shared_ptr<Shader>
 
 auto TransitionShaderManager::CompileTransitionShader(const std::string& shaderBodyCode) -> std::shared_ptr<Shader>
 {
-#if USE_GLES
+#ifdef USE_GLES
     // GLES also requires a precision specifier for variables and 3D samplers
     constexpr char versionHeader[] = "#version 300 es\n\nprecision mediump float;\nprecision mediump sampler3D;\n";
 #else

--- a/src/libprojectM/projectM-opengl.h
+++ b/src/libprojectM/projectM-opengl.h
@@ -35,7 +35,7 @@
 #include "GL/glew.h"
 #include "GL/wglew.h"
 #else /* linux/unix/other */
-# if USE_GLES
+# ifdef USE_GLES
 #  include <GLES3/gl3.h>
 # else
 #  if !defined(GL_GLEXT_PROTOTYPES)

--- a/src/playlist/FilesystemSupport.cmake
+++ b/src/playlist/FilesystemSupport.cmake
@@ -46,4 +46,6 @@ else()
             PUBLIC
             Boost::filesystem
             )
+
+    set(ENABLE_BOOST_FILESYSTEM ON CACHE BOOL "Compiler does not support std::filesystem, reverting to boost::filesystem." FORCE)
 endif()

--- a/src/playlist/projectM4PlaylistConfig.cmake.in
+++ b/src/playlist/projectM4PlaylistConfig.cmake.in
@@ -2,4 +2,8 @@ set(projectM4Playlist_VERSION @PROJECT_VERSION@)
 
 @PACKAGE_INIT@
 
+if("@ENABLE_BOOST_FILESYSTEM@") # ENABLE_BOOST_FILESYSTEM
+    find_dependency(Boost COMPONENTS Filesystem)
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/projectM4PlaylistTargets.cmake")

--- a/src/sdl-test-ui/setup.cpp
+++ b/src/sdl-test-ui/setup.cpp
@@ -87,9 +87,9 @@ void seedRand() {
 }
 
 void initGL() {
-#if USE_GLES
-    // use GLES 2.0 (this may need adjusting)
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+#ifdef USE_GLES
+    // use GLES 3.0
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
 #else
@@ -121,7 +121,7 @@ void initStereoscopicView(SDL_Window *win) {
 }
 
 void enableGLDebugOutput() {
-#if OGL_DEBUG && !USE_GLES
+#if OGL_DEBUG && !defined (USE_GLES)
     glEnable(GL_DEBUG_OUTPUT);
     glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
     glDebugMessageCallback(debugGL, NULL);

--- a/vendor/hlslparser/src/GLSLGenerator.cpp
+++ b/vendor/hlslparser/src/GLSLGenerator.cpp
@@ -114,7 +114,7 @@ GLSLGenerator::GLSLGenerator() :
     m_tree                      = NULL;
     m_entryName                 = NULL;
     m_target                    = Target_VertexShader;
-#if USE_GLES
+#ifdef USE_GLES
     m_version                   = Version_300_ES;
 #else
     m_version                   = Version_330;


### PR DESCRIPTION
A few things were off regarding GLES support, used on the Raspberry Pi, on Android, in Emscripten builds and when building for the Universal Windows Platform (Xbox) as well.

This includes wrong shader headers and some wrongly used defines. Also fixed the CMake package config files installed with the playlist library to properly pass the dependency on boost::filesystem if it was built with C++14.