### PR TITLE
Use renderContext for preset state time, frame, fps, progress

### DIFF
--- a/src/libprojectM/MilkdropPreset/MilkdropShader.cpp
+++ b/src/libprojectM/MilkdropPreset/MilkdropShader.cpp
@@ -183,9 +183,9 @@ void MilkdropShader::LoadVariables(const PresetState& presetState, const PerFram
                                       0.0,
                                       0.0});
     m_shader.SetUniformFloat4("_c2", {timeSincePresetStartWrapped,
-                                      presetState.fps,
-                                      presetState.frame,
-                                      presetState.progress});
+                                      presetState.renderContext.fps,
+                                      presetState.renderContext.frame,
+                                      presetState.renderContext.progress});
     m_shader.SetUniformFloat4("_c3", {presetState.audioData.bass / 100,
                                       presetState.audioData.mid / 100,
                                       presetState.audioData.treb / 100,

--- a/src/libprojectM/MilkdropPreset/PerFrameContext.cpp
+++ b/src/libprojectM/MilkdropPreset/PerFrameContext.cpp
@@ -173,7 +173,7 @@ void PerFrameContext::LoadStateVariables(PresetState& state)
     {
         *q_vars[q] = q_values_after_init_code[q];
     }
-    *progress = static_cast<PRJM_EVAL_F>(state.progress);
+    *progress = static_cast<PRJM_EVAL_F>(state.renderContext.progress);
     *decay = static_cast<PRJM_EVAL_F>(state.decay);
     *wave_a = static_cast<PRJM_EVAL_F>(state.waveAlpha);
     *wave_r = static_cast<PRJM_EVAL_F>(state.waveR);

--- a/src/libprojectM/MilkdropPreset/PresetState.hpp
+++ b/src/libprojectM/MilkdropPreset/PresetState.hpp
@@ -120,11 +120,6 @@ public:
     BlendableFloat blur3Max{1.0f};
     BlendableFloat blur1EdgeDarken{0.25f};
 
-    double presetTime{0.0};
-    double fps{60.0};
-    int frame{0};
-    double progress{0.0};
-
     int presetVersion{100};        //!< Value of MILKDROP_PRESET_VERSION in preset files.
     int warpShaderVersion{2};      //!< PSVERSION or PSVERSION_WARP.
     int compositeShaderVersion{2}; //!< PSVERSION or PSVERSION_COMP.

--- a/src/libprojectM/MilkdropPreset/WaveformPerFrameContext.cpp
+++ b/src/libprojectM/MilkdropPreset/WaveformPerFrameContext.cpp
@@ -68,10 +68,10 @@ void WaveformPerFrameContext::RegisterBuiltinVariables()
 
 void WaveformPerFrameContext::LoadStateVariables(PresetState& state, const PerFrameContext& presetPerFrameContext, CustomWaveform& waveform)
 {
-    *time = static_cast<double>(state.presetTime);
-    *frame = static_cast<double>(state.frame);
-    *fps = static_cast<double>(state.fps);
-    *progress = static_cast<double>(state.progress);
+    *time = static_cast<double>(state.renderContext.time);
+    *frame = static_cast<double>(state.renderContext.frame);
+    *fps = static_cast<double>(state.renderContext.fps);
+    *progress = static_cast<double>(state.renderContext.progress);
     *bass = static_cast<double>(state.audioData.bass);
     *mid = static_cast<double>(state.audioData.mid);
     *treb = static_cast<double>(state.audioData.treb);


### PR DESCRIPTION
The robotopia preset uses the current time in per-waveform calculations. For custom waveforms, this is pulled directly from the preset state's time field. However, this field is never set and is permanently zero. For custom shapes, the time is pulled from the preset state's render context. Looking through the code, it appears that these values migrated to the render context at some point but weren't updated everywhere. I've removed these fields from the preset state entirely to prevent confusion and updated references to the preset state's time, frame, fps, and progress counters to use the preset state's render context. This fixes (I think) the shifter - robotopia presets. 