### PR TITLE
Issue #872: Fix float overflow in plasma transition shader

### DIFF
--- a/src/libprojectM/Renderer/TransitionShaders/TransitionShaderBuiltInPlasmaGlsl330.frag
+++ b/src/libprojectM/Renderer/TransitionShaders/TransitionShaderBuiltInPlasmaGlsl330.frag
@@ -3,7 +3,7 @@
 
 float sinNoise(vec2 uv)
 {
-    return fract(abs(sin(uv.x * 180.0 + uv.y * 3077.0) * (float(iRandStatic.x) * .001)));
+    return fract(abs(sin(uv.x * 0.018 + uv.y * 0.3077) * (float(iRandStatic.x) * .001)));
 }
 
 float valueNoise(vec2 uv, float scale)


### PR DESCRIPTION
On higher resolutiuons and when using GLES, the plasma transition shader could result in generating using huge numbers as input for `sin()`, returning NaN as a result and breaking the shader output. Fixed by dividing each coordinate multiplier by 10.000.