### PR TITLE
Convert HLSL array subscript operator operand to int

### DIFF
--- a/vendor/hlslparser/src/GLSLGenerator.cpp
+++ b/vendor/hlslparser/src/GLSLGenerator.cpp
@@ -887,9 +887,11 @@ void GLSLGenerator::OutputExpression(HLSLExpression* expression, const HLSLType*
         }
         else
         {
+            // Array subscript operator in GLSL requires an explicit int parameter
+            const HLSLType& intType = HLSLType(HLSLBaseType_Int);
             OutputExpression(arrayAccess->array);
             m_writer.Write("[");
-            OutputExpression(arrayAccess->index);
+            OutputExpression(arrayAccess->index, &intType);
             m_writer.Write("]");
         }
 


### PR DESCRIPTION
GLSL requires an explicit `int` argument for the array subscript operator, so we just cast anythin passed here to `int`.

Fixes a few presets such as [martin - nivush - emergency power supply only.milk](https://forums.winamp.com/forum/visualizations/milkdrop/milkdrop-presets/270301-my-complete-collection/page35#post4651530).