### PR TITLE
Search preloaded random textures in TextureManager::GetRandomTexture

### DIFF
--- a/src/libprojectM/Renderer/TextureManager.hpp
+++ b/src/libprojectM/Renderer/TextureManager.hpp
@@ -40,9 +40,11 @@ public:
      * @brief Returns a random texture descriptor, optionally using a prefix (after the `randXX_` name).
      * Will use the default texture loading logic by calling GetTexture() if a texture was selected.
      * @param randomName The filename prefix to filter. If empty, all available textures are matches. Case-insensitive.
-     * @return A texture descriptor with the random texture and a default sampler, or an empty sampler if no texture could be matched.
+     * @param type The type of texture to load.
+     * @return A texture descriptor with the random texture of specified type and a default sampler,
+     *  or an empty sampler if no texture could be matched.
      */
-    auto GetRandomTexture(const std::string& randomName) -> TextureSamplerDescriptor;
+    auto GetRandomTexture(const std::string& randomName, GLenum type = GL_TEXTURE_2D) -> TextureSamplerDescriptor;
 
     /**
      * @brief Returns a sampler for the given name.


### PR DESCRIPTION
We currently only check textures loaded from files when selecting a random texture. Since we purge textures between presets, if a preset uses something like `sampler_rand00`, no presets will be found, the returned sampler will be null, and we end up creating invalid GLSL. This PR doesn't check the results of `GetRandomSampler` to make sure they're valid, but does extend `GetRandomSampler` to include preloaded textures. As this list includes volumetric textures, also filter textures by type. This type defaults to 2D textures and is not otherwise specified elsewhere as I can't find evidence that `GetRandomSampler` is ever expected to return a 3D texture.