### PR TITLE
Let the static playlist library depend on the static symbols of the projectM library

### DIFF
--- a/src/playlist/CMakeLists.txt
+++ b/src/playlist/CMakeLists.txt
@@ -71,6 +71,10 @@ if(BUILD_SHARED_LIBS)
             ${CMAKE_DL_LIBS}
             )
 else()
+    target_compile_definitions(projectM_playlist_main
+            PUBLIC
+            PROJECTM_STATIC_DEFINE
+            )
     target_compile_definitions(projectM_playlist
             PUBLIC
             PROJECTM_STATIC_DEFINE


### PR DESCRIPTION
Situation: If you're compiling a program with CMake (on windows, using msys2) using BUILD_SHARED_LIBS=OFF, and your program/target depends on "libprojectM::playlist", then CMake will automatically add the static targets for "libprojectM::projectM". Without the changes in this PR, the linker may then complain about missing symbols like `__imp__projectm_set_preset_switch_requested_event_callback`, as the export defines were not set to remove the declspec.

This PR fixes compilation with static linking of the client to the projectM playlist library. 
