### PR TITLE
Fix various typos

### DIFF
--- a/cmake/gles/FindOpenGL.cmake
+++ b/cmake/gles/FindOpenGL.cmake
@@ -163,7 +163,7 @@ The value may be one of:
 
  .. versionchanged:: 3.11
   This is the default, unless policy :policy:`CMP0072` is set to ``OLD``
-  and no components are requeted (since components
+  and no components are requested (since components
   correspond to GLVND libraries).
 
 ``LEGACY``

--- a/src/libprojectM/MilkdropPreset/MilkdropShader.cpp
+++ b/src/libprojectM/MilkdropPreset/MilkdropShader.cpp
@@ -614,7 +614,7 @@ void MilkdropShader::TranspileHLSLShader(const PresetState& presetState, std::st
                             MilkdropStaticShaders::Get()->GetGlslGeneratorVersion(),
                             "PS"))
     {
-        throw Renderer::ShaderException("Error translating HLSL " + shaderTypeString + " shader: GLSL generating fails.\nSource:\n" + sourcePreprocessed);
+        throw Renderer::ShaderException("Error translating HLSL " + shaderTypeString + " shader: GLSL generating failed.\nSource:\n" + sourcePreprocessed);
     }
 
     // Now we have GLSL source for the preset shader program (hopefully it's valid!)

--- a/src/libprojectM/MilkdropPreset/MilkdropShader.cpp
+++ b/src/libprojectM/MilkdropPreset/MilkdropShader.cpp
@@ -344,7 +344,7 @@ void MilkdropShader::PreprocessPresetShader(std::string& program)
     found = program.find("sampler_state");
     while (found != std::string::npos)
     {
-        // Now go backwards and find the assigment
+        // Now go backwards and find the assignment
         found = program.rfind('=', found);
         auto startPos = found;
 
@@ -614,7 +614,7 @@ void MilkdropShader::TranspileHLSLShader(const PresetState& presetState, std::st
                             MilkdropStaticShaders::Get()->GetGlslGeneratorVersion(),
                             "PS"))
     {
-        throw Renderer::ShaderException("Error translating HLSL " + shaderTypeString + " shader: GLSL generating failes.\nSource:\n" + sourcePreprocessed);
+        throw Renderer::ShaderException("Error translating HLSL " + shaderTypeString + " shader: GLSL generating fails.\nSource:\n" + sourcePreprocessed);
     }
 
     // Now we have GLSL source for the preset shader program (hopefully it's valid!)

--- a/src/libprojectM/MilkdropPreset/MotionVectors.hpp
+++ b/src/libprojectM/MilkdropPreset/MotionVectors.hpp
@@ -29,7 +29,7 @@ public:
     void InitVertexAttrib();
 
     /**
-     * Redners the motion vectors.
+     * Renders the motion vectors.
      * @param presetPerFrameContext The per-frame context variables.
      * @param motionTexture The u/v "motion" texture written by the warp shader.
      */

--- a/src/libprojectM/MilkdropPreset/ShapePerFrameContext.hpp
+++ b/src/libprojectM/MilkdropPreset/ShapePerFrameContext.hpp
@@ -29,7 +29,7 @@ public:
      * @brief Loads the current state values into the expression evaluator variables.
      * @param state The preset state container.
      * @param shape The shape this context belongs to.
-     * @param inst The current shape isntance.
+     * @param inst The current shape instance.
      */
     void LoadStateVariables(const PresetState& state,
                             CustomShape& shape,

--- a/src/playlist/api/projectM-4/playlist_playback.h
+++ b/src/playlist/api/projectM-4/playlist_playback.h
@@ -68,7 +68,7 @@ PROJECTM_PLAYLIST_EXPORT uint32_t projectm_playlist_get_retry_count(projectm_pla
  * repeating the playlist as if shuffle was disabled. It has no effect if the playlist is empty.
  *
  * This method ignores the shuffle setting and will always jump to the requested index, given it is
- * withing playlist bounds.
+ * within playlist bounds.
  *
  * @param instance The playlist manager instance.
  * @param new_position The new position to jump to.

--- a/src/sdl-test-ui/audioCapture.cpp
+++ b/src/sdl-test-ui/audioCapture.cpp
@@ -16,7 +16,7 @@ int projectMSDL::initAudioInput() {
     want.callback = projectMSDL::audioInputCallbackF32;
     want.userdata = this;
 
-    // index -1 means "system deafult", which is used if we pass deviceName == NULL
+    // index -1 means "system default", which is used if we pass deviceName == NULL
     const char *deviceName = _selectedAudioDevice == -1 ? NULL : SDL_GetAudioDeviceName(_selectedAudioDevice, true);
     _audioDeviceId = SDL_OpenAudioDevice(deviceName, true, &want, &have, 0);
 

--- a/src/sdl-test-ui/projectM_SDL_main.cpp
+++ b/src/sdl-test-ui/projectM_SDL_main.cpp
@@ -26,7 +26,7 @@
  *
  *	RobertPancoast77@gmail.com :
  * experimental Stereoscopic SBS driver functionality
- * WASAPI looback implementation
+ * WASAPI loopback implementation
  *
  *
  */

--- a/src/sdl-test-ui/setup.cpp
+++ b/src/sdl-test-ui/setup.cpp
@@ -135,7 +135,7 @@ projectMSDL *setupSDLApp() {
         
     if (!initLoopback())
 		{
-			SDL_Log("Failed to initialize audio loopback devide.");
+			SDL_Log("Failed to initialize audio loopback device.");
 			exit(1);
 		}
 


### PR DESCRIPTION
Found via `codespell -q 3 -S "./vendor" -L ist`