### PR TITLE
Redirect link to the latest MegaPack presets. Typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,7 @@ separate repositories in the projectM repository list:
 Included with projectM are the bltc201, Milkdrop 1 and 2, projectM, tryptonaut and yin collections. You can grab these
 presets [here](http://spiegelmc.com/pub/projectm_presets.zip).
 
-You can also download an enormous 41,000 preset pack of
-presets [here](https://mischa.lol/projectM/presets_community.zip) (123MB zipped).
+You can also download an enormous 130k+ presets from the MegaPack [here](https://drive.google.com/file/d/1DlszoqMG-pc5v1Bo9x4NhemGPiwT-0pv/view) (4.08GB zipped, incl. textures).
 
 ### Also Featured In
 


### PR DESCRIPTION
The community presets link is very old. Here's why:
- It contains .mil or other extension files, which is not a preset extension.
- Some of the presets are required some textures, which these aren't included and it's missing.

With my latest MegaPack, all of the presets are messy-free (no extension clutter), hardly patch fixed and included textures for use in presets.