### PR TITLE
Fix wrong API exports definition in playlist build.

### DIFF
--- a/src/playlist/CMakeLists.txt
+++ b/src/playlist/CMakeLists.txt
@@ -63,7 +63,7 @@ target_link_libraries(projectM_playlist
 if(BUILD_SHARED_LIBS)
     target_compile_definitions(projectM_playlist
             PRIVATE
-            projectM_api_EXPORTS
+            projectM_playlist_EXPORTS
             )
 
     target_link_libraries(projectM_playlist


### PR DESCRIPTION
Mostly irrelevant on UNIX (except if visibility is set to hidden by default), but may cause issues on Windows as the dllexport declspec was missing.