### PR TITLE
Fix Emscripten build check workflow

### DIFF
--- a/.github/workflows/build_emscripten.yml
+++ b/.github/workflows/build_emscripten.yml
@@ -22,7 +22,7 @@ jobs:
           submodules: 'recursive'
       
       - name: Setup emsdk
-        uses: mymindstorm/setup-emsdk@v13
+        uses: mymindstorm/setup-emsdk@v14
         with:
           # Make sure to set a version number!
           version: 3.1.53


### PR DESCRIPTION
Updated the emsdk cache action to v14, as NodeJS changes broke the build.