### PR TITLE
Refactor waveform aligner and add test

### DIFF
--- a/src/libprojectM/Audio/WaveformAligner.cpp
+++ b/src/libprojectM/Audio/WaveformAligner.cpp
@@ -31,7 +31,7 @@ WaveformAligner::WaveformAligner()
     }
 }
 
-void WaveformAligner::ResampleOctaves(std::vector<WaveformBuffer> &dstWaveformMips, WaveformBuffer& newWaveform)
+void WaveformAligner::ResampleOctaves(std::vector<WaveformBuffer>& dstWaveformMips, WaveformBuffer& newWaveform)
 {
     // Octave 0 is a direct copy of the new waveform
     std::copy(newWaveform.begin(), newWaveform.end(), dstWaveformMips[0].begin());
@@ -119,7 +119,7 @@ void WaveformAligner::GenerateWeights()
     }
 }
 
-int WaveformAligner::CalculateOffset(std::vector<WaveformBuffer> &newWaveformMips)
+int WaveformAligner::CalculateOffset(std::vector<WaveformBuffer>& newWaveformMips)
 {
     /*
      * Note that we use signed variables here because we need to check for negatives even

--- a/src/libprojectM/Audio/WaveformAligner.hpp
+++ b/src/libprojectM/Audio/WaveformAligner.hpp
@@ -36,8 +36,8 @@ public:
 
 protected:
     void GenerateWeights();
-    int CalculateOffset(std::vector<WaveformBuffer> &newWaveformMips);
-    void ResampleOctaves(std::vector<WaveformBuffer> &dstWaveformMips, WaveformBuffer& newWaveform);
+    int CalculateOffset(std::vector<WaveformBuffer>& newWaveformMips);
+    void ResampleOctaves(std::vector<WaveformBuffer>& dstWaveformMips, WaveformBuffer& newWaveform);
 
     bool m_alignWaveReady{false}; //!< Alignment needs special treatment for the first buffer fill.
 
@@ -48,8 +48,8 @@ protected:
     std::vector<uint32_t> m_octaveSampleSpacing; //!< Space between samples per octave.
 
     std::vector<WaveformBuffer> m_oldWaveformMips; //!< Mip levels of the previous frame's waveform.
-    std::vector<uint32_t> m_firstNonzeroWeights;     //!< First non-zero weight sample index for each octave.
-    std::vector<uint32_t> m_lastNonzeroWeights;      //!< Last non-zero weight sample index for each octave.
+    std::vector<uint32_t> m_firstNonzeroWeights;   //!< First non-zero weight sample index for each octave.
+    std::vector<uint32_t> m_lastNonzeroWeights;    //!< Last non-zero weight sample index for each octave.
 };
 
 } // namespace Audio

--- a/src/libprojectM/Audio/WaveformAligner.hpp
+++ b/src/libprojectM/Audio/WaveformAligner.hpp
@@ -8,6 +8,7 @@
 #include "AudioConstants.hpp"
 
 #include <cstddef>
+#include <cstdint>
 #include <vector>
 
 namespace libprojectM {
@@ -38,13 +39,13 @@ private:
 
     std::vector<std::array<float, AudioBufferSamples>> m_aligmentWeights; //!< Sample weights per octave.
 
-    size_t m_octaves{};                        //!< Number of mip-levels/octaves.
-    std::vector<size_t> m_octaveSamples;       //!< Samples per octave.
-    std::vector<size_t> m_octaveSampleSpacing; //!< Space between samples per octave.
+    uint32_t m_octaves{};                        //!< Number of mip-levels/octaves.
+    std::vector<uint32_t> m_octaveSamples;       //!< Samples per octave.
+    std::vector<uint32_t> m_octaveSampleSpacing; //!< Space between samples per octave.
 
     std::vector<WaveformBuffer> m_oldWaveformMips; //!< Mip levels of the previous frame's waveform.
-    std::vector<size_t> m_firstNonzeroWeights;     //!< First non-zero weight sample index for each octave.
-    std::vector<size_t> m_lastNonzeroWeights;      //!< Last non-zero weight sample index for each octave.
+    std::vector<uint32_t> m_firstNonzeroWeights;     //!< First non-zero weight sample index for each octave.
+    std::vector<uint32_t> m_lastNonzeroWeights;      //!< Last non-zero weight sample index for each octave.
 };
 
 } // namespace Audio

--- a/src/libprojectM/Audio/WaveformAligner.hpp
+++ b/src/libprojectM/Audio/WaveformAligner.hpp
@@ -34,7 +34,11 @@ public:
      */
     void Align(WaveformBuffer& newWaveform);
 
-private:
+protected:
+    void GenerateWeights();
+    int CalculateOffset(std::vector<WaveformBuffer> &newWaveformMips);
+    void ResampleOctaves(std::vector<WaveformBuffer> &dstWaveformMips, WaveformBuffer& newWaveform);
+
     bool m_alignWaveReady{false}; //!< Alignment needs special treatment for the first buffer fill.
 
     std::vector<std::array<float, AudioBufferSamples>> m_aligmentWeights; //!< Sample weights per octave.

--- a/tests/libprojectM/CMakeLists.txt
+++ b/tests/libprojectM/CMakeLists.txt
@@ -1,6 +1,7 @@
 find_package(GTest 1.10 REQUIRED NO_MODULE)
 
 add_executable(projectM-unittest
+        WaveformAlignerTest.cpp
         PresetFileParserTest.cpp
 
         $<TARGET_OBJECTS:Audio>

--- a/tests/libprojectM/WaveformAlignerTest.cpp
+++ b/tests/libprojectM/WaveformAlignerTest.cpp
@@ -1,0 +1,85 @@
+#include "Audio/WaveformAligner.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace libprojectM::Audio;
+
+/**
+ * Class to make protected function accessible to tests.
+ */
+class WaveformAlignerMock : public WaveformAligner
+{
+private:
+    /*
+     * gtest docs discourage access to private members using this, but
+     * we're testing the modern port of legacy code here so we want to
+     * stick to the original structure as much as possible.
+     */
+    FRIEND_TEST(projectMWaveformAligner, AlignDelta);
+};
+
+TEST(projectMWaveformAligner, AlignDelta)
+{
+    auto aligner = WaveformAlignerMock();
+    ASSERT_EQ(aligner.m_octaves, 6);
+
+    std::array<float, AudioBufferSamples> wf;
+    std::fill(wf.begin(), wf.end(), 0.0f);
+
+    // Create a delta waveform by setting a single value non-zero.
+    wf[AudioBufferSamples/2] = 1.0f;
+
+    aligner.Align(wf);
+    // Ensure that the waveform has not shifted when first sampled.
+    EXPECT_FLOAT_EQ(wf[AudioBufferSamples/2], 1.0f);
+
+    // Verify weights
+    for (uint32_t octave=0; octave < aligner.m_octaves; octave++)
+    {
+        size_t const compareSamples = aligner.m_octaveSamples[octave] - aligner.m_octaveSampleSpacing[octave];
+        // Non-zero range should be (0.32, 0.68)*compareSamples based on
+        // the "TWEAK" calculation. If the weight calculation changes this
+        // range will need to change.
+        // Note that the test below is not a requirement for the algorithm. Instead
+        // of testing the correctness of the algorithm, this is testing that we
+        // understand the implications of the legacy code.
+        EXPECT_NEAR(aligner.m_firstNonzeroWeights[octave], 0.32*compareSamples, 2.0);
+        EXPECT_NEAR(aligner.m_lastNonzeroWeights[octave], 0.68*compareSamples, 2.0);
+    }
+
+    // Reset test waveform to all zeroes
+    wf[AudioBufferSamples/2] = 0.0f;
+
+    for (int i=-8; i<98; i++)
+    {
+        wf[AudioBufferSamples/2 + i] = 1.0f;
+
+        std::vector<WaveformBuffer> newWaveformMips(aligner.m_octaves, WaveformBuffer());
+        aligner.ResampleOctaves(newWaveformMips, wf);
+        int alignOffset = aligner.CalculateOffset(newWaveformMips);
+        if (i < 0 || i >= static_cast<int>(aligner.m_octaveSampleSpacing[0]))
+        {
+            // Only offsets between 0 and (AudioBufferSamples - WaveformSamples) are recognized
+            EXPECT_EQ(alignOffset, 0);
+        } else {
+            // Verify that the actual waveform offset matches the reported value
+            EXPECT_EQ(alignOffset, i);
+        }
+
+        wf[AudioBufferSamples/2 + i] = 0.0f;
+    }
+
+    for (int i=0; i<96; i++)
+    {
+        wf[AudioBufferSamples/2 + i] = 1.0f;
+        aligner.Align(wf);
+        // Verify that the new waveform has been shifted to match the first
+        EXPECT_EQ(wf[AudioBufferSamples/2], 1.0f);
+        if (i != 0)
+        {
+            EXPECT_EQ(wf[AudioBufferSamples/2 + i], 0.0f);
+        }
+        // Reset waveform
+        wf[AudioBufferSamples/2] = 0.0f;
+    }
+}


### PR DESCRIPTION
This PR adds a friend test for WaveformAligner that verifies a few internal implementation details as well as verifying proper alignment for waveforms with supported offsets.

This PR also refactors WaveformAligner for readability and fixes two bugs:
1) The code to calculate errorSum is supposed to calculate a windowed convolution but introduced an indexing bug that resulted in repeatedly calculating the product of the two waveforms instead.
2) The calculated "mip levels" or resampled waveforms were recalculated in the original Milkdrop code but was re-used as an optimization in the projectM code. However the re-used mip levels did not take the applied shift into account, resulting in the calculated offset being relative to the previous *unshifted* waveform. This bug was not present in the original Milkdrop code since the mip levels were recalculated including the applied shift.