### PR TITLE
Check if active preset output texture is valid before copying

### DIFF
--- a/src/libprojectM/ProjectM.cpp
+++ b/src/libprojectM/ProjectM.cpp
@@ -243,6 +243,9 @@ void ProjectM::StartPresetTransition(std::unique_ptr<Preset>&& preset, bool hard
     if (m_activePreset)
     {
         auto outputTexture = m_activePreset->OutputTexture();
+
+        // Check if the output texture is valid by testing if the OpenGL texturing target enum has been initialized.
+        // In case of the initial preset transition, it is 0.
         if (outputTexture->Type() != 0) {
             preset->DrawInitialImage(outputTexture, GetRenderContext());
         }

--- a/src/libprojectM/ProjectM.cpp
+++ b/src/libprojectM/ProjectM.cpp
@@ -242,7 +242,10 @@ void ProjectM::StartPresetTransition(std::unique_ptr<Preset>&& preset, bool hard
 
     if (m_activePreset)
     {
-        preset->DrawInitialImage(m_activePreset->OutputTexture(), GetRenderContext());
+        auto outputTexture = m_activePreset->OutputTexture();
+        if (outputTexture->Type() != 0) {
+            preset->DrawInitialImage(outputTexture, GetRenderContext());
+        }
     }
 
     if (hardCut)


### PR DESCRIPTION
Possible fix for https://github.com/projectM-visualizer/projectm/issues/823