### PR TITLE
Restore the original viewport

### DIFF
--- a/src/api/include/projectM-4/parameters.h
+++ b/src/api/include/projectM-4/parameters.h
@@ -305,32 +305,6 @@ PROJECTM_EXPORT void projectm_set_window_size(projectm_handle instance, size_t w
  */
 PROJECTM_EXPORT void projectm_get_window_size(projectm_handle instance, size_t* width, size_t* height);
 
-/**
- * @brief Sets the viewport of the target framebuffer and the texture filter used to draw in the target framebuffer.
- *
- * Setting a width and a height of zero uses default logic.
- * Calling this function is cheap, i.e. no resources are recreated.
- *
- * @param instance The projectM instance handle.
- * @param targetX New viewport x in pixels.
- * @param targetY New viewport y in pixels.
- * @param targetWidth New viewport width in pixels.
- * @param targetHeight New viewport height in pixels.
- * @param targetTextureFilter New texture filter, nearest or linear.
- */
-PROJECTM_EXPORT void projectm_set_target_options(projectm_handle instance, uint32_t targetX, uint32_t targetY, uint32_t targetWidth, uint32_t targetHeight, projectm_texture_filter targetTextureFilter);
-
-/**
- * @brief Returns the current target framebuffer viewport in pixels and the current texture filter.
- * @param instance The projectM instance handle.
- * @param targetX Valid pointer to a uint32_t variable that will receive the viewport x value.
- * @param targetY Valid pointer to a uint32_t variable that will receive the viewport y value.
- * @param targetWidth Valid pointer to a uint32_t variable that will receive the viewport width value.
- * @param targetHeight Valid pointer to a uint32_t variable that will receive the viewport height value.
- * @param targetTextureFilter Valid pointer to a projectm_texture_filter variable that will receive the texture filter value.
- */
-PROJECTM_EXPORT void projectm_get_target_options(projectm_handle instance, uint32_t* targetX, uint32_t* targetY, uint32_t* targetWidth, uint32_t* targetHeight, projectm_texture_filter* targetTextureFilter);
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/api/include/projectM-4/parameters.h
+++ b/src/api/include/projectM-4/parameters.h
@@ -305,6 +305,32 @@ PROJECTM_EXPORT void projectm_set_window_size(projectm_handle instance, size_t w
  */
 PROJECTM_EXPORT void projectm_get_window_size(projectm_handle instance, size_t* width, size_t* height);
 
+/**
+ * @brief Sets the viewport of the target framebuffer and the texture filter used to draw in the target framebuffer.
+ *
+ * Setting a width and a height of zero uses default logic.
+ * Calling this function is cheap, i.e. no resources are recreated.
+ *
+ * @param instance The projectM instance handle.
+ * @param targetX New viewport x in pixels.
+ * @param targetY New viewport y in pixels.
+ * @param targetWidth New viewport width in pixels.
+ * @param targetHeight New viewport height in pixels.
+ * @param targetTextureFilter New texture filter, nearest or linear.
+ */
+PROJECTM_EXPORT void projectm_set_target_options(projectm_handle instance, uint32_t targetX, uint32_t targetY, uint32_t targetWidth, uint32_t targetHeight, projectm_texture_filter targetTextureFilter);
+
+/**
+ * @brief Returns the current target framebuffer viewport in pixels and the current texture filter.
+ * @param instance The projectM instance handle.
+ * @param targetX Valid pointer to a uint32_t variable that will receive the viewport x value.
+ * @param targetY Valid pointer to a uint32_t variable that will receive the viewport y value.
+ * @param targetWidth Valid pointer to a uint32_t variable that will receive the viewport width value.
+ * @param targetHeight Valid pointer to a uint32_t variable that will receive the viewport height value.
+ * @param targetTextureFilter Valid pointer to a projectm_texture_filter variable that will receive the texture filter value.
+ */
+PROJECTM_EXPORT void projectm_get_target_options(projectm_handle instance, uint32_t* targetX, uint32_t* targetY, uint32_t* targetWidth, uint32_t* targetHeight, projectm_texture_filter* targetTextureFilter);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/api/include/projectM-4/render_opengl.h
+++ b/src/api/include/projectM-4/render_opengl.h
@@ -46,6 +46,32 @@ PROJECTM_EXPORT void projectm_opengl_render_frame(projectm_handle instance);
  */
 PROJECTM_EXPORT void projectm_opengl_render_frame_fbo(projectm_handle instance, uint32_t framebuffer_object_id);
 
+/**
+ * @brief Sets the viewport of the target framebuffer and the texture filter used to draw in the target framebuffer.
+ *
+ * Setting a width and a height of zero uses default logic.
+ * Calling this function is cheap, i.e. no resources are recreated.
+ *
+ * @param instance The projectM instance handle.
+ * @param targetX New viewport x in pixels.
+ * @param targetY New viewport y in pixels.
+ * @param targetWidth New viewport width in pixels.
+ * @param targetHeight New viewport height in pixels.
+ * @param targetTextureFilter New texture filter, nearest or linear.
+ */
+PROJECTM_EXPORT void projectm_set_target_options(projectm_handle instance, uint32_t targetX, uint32_t targetY, uint32_t targetWidth, uint32_t targetHeight, projectm_texture_filter targetTextureFilter);
+
+/**
+ * @brief Returns the current target framebuffer viewport in pixels and the current texture filter.
+ * @param instance The projectM instance handle.
+ * @param targetX Valid pointer to a uint32_t variable that will receive the viewport x value.
+ * @param targetY Valid pointer to a uint32_t variable that will receive the viewport y value.
+ * @param targetWidth Valid pointer to a uint32_t variable that will receive the viewport width value.
+ * @param targetHeight Valid pointer to a uint32_t variable that will receive the viewport height value.
+ * @param targetTextureFilter Valid pointer to a projectm_texture_filter variable that will receive the texture filter value.
+ */
+PROJECTM_EXPORT void projectm_get_target_options(projectm_handle instance, uint32_t* targetX, uint32_t* targetY, uint32_t* targetWidth, uint32_t* targetHeight, projectm_texture_filter* targetTextureFilter);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/api/include/projectM-4/types.h
+++ b/src/api/include/projectM-4/types.h
@@ -74,6 +74,15 @@ typedef enum
     PROJECTM_TOUCH_TYPE_DOUBLE_LINE      //!< Draws a double-line waveform.
 } projectm_touch_type;
 
+/**
+ * Texture filter when rendering to the target framebuffer.
+ */
+typedef enum
+{
+    PROJECTM_TEXTURE_FILTER_NEAREST = 0, //!< Nearest texture filtering (pixelated outcome).
+    PROJECTM_TEXTURE_FILTER_LINEAR = 1  //!< Linear texture filtering (smoother outcome).
+} projectm_texture_filter;
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/libprojectM/ProjectM.cpp
+++ b/src/libprojectM/ProjectM.cpp
@@ -98,6 +98,10 @@ void ProjectM::RenderFrame(uint32_t targetFramebufferObject /*= 0*/)
         return;
     }
 
+    // Save the viewport.
+    GLint aiViewport[4];
+    glGetIntegerv(GL_VIEWPORT, aiViewport);
+
     // Update FPS and other timer values.
     m_timeKeeper->UpdateTimers();
 
@@ -167,6 +171,13 @@ void ProjectM::RenderFrame(uint32_t targetFramebufferObject /*= 0*/)
     m_activePreset->RenderFrame(audioData, renderContext);
 
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, static_cast<GLuint>(targetFramebufferObject));
+
+    // Restore the viewport.
+    glViewport(aiViewport[0], aiViewport[1], (GLsizei)aiViewport[2], (GLsizei)aiViewport[3]);
+
+    // Update viewport information for PresetTransition.
+    renderContext.viewportSizeX = aiViewport[2];
+    renderContext.viewportSizeY = aiViewport[3];
 
     if (m_transition != nullptr && m_transitioningPreset != nullptr)
     {

--- a/src/libprojectM/ProjectM.hpp
+++ b/src/libprojectM/ProjectM.hpp
@@ -89,6 +89,10 @@ public:
 
     void SetWindowSize(uint32_t width, uint32_t height);
 
+    void GetTargetOptions(uint32_t* targetX, uint32_t* targetY, uint32_t* targetWidth, uint32_t* targetHeight, Renderer::RenderContextTextureFilter* targetTextureFilter);
+
+    void SetTargetOptions(uint32_t targetX, uint32_t targetY, uint32_t targetWidth, uint32_t targetHeight, Renderer::RenderContextTextureFilter targetTextureFilter);
+
     /**
      * @brief Sets the texture paths used to find images for presets.
      *
@@ -214,6 +218,13 @@ private:
     bool m_aspectCorrection{true};   //!< If true, corrects aspect ratio for non-rectangular windows.
     float m_easterEgg{1.0};          //!< Random preset duration modifier. See TimeKeeper class.
     float m_previousFrameVolume{};   //!< Volume in previous frame, used for hard cuts.
+
+    bool m_targetOptionsEnabled{false}; //!< If true, use the target options.
+    uint32_t m_targetX{0};                   //!< Target framebuffer viewport x.
+    uint32_t m_targetY{0};                   //!< Target framebuffer viewport y.
+    uint32_t m_targetWidth{0};               //!< Target framebuffer viewport width.
+    uint32_t m_targetHeight{0};              //!< Target framebuffer viewport height.
+    Renderer::RenderContextTextureFilter m_targetTextureFilter{Renderer::RenderContextTextureFilter::Nearest}; //!< Target texture filtering when drawing to framebuffer.
 
     std::vector<std::string> m_textureSearchPaths; ///!< List of paths to search for texture files
 

--- a/src/libprojectM/ProjectMCWrapper.cpp
+++ b/src/libprojectM/ProjectMCWrapper.cpp
@@ -1,4 +1,5 @@
 #include "ProjectMCWrapper.hpp"
+#include "Renderer/RenderContext.hpp"
 
 #include <projectM-4/projectM.h>
 
@@ -362,6 +363,18 @@ void projectm_set_window_size(projectm_handle instance, size_t width, size_t hei
 {
     auto projectMInstance = handle_to_instance(instance);
     projectMInstance->SetWindowSize(static_cast<uint32_t>(width), static_cast<uint32_t>(height));
+}
+
+void projectm_get_target_options(projectm_handle instance, uint32_t* targetX, uint32_t* targetY, uint32_t* targetWidth, uint32_t* targetHeight, projectm_texture_filter* targetTextureFilter)
+{
+    auto projectMInstance = handle_to_instance(instance);
+    projectMInstance->GetTargetOptions(targetX, targetY, targetWidth, targetHeight, reinterpret_cast<libprojectM::Renderer::RenderContextTextureFilter*>(targetTextureFilter));
+}
+
+void projectm_set_target_options(projectm_handle instance, uint32_t targetX, uint32_t targetY, uint32_t targetWidth, uint32_t targetHeight, projectm_texture_filter targetTextureFilter)
+{
+    auto projectMInstance = handle_to_instance(instance);
+    projectMInstance->SetTargetOptions(targetX, targetY, targetWidth, targetHeight, static_cast<libprojectM::Renderer::RenderContextTextureFilter>(targetTextureFilter));
 }
 
 unsigned int projectm_pcm_get_max_samples()

--- a/src/libprojectM/Renderer/CopyTexture.cpp
+++ b/src/libprojectM/Renderer/CopyTexture.cpp
@@ -197,6 +197,12 @@ auto CopyTexture::Texture() -> std::shared_ptr<class Texture>
     return m_framebuffer.GetColorAttachmentTexture(0, 0);
 }
 
+void CopyTexture::UpdateTextureFilter(RenderContextTextureFilter textureFilter)
+{
+    const GLint filterMode = textureFilter == RenderContextTextureFilter::Linear ? GL_LINEAR : GL_NEAREST;
+    m_sampler.FilterMode(filterMode);
+}
+
 void CopyTexture::UpdateTextureSize(int width, int height)
 {
     if (m_width == width &&

--- a/src/libprojectM/Renderer/CopyTexture.hpp
+++ b/src/libprojectM/Renderer/CopyTexture.hpp
@@ -3,6 +3,7 @@
 #include "Renderer/Framebuffer.hpp"
 #include "Renderer/RenderItem.hpp"
 #include "Renderer/Shader.hpp"
+#include "Renderer/RenderContext.hpp"
 
 namespace libprojectM {
 namespace Renderer {
@@ -19,6 +20,11 @@ public:
     CopyTexture();
 
     void InitVertexAttrib() override;
+
+    /**
+     * Set e.g. nearest or linear texture filtering.
+     */
+    void UpdateTextureFilter(RenderContextTextureFilter textureFilter);
 
     /**
      * @brief Copies the original texture into the currently bound framebuffer.

--- a/src/libprojectM/Renderer/PresetTransition.cpp
+++ b/src/libprojectM/Renderer/PresetTransition.cpp
@@ -71,8 +71,8 @@ void PresetTransition::Draw(const Preset& oldPreset,
     m_transitionShader->Bind();
 
     // Numerical parameters
-    m_transitionShader->SetUniformFloat3("iResolution", {static_cast<float>(context.viewportSizeX),
-                                                         static_cast<float>(context.viewportSizeY),
+    m_transitionShader->SetUniformFloat3("iResolution", {static_cast<float>(context.targetWidth),
+                                                         static_cast<float>(context.targetHeight),
                                                          0.0f});
 
     m_transitionShader->SetUniformFloat4("durationParams", {linearProgress,

--- a/src/libprojectM/Renderer/RenderContext.hpp
+++ b/src/libprojectM/Renderer/RenderContext.hpp
@@ -9,6 +9,12 @@ namespace Renderer {
 
 class TextureManager;
 
+enum class RenderContextTextureFilter
+{
+    Nearest = 0,
+    Linear = 1,
+};
+
 /**
  * @brief Holds all global data of the current rendering context, which can change from frame to frame.
  */
@@ -28,6 +34,12 @@ public:
 
     int perPixelMeshX{64}; //!< Per-pixel/per-vertex mesh X resolution.
     int perPixelMeshY{48}; //!< Per-pixel/per-vertex mesh Y resolution.
+
+    int targetX{0};        //!< Target framebuffer viewport x.
+    int targetY{0};        //!< Target framebuffer viewport y.
+    int targetWidth{0};    //!< Target framebuffer viewport width.
+    int targetHeight{0};   //!< Target framebuffer viewport height.
+    RenderContextTextureFilter targetTextureFilter{RenderContextTextureFilter::Nearest}; //!< Target texture filtering when drawing to framebuffer.
 
     TextureManager* textureManager{nullptr}; //!< Holds all loaded textures for shader access.
 };


### PR DESCRIPTION
Restore the original viewport (e.g. of the default frame buffer) so up or down scaling will work. Based on the snippet:
https://stackoverflow.com/a/63279269/628696

This change is a quick fix. Maybe it is better to introduce two extra fields in RenderContext saving the original viewport size.