### PR TITLE
Fix inverted Y and angle coordinates passed to per-pixel expressions

### DIFF
--- a/src/libprojectM/MilkdropPreset/PerPixelMesh.cpp
+++ b/src/libprojectM/MilkdropPreset/PerPixelMesh.cpp
@@ -230,7 +230,7 @@ void PerPixelMesh::CalculateMesh(const PresetState& presetState, const PerFrameC
             if (perPixelContext.perPixelCodeHandle)
             {
                 *perPixelContext.x = static_cast<double>(curVertex.X() * 0.5f * presetState.renderContext.aspectX + 0.5f);
-                *perPixelContext.y = static_cast<double>(curVertex.Y() * -0.5f * presetState.renderContext.aspectY + 0.5f);
+                *perPixelContext.y = static_cast<double>(curVertex.Y() * 0.5f * presetState.renderContext.aspectY + 0.5f);
                 *perPixelContext.rad = static_cast<double>(curRadiusAngle.radius);
                 *perPixelContext.ang = static_cast<double>(curRadiusAngle.angle);
                 *perPixelContext.zoom = static_cast<double>(*perFrameContext.zoom);

--- a/src/libprojectM/MilkdropPreset/PerPixelMesh.cpp
+++ b/src/libprojectM/MilkdropPreset/PerPixelMesh.cpp
@@ -232,7 +232,7 @@ void PerPixelMesh::CalculateMesh(const PresetState& presetState, const PerFrameC
                 *perPixelContext.x = static_cast<double>(curVertex.X() * 0.5f * presetState.renderContext.aspectX + 0.5f);
                 *perPixelContext.y = static_cast<double>(curVertex.Y() * 0.5f * presetState.renderContext.aspectY + 0.5f);
                 *perPixelContext.rad = static_cast<double>(curRadiusAngle.radius);
-                *perPixelContext.ang = static_cast<double>(curRadiusAngle.angle);
+                *perPixelContext.ang = static_cast<double>(-curRadiusAngle.angle);
                 *perPixelContext.zoom = static_cast<double>(*perFrameContext.zoom);
                 *perPixelContext.zoomexp = static_cast<double>(*perFrameContext.zoomexp);
                 *perPixelContext.rot = static_cast<double>(*perFrameContext.rot);


### PR DESCRIPTION
Fixes #959 

Not really review-worthy, as it's a single-character change. PR is just for visibility.