### PR TITLE
Add custom FBO rendering function

### DIFF
--- a/src/api/include/projectM-4/render_opengl.h
+++ b/src/api/include/projectM-4/render_opengl.h
@@ -34,12 +34,17 @@ extern "C" {
 /**
  * @brief Renders a single frame.
  *
- * @note Separate two-pass frame rendering is currently not supported by the C API as it is rarely used
- *       and also depends on the loaded preset.
- *
  * @param instance The projectM instance handle.
  */
 PROJECTM_EXPORT void projectm_opengl_render_frame(projectm_handle instance);
+
+/**
+ * @brief Renders a single frame into a user-defined framebuffer object.
+ *
+ * @param instance The projectM instance handle.
+ * @param framebuffer_object_id The OpenGL FBO ID to render to.
+ */
+PROJECTM_EXPORT void projectm_opengl_render_frame_fbo(projectm_handle instance, uint32_t framebuffer_object_id);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/libprojectM/ProjectM.cpp
+++ b/src/libprojectM/ProjectM.cpp
@@ -90,7 +90,7 @@ void ProjectM::ResetTextures()
     m_textureManager = std::make_unique<Renderer::TextureManager>(m_textureSearchPaths);
 }
 
-void ProjectM::RenderFrame()
+void ProjectM::RenderFrame(uint32_t targetFramebufferObject /*= 0*/)
 {
     // Don't render if window area is zero.
     if (m_windowWidth == 0 || m_windowHeight == 0)
@@ -166,8 +166,7 @@ void ProjectM::RenderFrame()
     // ToDo: Call the to-be-implemented render method in Renderer
     m_activePreset->RenderFrame(audioData, renderContext);
 
-    // ToDo: Allow external apps to provide a custom target framebuffer.
-    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, static_cast<GLuint>(targetFramebufferObject));
 
     if (m_transition != nullptr && m_transitioningPreset != nullptr)
     {

--- a/src/libprojectM/ProjectM.hpp
+++ b/src/libprojectM/ProjectM.hpp
@@ -101,7 +101,7 @@ public:
 
     void ResetTextures();
 
-    void RenderFrame();
+    void RenderFrame(uint32_t targetFramebufferObject = 0);
 
     void SetBeatSensitivity(float sensitivity);
 

--- a/src/libprojectM/ProjectMCWrapper.cpp
+++ b/src/libprojectM/ProjectMCWrapper.cpp
@@ -6,6 +6,8 @@
 
 #include <cstring>
 #include <sstream>
+#include <projectM-4/render_opengl.h>
+
 
 namespace libprojectM {
 
@@ -169,6 +171,12 @@ void projectm_opengl_render_frame(projectm_handle instance)
 {
     auto projectMInstance = handle_to_instance(instance);
     projectMInstance->RenderFrame();
+}
+
+void projectm_opengl_render_frame_fbo(projectm_handle instance, uint32_t framebuffer_object_id)
+{
+    auto projectMInstance = handle_to_instance(instance);
+    projectMInstance->RenderFrame(framebuffer_object_id);
 }
 
 void projectm_set_beat_sensitivity(projectm_handle instance, float sensitivity)


### PR DESCRIPTION
Added a new API function `projectm_opengl_render_frame_fbo()` to pass an optional custom OpenGL FBO ID for the final rendering output copy operation. This will allow users to render to an offscreen texture or a framebuffer provided by the embedding application's drawing subsystem, e.g. Qt.