### PR TITLE
Updated copyright dates and AUTHORS.txt

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -20,8 +20,7 @@ For the purposes of the copyright statement in the preamble of each source
 code file comprising projectM, the projectM team are:
 
 Carmelo Piccione
-    Parser
-    Evaluator
+    Original Expression Parser/Evaluator
     Pulse Audio support (projectM-pulseaudio)
     Qt GUI (projectM-qt)
 
@@ -41,14 +40,14 @@ Roger Dannenburg
     Advice & Support
 
 Matthias Klumpp
-    CMake build system
+    Original CMake build system
     Distro integration
     Bug fixes
 
 Mischa Spiegelmock
     OSX native iTunes visualization plugin
     Preliminary web support (projectM-emscripten)
-    cmake improvements for OSX and Linux
+    CMake improvements for OSX and Linux
     SDL
     OpenGLES
 
@@ -58,3 +57,23 @@ Robert Pancoast
     Provide XBOX Support
     Input Windows Audio Loopback with WASAPI
 
+Kai Blaschke
+    Updated CMake build system
+    New Bison-/Flex-based Expression Evaluator (projectm-eval)
+    C API
+    Modernized Milkdrop 2 Renderer
+
+Blaque Allen
+    Rust Crates
+    Emscripten Improvements
+    Code Reviews
+
+Dane Wagner
+    Improved Audio Processing
+    HLSL Shader Translation Fixes
+    Sphinx Documentation
+
+...and many others!
+
+For a full list, please see the contributors page on GitHub:
+https://github.com/projectM-visualizer/projectm/graphs/contributors

--- a/COPYING
+++ b/COPYING
@@ -1,6 +1,6 @@
 /**
 * projectM -- Milkdrop-esque visualisation SDK
-* Copyright (C)2003-2009 projectM Team
+* Copyright (C)2003-2024 projectM Team
 *
 * This library is free software; you can redistribute it and/or
 * modify it under the terms of the GNU Lesser General Public

--- a/src/api/include/projectM-4/audio.h
+++ b/src/api/include/projectM-4/audio.h
@@ -1,10 +1,10 @@
 /**
  * @file audio.h
- * @copyright 2003-2023 projectM Team
+ * @copyright 2003-2024 projectM Team
  * @brief Functions to pass in audio data to libprojectM.
  *
  * projectM -- Milkdrop-esque visualisation SDK
- * Copyright (C)2003-2023 projectM Team
+ * Copyright (C)2003-2024 projectM Team
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/api/include/projectM-4/callbacks.h
+++ b/src/api/include/projectM-4/callbacks.h
@@ -1,10 +1,10 @@
 /**
  * @file callbacks.h
- * @copyright 2003-2023 projectM Team
+ * @copyright 2003-2024 projectM Team
  * @brief Functions and prototypes for projectM callbacks.
  *
  * projectM -- Milkdrop-esque visualisation SDK
- * Copyright (C)2003-2023 projectM Team
+ * Copyright (C)2003-2024 projectM Team
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/api/include/projectM-4/core.h
+++ b/src/api/include/projectM-4/core.h
@@ -1,10 +1,10 @@
 /**
  * @file core.h
- * @copyright 2003-2023 projectM Team
+ * @copyright 2003-2024 projectM Team
  * @brief Core functions to instantiate, destroy and control projectM.
  *
  * projectM -- Milkdrop-esque visualisation SDK
- * Copyright (C)2003-2023 projectM Team
+ * Copyright (C)2003-2024 projectM Team
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/api/include/projectM-4/debug.h
+++ b/src/api/include/projectM-4/debug.h
@@ -1,10 +1,10 @@
 /**
  * @file debug.h
- * @copyright 2003-2023 projectM Team
+ * @copyright 2003-2024 projectM Team
  * @brief Debug functions for both libprojectM and preset developers.
  *
  * projectM -- Milkdrop-esque visualisation SDK
- * Copyright (C)2003-2023 projectM Team
+ * Copyright (C)2003-2024 projectM Team
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/api/include/projectM-4/memory.h
+++ b/src/api/include/projectM-4/memory.h
@@ -1,10 +1,10 @@
 /**
  * @file memory.h
- * @copyright 2003-2023 projectM Team
+ * @copyright 2003-2024 projectM Team
  * @brief Memory allocation/deallocation helpers.
  *
  * projectM -- Milkdrop-esque visualisation SDK
- * Copyright (C)2003-2023 projectM Team
+ * Copyright (C)2003-2024 projectM Team
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/api/include/projectM-4/parameters.h
+++ b/src/api/include/projectM-4/parameters.h
@@ -1,10 +1,10 @@
 /**
  * @file parameters.h
- * @copyright 2003-2023 projectM Team
+ * @copyright 2003-2024 projectM Team
  * @brief Functions to set and retrieve all sorts of projectM parameters and setting.
  *
  * projectM -- Milkdrop-esque visualisation SDK
- * Copyright (C)2003-2023 projectM Team
+ * Copyright (C)2003-2024 projectM Team
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/api/include/projectM-4/projectM.h
+++ b/src/api/include/projectM-4/projectM.h
@@ -1,6 +1,6 @@
 /**
  * @file projectM.h
- * @copyright 2003-2023 projectM Team
+ * @copyright 2003-2024 projectM Team
  * @brief Convenience include file that includes all other API headers.
  *
  * projectM -- Milkdrop-esque visualisation SDK

--- a/src/api/include/projectM-4/render_opengl.h
+++ b/src/api/include/projectM-4/render_opengl.h
@@ -1,10 +1,10 @@
 /**
  * @file render_opengl.h
- * @copyright 2003-2023 projectM Team
+ * @copyright 2003-2024 projectM Team
  * @brief Functions to configure and render projectM visuals using OpenGL.
  *
  * projectM -- Milkdrop-esque visualisation SDK
- * Copyright (C)2003-2023 projectM Team
+ * Copyright (C)2003-2024 projectM Team
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/api/include/projectM-4/touch.h
+++ b/src/api/include/projectM-4/touch.h
@@ -1,10 +1,10 @@
 /**
  * @file touch.h
- * @copyright 2003-2023 projectM Team
+ * @copyright 2003-2024 projectM Team
  * @brief Touch-related functions to add random waveforms.
  *
  * projectM -- Milkdrop-esque visualisation SDK
- * Copyright (C)2003-2023 projectM Team
+ * Copyright (C)2003-2024 projectM Team
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/api/include/projectM-4/types.h
+++ b/src/api/include/projectM-4/types.h
@@ -1,10 +1,10 @@
 /**
  * @file types.h
- * @copyright 2003-2023 projectM Team
+ * @copyright 2003-2024 projectM Team
  * @brief Types and enumerations used in the other API headers.
  *
  * projectM -- Milkdrop-esque visualisation SDK
- * Copyright (C)2003-2023 projectM Team
+ * Copyright (C)2003-2024 projectM Team
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/playlist/api/projectM-4/playlist.h
+++ b/src/playlist/api/projectM-4/playlist.h
@@ -1,10 +1,10 @@
 /**
  * @file playlist.h
- * @copyright 2003-2023 projectM Team
+ * @copyright 2003-2024 projectM Team
  * @brief Optional playlist API for libprojectM.
  *
  * projectM -- Milkdrop-esque visualisation SDK
- * Copyright (C)2003-2023 projectM Team
+ * Copyright (C)2003-2024 projectM Team
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/playlist/api/projectM-4/playlist_callbacks.h
+++ b/src/playlist/api/projectM-4/playlist_callbacks.h
@@ -1,10 +1,10 @@
 /**
  * @file playlist_callbacks.h
- * @copyright 2003-2023 projectM Team
+ * @copyright 2003-2024 projectM Team
  * @brief Functions and prototypes for projectM playlist callbacks.
  *
  * projectM -- Milkdrop-esque visualisation SDK
- * Copyright (C)2003-2023 projectM Team
+ * Copyright (C)2003-2024 projectM Team
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/playlist/api/projectM-4/playlist_core.h
+++ b/src/playlist/api/projectM-4/playlist_core.h
@@ -1,10 +1,10 @@
 /**
  * @file playlist_core.h
- * @copyright 2003-2023 projectM Team
+ * @copyright 2003-2024 projectM Team
  * @brief Core functions to instantiate, destroy and connect a projectM playlist.
  *
  * projectM -- Milkdrop-esque visualisation SDK
- * Copyright (C)2003-2023 projectM Team
+ * Copyright (C)2003-2024 projectM Team
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/playlist/api/projectM-4/playlist_filter.h
+++ b/src/playlist/api/projectM-4/playlist_filter.h
@@ -1,10 +1,10 @@
 /**
  * @file playlist_filter.h
- * @copyright 2003-2023 projectM Team
+ * @copyright 2003-2024 projectM Team
  * @brief Playlist filter functions.
  *
  * projectM -- Milkdrop-esque visualisation SDK
- * Copyright (C)2003-2023 projectM Team
+ * Copyright (C)2003-2024 projectM Team
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/playlist/api/projectM-4/playlist_items.h
+++ b/src/playlist/api/projectM-4/playlist_items.h
@@ -1,10 +1,10 @@
 /**
  * @file playlist_items.h
- * @copyright 2003-2023 projectM Team
+ * @copyright 2003-2024 projectM Team
  * @brief Playlist item management functions.
  *
  * projectM -- Milkdrop-esque visualisation SDK
- * Copyright (C)2003-2023 projectM Team
+ * Copyright (C)2003-2024 projectM Team
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/playlist/api/projectM-4/playlist_memory.h
+++ b/src/playlist/api/projectM-4/playlist_memory.h
@@ -1,10 +1,10 @@
 /**
  * @file playlist_memory.h
- * @copyright 2003-2023 projectM Team
+ * @copyright 2003-2024 projectM Team
  * @brief Memory allocation/deallocation helpers.
  *
  * projectM -- Milkdrop-esque visualisation SDK
- * Copyright (C)2003-2023 projectM Team
+ * Copyright (C)2003-2024 projectM Team
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/playlist/api/projectM-4/playlist_playback.h
+++ b/src/playlist/api/projectM-4/playlist_playback.h
@@ -1,10 +1,10 @@
 /**
  * @file playlist_playback.h
- * @copyright 2003-2023 projectM Team
+ * @copyright 2003-2024 projectM Team
  * @brief Playback control functions.
  *
  * projectM -- Milkdrop-esque visualisation SDK
- * Copyright (C)2003-2023 projectM Team
+ * Copyright (C)2003-2024 projectM Team
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/playlist/api/projectM-4/playlist_types.h
+++ b/src/playlist/api/projectM-4/playlist_types.h
@@ -1,10 +1,10 @@
 /**
  * @file playlist_types.h
- * @copyright 2003-2023 projectM Team
+ * @copyright 2003-2024 projectM Team
  * @brief Types and enumerations used in the playlist API headers.
  *
  * projectM -- Milkdrop-esque visualisation SDK
- * Copyright (C)2003-2023 projectM Team
+ * Copyright (C)2003-2024 projectM Team
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
No code changes, just changed all copyright dates to 2024 and added new top contributors since v4.0 to AUTHORS.txt ("in order of appearance")