### PR TITLE
Modify NaN propagation for multiplication

### DIFF
--- a/src/libprojectM/MilkdropPreset/MilkdropShader.cpp
+++ b/src/libprojectM/MilkdropPreset/MilkdropShader.cpp
@@ -612,7 +612,7 @@ void MilkdropShader::TranspileHLSLShader(const PresetState& presetState, std::st
     // Then generate GLSL from the resulting parser tree
     if (!generator.Generate(&tree, M4::GLSLGenerator::Target_FragmentShader,
                             MilkdropStaticShaders::Get()->GetGlslGeneratorVersion(),
-                            "PS"))
+                            "PS", M4::GLSLGenerator::Options(M4::GLSLGenerator::Flag_AlternateNanPropagation)))
     {
         throw Renderer::ShaderException("Error translating HLSL " + shaderTypeString + " shader: GLSL generating failed.\nSource:\n" + sourcePreprocessed);
     }

--- a/vendor/hlslparser/src/GLSLGenerator.cpp
+++ b/vendor/hlslparser/src/GLSLGenerator.cpp
@@ -430,6 +430,11 @@ bool GLSLGenerator::Generate(HLSLTree* tree, Target target, Version version, con
         m_writer.WriteLine(0, "vec2 %s(vec2 x, vec2 y) { return vec2(%s(x.x, y.x), %s(x.y, y.y)); }", m_altMultFunction, m_altMultFunction, m_altMultFunction);
         m_writer.WriteLine(0, "vec3 %s(vec3 x, vec3 y) { return vec3(%s(x.x, y.x), %s(x.y, y.y), %s(x.z, y.z)); }", m_altMultFunction, m_altMultFunction, m_altMultFunction, m_altMultFunction);
         m_writer.WriteLine(0, "vec4 %s(vec4 x, vec4 y) { return vec4(%s(x.x, y.x), %s(x.y, y.y), %s(x.z, y.z), %s(x.w, y.w)); }", m_altMultFunction, m_altMultFunction, m_altMultFunction, m_altMultFunction, m_altMultFunction);
+        // For matrix multiplication just perform the multiplication
+        m_writer.WriteLine(0, "mat2 %s(mat2 x, mat2 y) { return x * y; }", m_altMultFunction);
+        m_writer.WriteLine(0, "mat3 %s(mat3 x, mat3 y) { return x * y; }", m_altMultFunction);
+        m_writer.WriteLine(0, "mat4 %s(mat4 x, mat4 y) { return x * y; }", m_altMultFunction);
+
     }
 
     m_writer.WriteLine(0, "vec2  %s(float x) { return  vec2(x, x); }", m_scalarSwizzle2Function);

--- a/vendor/hlslparser/src/GLSLGenerator.h
+++ b/vendor/hlslparser/src/GLSLGenerator.h
@@ -43,6 +43,7 @@ public:
         Flag_EmulateConstantBuffer = 1 << 1,
         Flag_PackMatrixRowMajor = 1 << 2,
         Flag_LowerMatrixMultiplication = 1 << 3,
+        Flag_AlternateNanPropagation = 1 << 4,
     };
 
     struct Options
@@ -53,6 +54,12 @@ public:
         Options()
         {
             flags = 0;
+            constantBufferPrefix = "";
+        }
+
+        Options(unsigned int _flags)
+        {
+            flags = _flags;
             constantBufferPrefix = "";
         }
     };
@@ -160,6 +167,7 @@ private:
     char                m_modfFunction[64];
     char                m_acosFunction[64];
     char                m_asinFunction[64];
+    char                m_altMultFunction[64];
 
     bool                m_error;
 

--- a/vendor/hlslparser/src/HLSLParser.cpp
+++ b/vendor/hlslparser/src/HLSLParser.cpp
@@ -620,8 +620,8 @@ const Intrinsic _intrinsic[] =
         INTRINSIC_FLOAT2_FUNCTION( "step" ),
         INTRINSIC_FLOAT2_FUNCTION( "reflect" ),
 
-		INTRINSIC_FLOAT1_FUNCTION("isnan"),
-		INTRINSIC_FLOAT1_FUNCTION("isinf"),
+		Intrinsic("isnan",    HLSLBaseType_Bool, HLSLBaseType_Float),
+		Intrinsic("isinf",    HLSLBaseType_Bool, HLSLBaseType_Float),
 
 		Intrinsic("asuint",    HLSLBaseType_Uint, HLSLBaseType_Float),
 


### PR DESCRIPTION
This solves some edge cases in presets that suppress NaN or infinities by multiplying by zero. It's not clear what the performance impact is with this change, and it may not be something we want to always enable. Because of that, I've added an option flag to 
 `GLSLGenerator::Generate()` to enable or disable the behavior. This may be something we don't want to end up merging if the performance impact is too high.