### PR TITLE
Fix easter egg and refactor MilkdropNoise class

### DIFF
--- a/src/api/include/projectM-4/parameters.h
+++ b/src/api/include/projectM-4/parameters.h
@@ -225,7 +225,7 @@ PROJECTM_EXPORT bool projectm_get_aspect_correction(projectm_handle instance);
  * <p>See function sampledPresetDuration() of the TimeKeeper class on how it is used.</p>
  *
  * @param instance The projectM instance handle.
- * @param value The new "easter egg" value.
+ * @param value The new "easter egg" value. Must be greater than zero, otherwise a default sigma value of 1.0 will be used.
  */
 PROJECTM_EXPORT void projectm_set_easter_egg(projectm_handle instance, float value);
 

--- a/src/libprojectM/ProjectM.hpp
+++ b/src/libprojectM/ProjectM.hpp
@@ -196,7 +196,7 @@ private:
     float m_hardCutSensitivity{2.0}; //!< Loudness sensitivity value for hard cuts.
     float m_beatSensitivity{1.0};    //!< General beat sensitivity modifier for presets.
     bool m_aspectCorrection{true};   //!< If true, corrects aspect ratio for non-rectangular windows.
-    float m_easterEgg{0.0};          //!< Random preset duration modifier. See TimeKeeper class.
+    float m_easterEgg{1.0};          //!< Random preset duration modifier. See TimeKeeper class.
     float m_previousFrameVolume{};   //!< Volume in previous frame, used for hard cuts.
 
     std::vector<std::string> m_textureSearchPaths; ///!< List of paths to search for texture files

--- a/src/libprojectM/Renderer/MilkdropNoise.hpp
+++ b/src/libprojectM/Renderer/MilkdropNoise.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <Renderer/Texture.hpp>
+
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 namespace libprojectM {
@@ -24,25 +27,47 @@ namespace Renderer {
 class MilkdropNoise
 {
 public:
-    /**
-     * Constructor. Generates all noise textures.
-     */
-    MilkdropNoise();
+    MilkdropNoise() = delete;
 
     /**
-     * Destructor. Deletes the allocated noise textures.
+     * Low-quality (high frequency) 2D noise texture, 256x256 with zoom level 1
+     * @return A new noise texture ready for use in rendering.
      */
-    ~MilkdropNoise();
+    static auto LowQuality() -> std::shared_ptr<Texture>;
 
-    uint32_t* noise_lq{ nullptr }; //!< Low-quality (high frequency) 2D noise texture, 256x256 with zoom level 1
-    uint32_t* noise_lq_lite{ nullptr }; //!< Low-quality (high frequency) 2D noise texture, 32x32 with zoom level 1
-    uint32_t* noise_mq{ nullptr }; //!< Medium-quality (medium frequency) 2D noise texture, 256x256 with zoom level 4
-    uint32_t* noise_hq{ nullptr }; //!< High-quality (low frequency) 2D noise texture, 256x256 with zoom level 8
+    /**
+     * Low-quality (high frequency) 2D noise texture, 32x32 with zoom level 1
+     * @return A new noise texture ready for use in rendering.
+     */
+    static auto LowQualityLite() -> std::shared_ptr<Texture>;
 
-    uint32_t* noise_lq_vol{ nullptr }; //!< Low-quality (high frequency) 3D noise texture, 32x32 with zoom level 1
-    uint32_t* noise_hq_vol{ nullptr }; //!< High-quality (low frequency) 3D noise texture, 32x32 with zoom level 4
+    /**
+     * Medium-quality (medium frequency) 2D noise texture, 256x256 with zoom level 4
+     * @return A new noise texture ready for use in rendering.
+     */
+    static auto MediumQuality() -> std::shared_ptr<Texture>;
+
+    /**
+     * High-quality (low frequency) 2D noise texture, 256x256 with zoom level 8
+     * @return A new noise texture ready for use in rendering.
+     */
+    static auto HighQuality() -> std::shared_ptr<Texture>;
+
+    /**
+     * Low-quality (high frequency) 3D noise texture, 32x32 with zoom level 1
+     * @return A new noise texture ready for use in rendering.
+     */
+    static auto LowQualityVolume() -> std::shared_ptr<Texture>;
+
+    /**
+     * High-quality (low frequency) 3D noise texture, 32x32 with zoom level 4
+     * @return A new noise texture ready for use in rendering.
+     */
+    static auto HighQualityVolume() -> std::shared_ptr<Texture>;
 
 protected:
+
+    static auto GetPreferredInternalFormat() -> int;
 
     /**
      * @brief Milkdrop 2D noise algorithm
@@ -51,9 +76,9 @@ protected:
      *
      * @param size Texture size in pixels.
      * @param zoomFactor Zoom factor. Higher values give a more smoothed/interpolated look.
-     * @param textureData A pointer to the data structure that will receive the texture data. Must have size² elements.
+     * @return A vector with the texture data. Contains size² elements.
      */
-    static void generate2D(int size, int zoomFactor, uint32_t** textureData);
+    static auto generate2D(int size, int zoomFactor) -> std::vector<uint32_t>;
 
     /**
      * @brief Milkdrop §D noise algorithm
@@ -62,9 +87,9 @@ protected:
      *
      * @param size Texture size in pixels.
      * @param zoomFactor Zoom factor. Higher values give a more smoothed/interpolated look.
-     * @param textureData A pointer to the data structure that will receive the texture data. Must have size³ elements.
+     * @return A vector with the texture data. Contains size³ elements.
      */
-    static void generate3D(int size, int zoomFactor, uint32_t** textureData);
+    static auto generate3D(int size, int zoomFactor) -> std::vector<uint32_t>;
 
     static float fCubicInterpolate(float y0, float y1, float y2, float y3, float t);
 

--- a/src/libprojectM/Renderer/TextureManager.cpp
+++ b/src/libprojectM/Renderer/TextureManager.cpp
@@ -61,7 +61,6 @@ auto TextureManager::GetSampler(const std::string& fullName) -> std::shared_ptr<
     return m_samplers.at({wrapMode, filterMode});
 }
 
-
 void TextureManager::Preload()
 {
     // Create samplers
@@ -80,9 +79,7 @@ void TextureManager::Preload()
         SOIL_CREATE_NEW_ID,
         SOIL_FLAG_POWER_OF_TWO | SOIL_FLAG_MULTIPLY_ALPHA, &width, &height);
 
-
-    auto newTex = std::make_shared<Texture>("idlem", tex, GL_TEXTURE_2D, width, height, false);
-    m_textures["idlem"] = newTex;
+    m_textures["idlem"] = std::make_shared<Texture>("idlem", tex, GL_TEXTURE_2D, width, height, false);;
 
     tex = SOIL_load_OGL_texture_from_memory(
         headphones_data,
@@ -91,63 +88,15 @@ void TextureManager::Preload()
         SOIL_CREATE_NEW_ID,
         SOIL_FLAG_POWER_OF_TWO | SOIL_FLAG_MULTIPLY_ALPHA, &width, &height);
 
-    newTex = std::make_shared<Texture>("idleheadphones", tex, GL_TEXTURE_2D, width, height, false);
-    m_textures["idleheadphones"] = newTex;
+    m_textures["idleheadphones"] = std::make_shared<Texture>("idleheadphones", tex, GL_TEXTURE_2D, width, height, false);;
 
-    auto noise = std::make_unique<MilkdropNoise>();
-
-#ifdef USE_GLES
-    // GLES only supports GL_RGB and GL_RGBA, so we always use the latter.
-    GLint preferredInternalFormat{GL_RGBA};
-#else
-    // Query preferred internal texture format. GLES 3 only supports GL_RENDERBUFFER here, no texture targets.
-    // That's why we use GL_BGRA as default, as this is the best general-use format according to Khronos.
-    GLint preferredInternalFormat{GL_BGRA};
-    glGetInternalformativ(GL_TEXTURE_2D, GL_RGBA8, GL_TEXTURE_IMAGE_FORMAT, sizeof(preferredInternalFormat), &preferredInternalFormat);
-#endif
-
-    GLuint noise_texture_lq_lite;
-    glGenTextures(1, &noise_texture_lq_lite);
-    glBindTexture(GL_TEXTURE_2D, noise_texture_lq_lite);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, 32, 32, 0, preferredInternalFormat, GL_UNSIGNED_BYTE, noise->noise_lq_lite);
-    auto textureNoise_lq_lite = std::make_shared<Texture>("noise_lq_lite", noise_texture_lq_lite, GL_TEXTURE_2D, 32, 32, false);
-    m_textures["noise_lq_lite"] = textureNoise_lq_lite;
-
-    GLuint noise_texture_lq;
-    glGenTextures(1, &noise_texture_lq);
-    glBindTexture(GL_TEXTURE_2D, noise_texture_lq);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, 256, 256, 0, preferredInternalFormat, GL_UNSIGNED_BYTE, noise->noise_lq);
-    auto textureNoise_lq = std::make_shared<Texture>("noise_lq", noise_texture_lq, GL_TEXTURE_2D, 256, 256, false);
-    m_textures["noise_lq"] = textureNoise_lq;
-
-    GLuint noise_texture_mq;
-    glGenTextures(1, &noise_texture_mq);
-    glBindTexture(GL_TEXTURE_2D, noise_texture_mq);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, 256, 256, 0, preferredInternalFormat, GL_UNSIGNED_BYTE, noise->noise_mq);
-    auto textureNoise_mq = std::make_shared<Texture>("noise_mq", noise_texture_mq, GL_TEXTURE_2D, 256, 256, false);
-    m_textures["noise_mq"] = textureNoise_mq;
-
-    GLuint noise_texture_hq;
-    glGenTextures(1, &noise_texture_hq);
-    glBindTexture(GL_TEXTURE_2D, noise_texture_hq);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, 256, 256, 0, preferredInternalFormat, GL_UNSIGNED_BYTE, noise->noise_hq);
-    auto textureNoise_hq = std::make_shared<Texture>("noise_hq", noise_texture_hq, GL_TEXTURE_2D, 256, 256, false);
-    m_textures["noise_hq"] = textureNoise_hq;
-
-    GLuint noise_texture_lq_vol;
-    glGenTextures(1, &noise_texture_lq_vol);
-    glBindTexture(GL_TEXTURE_3D, noise_texture_lq_vol);
-    glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA8, 32, 32, 32, 0, preferredInternalFormat, GL_UNSIGNED_BYTE, noise->noise_lq_vol);
-    auto textureNoise_lq_vol = std::make_shared<Texture>("noisevol_lq", noise_texture_lq_vol, GL_TEXTURE_3D, 32, 32, false);
-    m_textures["noisevol_lq"] = textureNoise_lq_vol;
-
-    GLuint noise_texture_hq_vol;
-    glGenTextures(1, &noise_texture_hq_vol);
-    glBindTexture(GL_TEXTURE_3D, noise_texture_hq_vol);
-    glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA8, 32, 32, 32, 0, preferredInternalFormat, GL_UNSIGNED_BYTE, noise->noise_hq_vol);
-
-    auto textureNoise_hq_vol = std::make_shared<Texture>("noisevol_hq", noise_texture_hq_vol, GL_TEXTURE_3D, 32, 32, false);
-    m_textures["noisevol_hq"] = textureNoise_hq_vol;
+    // Noise textures
+    m_textures["noise_lq_lite"] = MilkdropNoise::LowQualityLite();
+    m_textures["noise_lq"] = MilkdropNoise::LowQuality();
+    m_textures["noise_mq"] = MilkdropNoise::MediumQuality();
+    m_textures["noise_hq"] = MilkdropNoise::HighQuality();
+    m_textures["noisevol_lq"] = MilkdropNoise::LowQualityVolume();
+    m_textures["noisevol_hq"] = MilkdropNoise::HighQualityVolume();
 }
 
 void TextureManager::PurgeTextures()

--- a/src/libprojectM/TimeKeeper.cpp
+++ b/src/libprojectM/TimeKeeper.cpp
@@ -1,6 +1,7 @@
 #include "TimeKeeper.hpp"
 
 #include <algorithm>
+#include <random>
 
 namespace libprojectM {
 
@@ -105,7 +106,12 @@ double TimeKeeper::PresetTimeA()
 
 double TimeKeeper::sampledPresetDuration()
 {
-    std::normal_distribution<double> gaussianDistribution{m_presetDuration, m_easterEgg};
+    if (m_easterEgg < 0.001)
+    {
+        return m_presetDuration;
+    }
+
+    std::normal_distribution<double> gaussianDistribution(m_presetDuration, m_easterEgg);
     return std::max<double>(1.0, gaussianDistribution(m_randomGenerator));
 }
 


### PR DESCRIPTION
Two small things I've fixed/reworked for the 4.1 release:

- Fixed an issue with the sigma value (AKA "easter egg parameter") being zero. It'll be used only when set to values >= 0.001 now, otherwise projecTM will just revert to the default sigma of 1.0. Updated the initial value and the API function documentation accordingly.
- Refactored the MilkdropNoise class so it's longer required to create an instance. It was only used once on startup anyway, and the noise functions were already static. Also moved the texture creation into MilkdropNoise, which now returns a ready-to-use shared pointer to a `Texture` instance.