### PR TITLE
hlslparser: Add missing "ldexp" and "faceforward" HLSL intrinsics.

### DIFF
--- a/vendor/hlslparser/src/GLSLGenerator.cpp
+++ b/vendor/hlslparser/src/GLSLGenerator.cpp
@@ -1019,6 +1019,23 @@ void GLSLGenerator::OutputExpression(HLSLExpression* expression, const HLSLType*
             m_writer.Write(")");
             handled = true;
         }
+        else if (String_Equal(functionName, "ldexp"))
+        {
+            /* HLSL has the second argument as float, while GLSL only supports ints, so we simulate the HLSL behaviour
+             * by using the equivalent "x * exp2(exp)" expression. */
+            HLSLExpression* argument[2];
+            if (GetFunctionArguments(functionCall, argument, 2) != 2)
+            {
+                Error("%s expects 2 arguments", functionName);
+                return;
+            }
+            m_writer.Write("(");
+            OutputExpression(argument[0], &functionCall->function->returnType);
+            m_writer.Write("*exp2(");
+            OutputExpression(argument[1], &functionCall->function->returnType);
+            m_writer.Write("))");
+            handled = true;
+        }
 
         if (!handled)
         {

--- a/vendor/hlslparser/src/HLSLParser.cpp
+++ b/vendor/hlslparser/src/HLSLParser.cpp
@@ -641,6 +641,11 @@ const Intrinsic _intrinsic[] =
         Intrinsic("refract",  HLSLBaseType_Float3, HLSLBaseType_Float3, HLSLBaseType_Float3, HLSLBaseType_Float),
         Intrinsic("refract",  HLSLBaseType_Float4, HLSLBaseType_Float4, HLSLBaseType_Float4, HLSLBaseType_Float),
 
+        Intrinsic("faceforward",  HLSLBaseType_Float, HLSLBaseType_Float, HLSLBaseType_Float, HLSLBaseType_Float),
+        Intrinsic("faceforward",  HLSLBaseType_Float2, HLSLBaseType_Float2, HLSLBaseType_Float2, HLSLBaseType_Float2),
+        Intrinsic("faceforward",  HLSLBaseType_Float3, HLSLBaseType_Float3, HLSLBaseType_Float3, HLSLBaseType_Float3),
+        Intrinsic("faceforward",  HLSLBaseType_Float4, HLSLBaseType_Float4, HLSLBaseType_Float4, HLSLBaseType_Float4),
+
 		Intrinsic("isnan",    HLSLBaseType_Bool, HLSLBaseType_Float),
 		Intrinsic("isinf",    HLSLBaseType_Bool, HLSLBaseType_Float),
 

--- a/vendor/hlslparser/src/HLSLParser.cpp
+++ b/vendor/hlslparser/src/HLSLParser.cpp
@@ -620,6 +620,23 @@ const Intrinsic _intrinsic[] =
         INTRINSIC_FLOAT2_FUNCTION( "step" ),
         INTRINSIC_FLOAT2_FUNCTION( "reflect" ),
 
+        Intrinsic("ldexp",  HLSLBaseType_Float, HLSLBaseType_Float, HLSLBaseType_Float),
+        Intrinsic("ldexp",  HLSLBaseType_Float2, HLSLBaseType_Float2, HLSLBaseType_Float2),
+        Intrinsic("ldexp",  HLSLBaseType_Float3, HLSLBaseType_Float3, HLSLBaseType_Float3),
+        Intrinsic("ldexp",  HLSLBaseType_Float4, HLSLBaseType_Float4, HLSLBaseType_Float4),
+
+        Intrinsic("ldexp",  HLSLBaseType_Float2x2, HLSLBaseType_Float2x2, HLSLBaseType_Float2x2),
+        Intrinsic("ldexp",  HLSLBaseType_Float2x3, HLSLBaseType_Float2x3, HLSLBaseType_Float2x3),
+        Intrinsic("ldexp",  HLSLBaseType_Float2x4, HLSLBaseType_Float2x4, HLSLBaseType_Float2x4),
+
+        Intrinsic("ldexp",  HLSLBaseType_Float3x2, HLSLBaseType_Float3x2, HLSLBaseType_Float3x2),
+        Intrinsic("ldexp",  HLSLBaseType_Float3x3, HLSLBaseType_Float3x3, HLSLBaseType_Float3x3),
+        Intrinsic("ldexp",  HLSLBaseType_Float3x4, HLSLBaseType_Float3x4, HLSLBaseType_Float3x4),
+
+        Intrinsic("ldexp",  HLSLBaseType_Float4x2, HLSLBaseType_Float4x2, HLSLBaseType_Float4x2),
+        Intrinsic("ldexp",  HLSLBaseType_Float4x3, HLSLBaseType_Float4x3, HLSLBaseType_Float4x3),
+        Intrinsic("ldexp",  HLSLBaseType_Float4x4, HLSLBaseType_Float4x4, HLSLBaseType_Float4x4),
+
         Intrinsic("refract",  HLSLBaseType_Float2, HLSLBaseType_Float2, HLSLBaseType_Float2, HLSLBaseType_Float),
         Intrinsic("refract",  HLSLBaseType_Float3, HLSLBaseType_Float3, HLSLBaseType_Float3, HLSLBaseType_Float),
         Intrinsic("refract",  HLSLBaseType_Float4, HLSLBaseType_Float4, HLSLBaseType_Float4, HLSLBaseType_Float),


### PR DESCRIPTION
Had to simulate it with the "x * exp2(exp)" expression in GLSL, as GLSL only supports integer types as exponents in its native ldexp implementation, while HLSL solely uses floats.