### PR TITLE
fix: parser test labels

### DIFF
--- a/tests/libprojectM/PresetFileParserTest.cpp
+++ b/tests/libprojectM/PresetFileParserTest.cpp
@@ -61,7 +61,6 @@ TEST(PresetFileParser, ValueWithSpaceDelimiter)
 
     const auto& values = parser.PresetValues();
 
-    // Lines with empty key should be ignored
     ASSERT_TRUE(values.find("value_with_space") != values.end());
     EXPECT_EQ(values.at("value_with_space"), "123");
 }

--- a/tests/libprojectM/PresetFileParserTest.cpp
+++ b/tests/libprojectM/PresetFileParserTest.cpp
@@ -54,7 +54,7 @@ TEST(PresetFileParser, EmptyValue)
     EXPECT_EQ(values.at("empty_value"), "");
 }
 
-TEST(PresetFileParser, EmptyKey)
+TEST(PresetFileParser, ValueWithSpaceDelimiter)
 {
     PresetFileParser parser;
     ASSERT_TRUE(parser.Read(std::string(fileParserTestDataPath) + "parser-simple.milk"));
@@ -66,7 +66,7 @@ TEST(PresetFileParser, EmptyKey)
     EXPECT_EQ(values.at("value_with_space"), "123");
 }
 
-TEST(PresetFileParser, ValueWithSpaceDelimiter)
+TEST(PresetFileParser, EmptyKey)
 {
     PresetFileParser parser;
     ASSERT_TRUE(parser.Read(std::string(fileParserTestDataPath) + "parser-simple.milk"));


### PR DESCRIPTION
* swaps misordered label values