### PR TITLE
Add external timing API

### DIFF
--- a/src/api/include/projectM-4/parameters.h
+++ b/src/api/include/projectM-4/parameters.h
@@ -46,6 +46,38 @@ PROJECTM_EXPORT void projectm_set_texture_search_paths(projectm_handle instance,
                                                        size_t count);
 
 /**
+ * @brief Sets a user-specified frame time in fractional seconds.
+ *
+ * Setting this to any value equal to or larger than zero will make projectM use this time value for
+ * animations instead of the system clock. Any value less than zero will use the system time instead,
+ * which is the default behavior.
+ *
+ * This method can be used to render visualizations at non-realtime frame rates, e.g. encoding a video
+ * as fast as projectM can render frames.
+ *
+ * While switching back and forth between system and user time values is possible, it will cause
+ * visual artifacts in the rendering as the time value will make large jumps between frames. Thus,
+ * it is recommended to stay with one type of timing value.
+ *
+ * If using this feature, it is further recommended to set the time to 0.0 on the first frame.
+ *
+ * @param instance The projectM instance handle.
+ * @param seconds_since_first_frame Any value >= 0 to use user-specified timestamps, values < 0 will use the system clock.
+ */
+PROJECTM_EXPORT void projectm_set_frame_time(projectm_handle instance, double seconds_since_first_frame);
+
+/**
+ * @brief Returns the fractional seconds time value used rendering the last frame.
+ * @note This will not return the value set with projectm_set_frame_time, but the actual time
+ *       used to render the last frame. If a user-specified frame time was set, this value is
+ *       returned. Otherwise, the frame time measured via the system clock will be returned.
+ * @param instance The projectM instance handle.
+ * @return Time elapsed since projectM was started, or the value of the user-specified time value used
+ *         to render the last frame.
+ */
+PROJECTM_EXPORT double projectm_get_last_frame_time(projectm_handle instance);
+
+/**
  * @brief Sets the beat sensitivity.
  *
  * The beat sensitivity to be used.

--- a/src/libprojectM/ProjectM.cpp
+++ b/src/libprojectM/ProjectM.cpp
@@ -150,7 +150,7 @@ void ProjectM::RenderFrame(uint32_t targetFramebufferObject /*= 0*/)
 
     if (m_transition != nullptr && m_transitioningPreset != nullptr)
     {
-        if (m_transition->IsDone())
+        if (m_transition->IsDone(m_timeKeeper->GetFrameTime()))
         {
             m_activePreset = std::move(m_transitioningPreset);
             m_transitioningPreset.reset();
@@ -170,7 +170,7 @@ void ProjectM::RenderFrame(uint32_t targetFramebufferObject /*= 0*/)
 
     if (m_transition != nullptr && m_transitioningPreset != nullptr)
     {
-        m_transition->Draw(*m_activePreset, *m_transitioningPreset, renderContext, audioData);
+        m_transition->Draw(*m_activePreset, *m_transitioningPreset, renderContext, audioData, m_timeKeeper->GetFrameTime());
     }
     else
     {
@@ -254,7 +254,7 @@ void ProjectM::StartPresetTransition(std::unique_ptr<Preset>&& preset, bool hard
     {
         m_transitioningPreset = std::move(preset);
         m_timeKeeper->StartSmoothing();
-        m_transition = std::make_unique<Renderer::PresetTransition>(m_transitionShaderManager->RandomTransition(), m_softCutDuration);
+        m_transition = std::make_unique<Renderer::PresetTransition>(m_transitionShaderManager->RandomTransition(), m_softCutDuration, m_timeKeeper->GetFrameTime());
     }
 }
 

--- a/src/libprojectM/ProjectM.cpp
+++ b/src/libprojectM/ProjectM.cpp
@@ -281,6 +281,16 @@ auto ProjectM::PresetLocked() const -> bool
     return m_presetLocked;
 }
 
+void ProjectM::SetFrameTime(double secondsSinceStart)
+{
+    m_timeKeeper->SetFrameTime(secondsSinceStart);
+}
+
+double ProjectM::GetFrameTime()
+{
+    return m_timeKeeper->GetFrameTime();
+}
+
 void ProjectM::SetBeatSensitivity(float sensitivity)
 {
     m_beatSensitivity = std::min(std::max(0.0f, sensitivity), 2.0f);

--- a/src/libprojectM/ProjectM.hpp
+++ b/src/libprojectM/ProjectM.hpp
@@ -103,6 +103,22 @@ public:
 
     void RenderFrame(uint32_t targetFramebufferObject = 0);
 
+    /**
+     * @brief Sets a user-specified time for rendering the next frame
+     * Negative values will make projectM use the system clock instead.
+     * @param secondsSinceStart Fractional seconds since rendering the first frame.
+     */
+    void SetFrameTime(double secondsSinceStart);
+
+    /**
+     * @brief Gets the time of the last frame rendered.
+     * @note This will not return the value set with SetFrameTime, but the actual time used to render the last frame.
+     *       If a user-specified frame time was set, this value is returned. Otherwise, the frame time measured via the
+     *       system clock will be returned.
+     * @return Seconds elapsed rendering the last frame since starting projectM.
+     */
+    double GetFrameTime();
+
     void SetBeatSensitivity(float sensitivity);
 
     auto GetBeatSensitivity() const -> float;

--- a/src/libprojectM/ProjectMCWrapper.cpp
+++ b/src/libprojectM/ProjectMCWrapper.cpp
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <sstream>
 #include <projectM-4/render_opengl.h>
+#include <projectM-4/parameters.h>
 
 
 namespace libprojectM {
@@ -177,6 +178,18 @@ void projectm_opengl_render_frame_fbo(projectm_handle instance, uint32_t framebu
 {
     auto projectMInstance = handle_to_instance(instance);
     projectMInstance->RenderFrame(framebuffer_object_id);
+}
+
+void projectm_set_frame_time(projectm_handle instance, double seconds_since_first_frame)
+{
+    auto projectMInstance = handle_to_instance(instance);
+    projectMInstance->SetFrameTime(seconds_since_first_frame);
+}
+
+double projectm_get_last_frame_time(projectm_handle instance)
+{
+    auto projectMInstance = handle_to_instance(instance);
+    return projectMInstance->GetFrameTime();
 }
 
 void projectm_set_beat_sensitivity(projectm_handle instance, float sensitivity)

--- a/src/libprojectM/Renderer/PresetTransition.hpp
+++ b/src/libprojectM/Renderer/PresetTransition.hpp
@@ -8,7 +8,6 @@
 
 #include <glm/glm.hpp>
 
-#include <chrono>
 #include <random>
 
 namespace libprojectM {
@@ -22,15 +21,24 @@ class PresetTransition : public RenderItem
 public:
     PresetTransition() = delete;
 
-    explicit PresetTransition(const std::shared_ptr<Shader>& transitionShader, double durationSeconds);
+    /**
+     * Constructor.
+     * @param transitionShader The transition shader program.
+     * @param durationSeconds Transition duration in seconds.
+     * @param transitionStartTime The time in seconds since start of projectM.
+     */
+    explicit PresetTransition(const std::shared_ptr<Shader>& transitionShader,
+                              double durationSeconds,
+                              double transitionStartTime);
 
     void InitVertexAttrib() override;
 
     /**
      * @brief Returns true if the transition is done.
+     * @param currentFrameTime The time in seconds since start of the current frame.
      * @return false if the transition is still in progress, true if it's done.
      */
-    auto IsDone() const -> bool;
+    auto IsDone(double currentFrameTime) const -> bool;
 
     /**
      * @brief Updates the transition variables and renders the shader quad to the current FBO.
@@ -38,11 +46,13 @@ public:
      * @param newPreset A reference to the new (fading in) preset.
      * @param context The rendering context used to render the presets.
      * @param audioData Current audio data and beat detection values.
+     * @param currentFrameTime The time in seconds since start of the current frame.
      */
     void Draw(const Preset& oldPreset,
               const Preset& newPreset,
               const RenderContext& context,
-              const libprojectM::Audio::FrameAudioData& audioData);
+              const libprojectM::Audio::FrameAudioData& audioData,
+              double currentFrameTime);
 
 private:
     std::vector<std::string> m_noiseTextureNames{"noise_lq",
@@ -59,9 +69,9 @@ private:
     std::shared_ptr<Shader> m_transitionShader;                                                       //!< The compiled shader used for this transition.
     std::shared_ptr<Sampler> m_presetSampler{std::make_shared<Sampler>(GL_CLAMP_TO_EDGE, GL_LINEAR)}; //!< Sampler for preset textures. Uses bilinear interpolation and no repeat.
 
-    double m_durationSeconds{3.0};                                                                              //!< Transition duration in seconds.
-    std::chrono::time_point<std::chrono::system_clock> m_transitionStartTime{std::chrono::system_clock::now()}; //!< Start time of this transition. Duration is measured from this point.
-    std::chrono::time_point<std::chrono::system_clock> m_lastFrameTime{std::chrono::system_clock::now()};       //!< Time when the previous frame was rendered.
+    double m_durationSeconds{3.0};  //!< Transition duration in seconds.
+    double m_transitionStartTime{}; //!< Start time of this transition. Duration is measured from this point.
+    double m_lastFrameTime{};       //!< Time when the previous frame was rendered.
 
     glm::ivec4 m_staticRandomValues{}; //!< Four random integers, remaining static during the whole transition.
 

--- a/src/libprojectM/TimeKeeper.cpp
+++ b/src/libprojectM/TimeKeeper.cpp
@@ -14,11 +14,26 @@ TimeKeeper::TimeKeeper(double presetDuration, double smoothDuration, double hard
     UpdateTimers();
 }
 
+void TimeKeeper::SetFrameTime(double secondsSinceStart)
+{
+    m_userSpecifiedTime = secondsSinceStart;
+}
+
+double TimeKeeper::GetFrameTime() const
+{
+    return m_currentTime;
+}
+
 void TimeKeeper::UpdateTimers()
 {
-    auto currentTime = std::chrono::high_resolution_clock::now();
+    double currentFrameTime{m_userSpecifiedTime};
 
-    double currentFrameTime = std::chrono::duration<double>(currentTime - m_startTime).count();
+    if (m_userSpecifiedTime < 0.0)
+    {
+        auto currentTime = std::chrono::high_resolution_clock::now();
+        currentFrameTime = std::chrono::duration<double>(currentTime - m_startTime).count();
+    }
+
     m_secondsSinceLastFrame = currentFrameTime - m_currentTime;
     m_currentTime = currentFrameTime;
     m_presetFrameA++;

--- a/src/libprojectM/TimeKeeper.hpp
+++ b/src/libprojectM/TimeKeeper.hpp
@@ -11,6 +11,25 @@ class TimeKeeper
 public:
     TimeKeeper(double presetDuration, double smoothDuration, double hardcutDuration, double easterEgg);
 
+    /**
+     * @brief Sets a custom time value to use instead of the system time.
+     * If less than zero, the system time will be used instead.
+     * @param secondsSinceStart Fractional seconds since rendering the first frame.
+     */
+    void SetFrameTime(double secondsSinceStart);
+
+    /**
+     * @brief Gets the time of the last frame rendered.
+     * @note This will not return the value set with SetFrameTime, but the actual time used to render the last frame.
+     *       If a user-specified frame time was set, this value is returned. Otherwise, the frame time measured via the
+     *       system clock will be returned.
+     * @return Seconds elapsed rendering the last frame since starting projectM.
+     */
+    double GetFrameTime() const;
+
+    /**
+     * @brief Updates internal timers with either the system clock or a user-specified time value.
+     */
     void UpdateTimers();
 
     void StartPreset();
@@ -92,6 +111,8 @@ private:
 
     std::random_device m_randomDevice{};
     std::mt19937 m_randomGenerator{m_randomDevice()};
+
+    double m_userSpecifiedTime{-1.0}; //!< User-specifed run time. If set to a value >= 0.0, this time is used instead of the system clock.
 
     double m_secondsSinceLastFrame{};
 


### PR DESCRIPTION
Allow apps to set the time before each frame, allowing for non-realtime rendering with fixed or dynamic framerates. Setting the frame time to any value equal to or greater than zero will use this value for the next frame, while setting it to a negative value will make projectM use the system time instead.

The value defaults to `-1.0`, so if the `projectm_set_frame_time()` method is not called, projectM will just behave as in previous versions.

Also added another function to retrieve the time of the last rendered frame.

Closes #740 