### PR TITLE
Fix texture loading if casing mismatches filename

### DIFF
--- a/src/libprojectM/CMakeLists.txt
+++ b/src/libprojectM/CMakeLists.txt
@@ -23,6 +23,8 @@ add_library(projectM_main OBJECT
         ProjectMCWrapper.hpp
         TimeKeeper.cpp
         TimeKeeper.hpp
+        Utils.cpp
+        Utils.hpp
         projectM-opengl.h
         )
 

--- a/src/libprojectM/MilkdropPreset/MilkdropShader.cpp
+++ b/src/libprojectM/MilkdropPreset/MilkdropShader.cpp
@@ -2,6 +2,7 @@
 
 #include "PerFrameContext.hpp"
 #include "PresetState.hpp"
+#include "Utils.hpp"
 
 #include <MilkdropStaticShaders.hpp>
 
@@ -69,8 +70,7 @@ void MilkdropShader::LoadTexturesAndCompile(PresetState& presetState)
             baseName = name.substr(3);
         }
 
-        std::string lowerCaseName(baseName);
-        std::transform(lowerCaseName.begin(), lowerCaseName.end(), lowerCaseName.begin(), tolower);
+        std::string lowerCaseName = Utils::ToLower(baseName);
 
         // The "main" and "blurX" textures are preset-specific and are not managed by TextureManager.
         if (lowerCaseName == "main")

--- a/src/libprojectM/PresetFactoryManager.cpp
+++ b/src/libprojectM/PresetFactoryManager.cpp
@@ -2,6 +2,8 @@
 
 #include <MilkdropPreset/Factory.hpp>
 
+#include <Utils.hpp>
+
 #include <algorithm>
 #include <cassert>
 #include <iostream>
@@ -135,9 +137,8 @@ auto PresetFactoryManager::ParseExtension(const std::string& filename) -> std::s
     if (start == std::string::npos || start >= (filename.length() - 1)) {
         return "";
     }
-    std::string ext = filename.substr(start + 1, filename.length());
-    std::transform(ext.begin(), ext.end(), ext.begin(), tolower);
-    return ext;
+
+    return Utils::ToLower(filename.substr(start + 1, filename.length()));
 }
 
 } // namespace libprojectM

--- a/src/libprojectM/Renderer/FileScanner.cpp
+++ b/src/libprojectM/Renderer/FileScanner.cpp
@@ -1,5 +1,7 @@
 #include "FileScanner.hpp"
 
+#include "Utils.hpp"
+
 #include <algorithm>
 #include <cctype>
 
@@ -17,7 +19,7 @@ FileScanner::FileScanner(const std::vector<std::string>& rootDirs, std::vector<s
     // Convert all extensions to lower-case.
     for (auto& extension : _extensions)
     {
-        std::transform(extension.begin(), extension.end(), extension.begin(), [](unsigned char c) { return std::tolower(c); });
+        Utils::ToLowerInPlace(extension);
     }
 }
 
@@ -59,8 +61,7 @@ void FileScanner::Scan(ScanCallback callback)
                 }
 
                 // Match the lower-case extension of the file with the provided list of valid extensions.
-                auto extension = entry.path().extension().string();
-                std::transform(extension.begin(), extension.end(), extension.begin(), [](unsigned char c) { return std::tolower(c); });
+                auto extension = Utils::ToLower(entry.path().extension().string());
                 if (std::find(_extensions.begin(), _extensions.end(), extension) != _extensions.end())
                 {
                     callback(entry.path().string(), entry.path().stem().string());

--- a/src/libprojectM/Renderer/TextureManager.hpp
+++ b/src/libprojectM/Renderer/TextureManager.hpp
@@ -82,7 +82,7 @@ private:
 
     void Preload();
 
-    TextureSamplerDescriptor LoadTexture(const std::string& fileName, const std::string& name);
+    auto LoadTexture(const ScannedFile& file) -> std::shared_ptr<Texture>;
 
     void AddTextureFile(const std::string& fileName, const std::string& baseName);
 

--- a/src/libprojectM/Utils.cpp
+++ b/src/libprojectM/Utils.cpp
@@ -1,0 +1,33 @@
+#include "Utils.hpp"
+
+#include <algorithm>
+
+namespace libprojectM {
+namespace Utils {
+
+auto ToLower(const std::string& str) -> std::string
+{
+    std::string lowerStr(str);
+    ToLowerInPlace(lowerStr);
+    return lowerStr;
+}
+
+auto ToUpper(const std::string& str) -> std::string
+{
+    std::string upperStr(str);
+    ToUpperInPlace(upperStr);
+    return upperStr;
+}
+
+void ToLowerInPlace(std::string& str)
+{
+    std::transform(str.begin(), str.end(), str.begin(), ::tolower);
+}
+
+void ToUpperInPlace(std::string& str)
+{
+    std::transform(str.begin(), str.end(), str.begin(), ::toupper);
+}
+
+} // namespace Utils
+} // namespace libprojectM

--- a/src/libprojectM/Utils.hpp
+++ b/src/libprojectM/Utils.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+namespace libprojectM {
+namespace Utils {
+
+auto ToLower(const std::string& str) -> std::string;
+auto ToUpper(const std::string& str) -> std::string;
+
+void ToLowerInPlace(std::string& str);
+void ToUpperInPlace(std::string& str);
+
+} // namespace Utils
+} // namespace libprojectM


### PR DESCRIPTION
Always use lower-case unqualified names to find and cache the actual textures.