### PR TITLE
Improve performance with vertex buffer updates

### DIFF
--- a/src/libprojectM/MilkdropPreset/Border.cpp
+++ b/src/libprojectM/MilkdropPreset/Border.cpp
@@ -15,6 +15,9 @@ void Border::InitVertexAttrib()
     glEnableVertexAttribArray(0);
     glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, nullptr);
     glDisableVertexAttribArray(1);
+
+    std::array<Point, 4> vertices{};
+    glBufferData(GL_ARRAY_BUFFER, sizeof(Point) * 4, vertices.data(), GL_STREAM_DRAW);
 }
 
 void Border::Draw(const PerFrameContext& presetPerFrameContext)
@@ -59,7 +62,7 @@ void Border::Draw(const PerFrameContext& presetPerFrameContext)
 
             for (int rot = 0; rot < 4; rot++)
             {
-                glBufferData(GL_ARRAY_BUFFER, sizeof(Point) * 4, vertices.data(), GL_DYNAMIC_DRAW);
+                glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(Point) * 4, vertices.data());
                 glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
 
                 // Rotate 90 degrees

--- a/src/libprojectM/MilkdropPreset/CustomShape.cpp
+++ b/src/libprojectM/MilkdropPreset/CustomShape.cpp
@@ -13,6 +13,9 @@ CustomShape::CustomShape(PresetState& presetState)
     : m_presetState(presetState)
     , m_perFrameContext(presetState.globalMemory, &presetState.globalRegisters)
 {
+    std::vector<TexturedPoint> vertexData;
+    vertexData.resize(102);
+
     glGenVertexArrays(1, &m_vaoIdTextured);
     glGenBuffers(1, &m_vboIdTextured);
 
@@ -30,6 +33,8 @@ CustomShape::CustomShape(PresetState& presetState)
     glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, sizeof(TexturedPoint), reinterpret_cast<void*>(offsetof(TexturedPoint, r))); // Color
     glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(TexturedPoint), reinterpret_cast<void*>(offsetof(TexturedPoint, u))); // Texture coordinate
 
+    glBufferData(GL_ARRAY_BUFFER, sizeof(TexturedPoint) * vertexData.size(), vertexData.data(), GL_STREAM_DRAW);
+
     glBindVertexArray(m_vaoIdUntextured);
     glBindBuffer(GL_ARRAY_BUFFER, m_vboIdUntextured);
 
@@ -38,6 +43,8 @@ CustomShape::CustomShape(PresetState& presetState)
 
     glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(TexturedPoint), reinterpret_cast<void*>(offsetof(TexturedPoint, x))); // Position
     glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, sizeof(TexturedPoint), reinterpret_cast<void*>(offsetof(TexturedPoint, r))); // Color
+
+    glBufferData(GL_ARRAY_BUFFER, sizeof(TexturedPoint) * vertexData.size(), vertexData.data(), GL_STREAM_DRAW);
 
     RenderItem::Init();
 
@@ -58,6 +65,10 @@ void CustomShape::InitVertexAttrib()
     glEnableVertexAttribArray(0);
     glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, nullptr); // points
     glDisableVertexAttribArray(1);
+
+    std::vector<Point> vertexData;
+    vertexData.resize(100);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(Point) * vertexData.size(), vertexData.data(), GL_STREAM_DRAW);
 }
 
 void CustomShape::Initialize(PresetFileParser& parsedFile, int index)
@@ -217,7 +228,7 @@ void CustomShape::Draw()
 
             glBindBuffer(GL_ARRAY_BUFFER, m_vboIdTextured);
 
-            glBufferData(GL_ARRAY_BUFFER, sizeof(TexturedPoint) * (sides + 2), vertexData.data(), GL_DYNAMIC_DRAW);
+            glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(TexturedPoint) * (sides + 2), vertexData.data());
 
             glBindVertexArray(m_vaoIdTextured);
             glDrawArrays(GL_TRIANGLE_FAN, 0, sides + 2);
@@ -231,7 +242,7 @@ void CustomShape::Draw()
             // Untextured (creates a color gradient: center=r/g/b/a to border=r2/b2/g2/a2)
             glBindBuffer(GL_ARRAY_BUFFER, m_vboIdUntextured);
 
-            glBufferData(GL_ARRAY_BUFFER, sizeof(TexturedPoint) * (sides + 2), vertexData.data(), GL_DYNAMIC_DRAW);
+            glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(TexturedPoint) * (sides + 2), vertexData.data());
 
             m_presetState.untexturedShader.Bind();
             m_presetState.untexturedShader.SetUniformMat4x4("vertex_transformation", PresetState::orthogonalProjection);
@@ -304,7 +315,7 @@ void CustomShape::Draw()
                         break;
                 }
 
-                glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizei>(sizeof(Point) * sides), points.data(), GL_DYNAMIC_DRAW);
+                glBufferSubData(GL_ARRAY_BUFFER, 0, static_cast<GLsizei>(sizeof(Point) * sides), points.data());
                 glDrawArrays(GL_LINE_LOOP, 0, sides);
             }
         }

--- a/src/libprojectM/MilkdropPreset/CustomWaveform.cpp
+++ b/src/libprojectM/MilkdropPreset/CustomWaveform.cpp
@@ -30,6 +30,10 @@ void CustomWaveform::InitVertexAttrib()
 
     glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(ColoredPoint), nullptr);                                    // points
     glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, sizeof(ColoredPoint), reinterpret_cast<void*>(sizeof(float) * 2)); // colors
+
+    std::vector<ColoredPoint> vertexData;
+    vertexData.resize(std::max(libprojectM::Audio::SpectrumSamples, libprojectM::Audio::WaveformSamples) * 2 + 2);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(ColoredPoint) * vertexData.size(), vertexData.data(), GL_STREAM_DRAW);
 }
 
 void CustomWaveform::Initialize(PresetFileParser& parsedFile, int index)
@@ -224,7 +228,7 @@ void CustomWaveform::Draw(const PerFrameContext& presetPerFrameContext)
                 break;
         }
 
-        glBufferData(GL_ARRAY_BUFFER, sizeof(ColoredPoint) * smoothedVertexCount, pointsSmoothed.data(), GL_DYNAMIC_DRAW);
+        glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(ColoredPoint) * smoothedVertexCount, pointsSmoothed.data());
         glDrawArrays(drawType, 0, smoothedVertexCount);
     }
 

--- a/src/libprojectM/MilkdropPreset/FinalComposite.cpp
+++ b/src/libprojectM/MilkdropPreset/FinalComposite.cpp
@@ -32,6 +32,10 @@ void FinalComposite::InitVertexAttrib()
     glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, sizeof(MeshVertex), reinterpret_cast<void*>(offsetof(MeshVertex, r)));      // Colors
     glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(MeshVertex), reinterpret_cast<void*>(offsetof(MeshVertex, u)));      // Textures
     glVertexAttribPointer(3, 2, GL_FLOAT, GL_FALSE, sizeof(MeshVertex), reinterpret_cast<void*>(offsetof(MeshVertex, radius))); // Radius/Angle
+
+    // Pre-allocate vertex and index buffers
+    glBufferData(GL_ARRAY_BUFFER, sizeof(MeshVertex) * vertexCount, m_vertices.data(), GL_STREAM_DRAW);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(int) * m_indices.size(), m_indices.data(), GL_STREAM_DRAW);
 }
 
 void FinalComposite::LoadCompositeShader(const PresetState& presetState)
@@ -121,7 +125,7 @@ void FinalComposite::Draw(const PresetState& presetState, const PerFrameContext&
         glDisable(GL_BLEND);
         glBindVertexArray(m_vaoID);
         glBindBuffer(GL_ARRAY_BUFFER, m_vboID);
-        glBufferData(GL_ARRAY_BUFFER, sizeof(MeshVertex) * vertexCount, m_vertices.data(), GL_DYNAMIC_DRAW);
+        glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(MeshVertex) * vertexCount, m_vertices.data());
         glBindBuffer(GL_ARRAY_BUFFER, 0);
 
         m_compositeShader->LoadVariables(presetState, perFrameContext);
@@ -303,7 +307,7 @@ void FinalComposite::InitializeMesh(const PresetState& presetState)
     // Store indices.
     // ToDo: Probably don't need to store m_indices
     glBindVertexArray(m_vaoID);
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(int) * m_indices.size(), m_indices.data(), GL_STATIC_DRAW);
+    glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, 0, sizeof(int) * m_indices.size(), m_indices.data());
     glBindVertexArray(0);
 }
 

--- a/src/libprojectM/MilkdropPreset/MotionVectors.cpp
+++ b/src/libprojectM/MilkdropPreset/MotionVectors.cpp
@@ -137,7 +137,15 @@ void MotionVectors::Draw(const PerFrameContext& presetPerFrameContext, std::shar
             }
 
             // Draw a row of lines.
-            glBufferData(GL_ARRAY_BUFFER, sizeof(MotionVectorVertex) * vertex, lineVertices.data(), GL_DYNAMIC_DRAW);
+            if (m_lastVertexCount >= vertex)
+            {
+                glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(MotionVectorVertex) * vertex, lineVertices.data());
+            }
+            else
+            {
+                glBufferData(GL_ARRAY_BUFFER, sizeof(MotionVectorVertex) * vertex, lineVertices.data(), GL_STREAM_DRAW);
+                m_lastVertexCount = vertex;
+            }
             glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(vertex));
         }
     }

--- a/src/libprojectM/MilkdropPreset/MotionVectors.hpp
+++ b/src/libprojectM/MilkdropPreset/MotionVectors.hpp
@@ -47,6 +47,8 @@ private:
 
     Renderer::Shader m_motionVectorShader; //!< The motion vector shader, calculates the trace positions in the GPU.
     std::shared_ptr<Renderer::Sampler> m_sampler{std::make_shared<Renderer::Sampler>(GL_CLAMP_TO_EDGE, GL_LINEAR)}; //!< The texture sampler.
+
+    int m_lastVertexCount{}; //!< Number of vertices drawn in the previous draw call.
 };
 
 } // namespace MilkdropPreset

--- a/src/libprojectM/MilkdropPreset/Waveform.cpp
+++ b/src/libprojectM/MilkdropPreset/Waveform.cpp
@@ -30,6 +30,10 @@ void Waveform::InitVertexAttrib()
     glDisableVertexAttribArray(1);
 
     glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, nullptr);
+
+    std::vector<Point> vertexData;
+    vertexData.resize(std::max(libprojectM::Audio::SpectrumSamples, libprojectM::Audio::WaveformSamples) * 2 + 2);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(Point) * vertexData.size(), vertexData.data(), GL_STREAM_DRAW);
 }
 
 void Waveform::Draw(const PerFrameContext& presetPerFrameContext)
@@ -118,7 +122,7 @@ void Waveform::Draw(const PerFrameContext& presetPerFrameContext)
                     break;
             }
 
-            glBufferData(GL_ARRAY_BUFFER, sizeof(Point) * smoothedWave.size(), smoothedWave.data(), GL_DYNAMIC_DRAW);
+            glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(Point) * smoothedWave.size(), smoothedWave.data());
             glDrawArrays(drawType, 0, static_cast<GLsizei>(smoothedWave.size()));
         }
     }


### PR DESCRIPTION
In wave/shape drawing code, we now preallocate the vertex buffer once for the maximum number of sides and only update the existing buffer instead of reallocating it over and over again. Trades a few KB of additional RAM for a good amount of drawing performance.

In the motion vector grid code, we only reallocate the buffer if we draw more vertices than in the previous draw call.

Also changed the drawing hint to GL_STREAM_DRAW, which is slightly better suited for this kind of usage (update once, draw once, repeat).

These changes should hopefully improve performance, especially when large numbers of custom shapes are drawn.