### PR TITLE
[V4.1.x] Fix GL_INVALID_ENUM error in CopyTexture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 
 project(libprojectM
         LANGUAGES C CXX
-        VERSION 4.1.1
+        VERSION 4.1.2
         )
 
 # The API (SO) version for the shared library. Should be incremented whenever the binary interface changes

--- a/src/libprojectM/Renderer/CopyTexture.cpp
+++ b/src/libprojectM/Renderer/CopyTexture.cpp
@@ -111,7 +111,10 @@ void CopyTexture::Draw(const std::shared_ptr<class Texture>& originalTexture, bo
 void CopyTexture::Draw(const std::shared_ptr<class Texture>& originalTexture, const std::shared_ptr<class Texture>& targetTexture,
                        bool flipVertical, bool flipHorizontal)
 {
-    if (originalTexture == nullptr || originalTexture == targetTexture)
+    if (originalTexture == nullptr ||
+        originalTexture->Empty() ||
+        (targetTexture != nullptr && targetTexture->Empty()) ||
+        originalTexture == targetTexture)
     {
         return;
     }
@@ -157,7 +160,10 @@ void CopyTexture::Draw(const std::shared_ptr<class Texture>& originalTexture, co
 void CopyTexture::Draw(const std::shared_ptr<class Texture>& originalTexture, Framebuffer& framebuffer, int framebufferIndex,
                        bool flipVertical, bool flipHorizontal)
 {
-    if (originalTexture == nullptr || framebuffer.GetColorAttachmentTexture(framebufferIndex, 0) == nullptr)
+    if (originalTexture == nullptr ||
+        originalTexture->Empty() ||
+        framebuffer.GetColorAttachmentTexture(framebufferIndex, 0) == nullptr ||
+        framebuffer.GetColorAttachmentTexture(framebufferIndex, 0)->Empty())
     {
         return;
     }

--- a/src/libprojectM/Renderer/Texture.cpp
+++ b/src/libprojectM/Renderer/Texture.cpp
@@ -15,7 +15,7 @@ Texture::Texture(std::string name, const int width, const int height, const bool
     , m_format(GL_RGB)
     , m_type(GL_UNSIGNED_BYTE)
 {
-    CreateEmptyTexture();
+    CreateNewTexture();
 }
 
 Texture::Texture(std::string name, int width, int height,
@@ -29,7 +29,7 @@ Texture::Texture(std::string name, int width, int height,
     , m_format(format)
     , m_type(type)
 {
-    CreateEmptyTexture();
+    CreateNewTexture();
 }
 
 Texture::Texture(std::string name, const GLuint texID, const GLenum target,
@@ -99,7 +99,12 @@ auto Texture::IsUserTexture() const -> bool
     return m_isUserTexture;
 }
 
-void Texture::CreateEmptyTexture()
+auto Texture::Empty() const -> bool
+{
+    return m_textureId == 0;
+}
+
+void Texture::CreateNewTexture()
 {
     glGenTextures(1, &m_textureId);
     glBindTexture(m_target, m_textureId);

--- a/src/libprojectM/Renderer/Texture.hpp
+++ b/src/libprojectM/Renderer/Texture.hpp
@@ -115,8 +115,17 @@ public:
      */
     auto IsUserTexture() const -> bool;
 
+    /**
+     * @brief Returns true if the texture is empty/unallocated.
+     * @return true if the texture is not yet allocated (e.g. the ID 0), false if the object contains a valid texture.
+     */
+    auto Empty() const -> bool;
+
 private:
-    void CreateEmptyTexture();
+    /**
+     * @brief Creates a new, blank texture with the given size.
+     */
+    void CreateNewTexture();
 
     GLuint m_textureId{0};    //!< The OpenGL texture name/ID.
     GLenum m_target{GL_NONE}; //!< The OpenGL texture target, e.g. GL_TEXTURE_2D.


### PR DESCRIPTION
Bumped libprojectM to v4.1.2 as well. Will create a bugfix release as this issue can break integrations checking for GL errors, e.g. GStreamer.