### PR TITLE
feat: Add link to open-source Android TV implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Store. Any bug reports in the projectM issue tracker regarding the apps will be 
 
 - [ProjectM TV w/ Cream of the Crop](https://github.com/johnneerdael/projectm-android-tv)
 
-**Note**: Fully free and open source implenmentation based on the original source code including Cream of the Pack is not made by projectM but is made available for your pleasure, later versions publisher to the play store might ask a small fee (that's definitely going to be cheaper then the current offerings)
+**Note**: ProjectM TV with Cream of the Crop is a fully free and open-source implementation based on the original ProjectM source code, including the massive "Cream of the Crop" preset collection. This app has been carefully developed to provide a seamless visualization experience on Android TV. It also introduces an intelligent, device-tier performance system that automatically adjusts quality settings based on your hardware, from high-end NVIDIA Shields to more budget-friendly Android TV boxes. This ensures smooth and beautiful visualizations on all compatible devices without sacrificing visual fidelity, making it the ideal solution for both casual users and enthusiasts. (This project is currently the only open-source and free Android TV implementation using the original projectM compiled binaries, but is not created or maintained by the projectM team).
 
 #### Xbox / Windows Phone
 


### PR DESCRIPTION
This pull request adds a link to a new, fully open-source and free Android TV implementation of projectM. 

**Motivation:**

Currently, the Android TV apps listed in the README are not created, supported, or maintained by the projectM developers. The primary motivation for this contribution is to provide an officially recognized, free, and open-source alternative for the Android TV platform. This implementation is built on the original projectM compiled binaries and aims to give back to the open-source community by offering a no-cost option where alternatives currently have a fee.

This new project offers:

-   A completely free and open-source solution.
-   An implementation that uses the original projectM binaries.

This project is not created or maintained by the projectM team but is my way of giving back to the community by providing a free and well-maintained option for Android TV users.

Thank you for considering this addition.