### PR TITLE
Fix PCM buffer thread safety with proper mutex

### DIFF
--- a/src/libprojectM/Audio/PCM.cpp
+++ b/src/libprojectM/Audio/PCM.cpp
@@ -1,5 +1,7 @@
 #include "Audio/PCM.hpp"
 
+#include <mutex>
+
 namespace libprojectM {
 namespace Audio {
 
@@ -17,6 +19,7 @@ void PCM::AddToBuffer(
         return;
     }
 
+    std::lock_guard<std::mutex> lock(m_pcmMutex);
     for (size_t i = 0; i < sampleCount; i++)
     {
         size_t const bufferOffset = (m_start + i) % AudioBufferSamples;
@@ -48,9 +51,12 @@ void PCM::Add(int16_t const* const samples, uint32_t channels, size_t const coun
 
 void PCM::UpdateFrameAudioData(double secondsSinceLastFrame, uint32_t frame)
 {
-    // 1. Copy audio data from input buffer
-    CopyNewWaveformData(m_inputBufferL, m_waveformL);
-    CopyNewWaveformData(m_inputBufferR, m_waveformR);
+    // 1. Copy audio data from input buffer (lock to prevent tearing with audio thread writes)
+    {
+        std::lock_guard<std::mutex> lock(m_pcmMutex);
+        CopyNewWaveformData(m_inputBufferL, m_waveformL);
+        CopyNewWaveformData(m_inputBufferR, m_waveformR);
+    }
 
     // 2. Update spectrum analyzer data for both channels
     UpdateSpectrum(m_waveformL, m_spectrumL);
@@ -110,7 +116,7 @@ void PCM::UpdateSpectrum(const WaveformBuffer& waveformData, SpectrumBuffer& spe
 
 void PCM::CopyNewWaveformData(const WaveformBuffer& source, WaveformBuffer& destination)
 {
-    auto const bufferStartIndex = m_start.load();
+    auto const bufferStartIndex = m_start;
 
     for (size_t i = 0; i < AudioBufferSamples; i++)
     {

--- a/src/libprojectM/Audio/PCM.hpp
+++ b/src/libprojectM/Audio/PCM.hpp
@@ -15,9 +15,9 @@
 
 #include <projectM-4/projectM_cxx_export.h>
 
-#include <atomic>
 #include <cstdint>
 #include <cstdlib>
+#include <mutex>
 
 
 namespace libprojectM {
@@ -89,10 +89,12 @@ private:
      */
     void CopyNewWaveformData(const WaveformBuffer& source, WaveformBuffer& destination);
 
+    std::mutex m_pcmMutex; //!< Protects the circular input buffer from concurrent access.
+
     // External input buffer
     WaveformBuffer m_inputBufferL{0.f}; //!< Circular buffer for left-channel PCM data.
     WaveformBuffer m_inputBufferR{0.f}; //!< Circular buffer for right-channel PCM data.
-    std::atomic<size_t> m_start{0};     //!< Circular buffer start index.
+    size_t m_start{0};                  //!< Circular buffer start index.
 
     // Frame waveform data
     WaveformBuffer m_waveformL{0.f}; //!< Left-channel waveform data, aligned. Only the first WaveformSamples number of samples are valid.


### PR DESCRIPTION
## Summary

The PCM circular input buffer is written by the audio thread (via `projectm_pcm_add_*`) and read by the render thread (via `RenderFrame` → `UpdateFrameAudioData` → `CopyNewWaveformData`). The previous design used `std::atomic<size_t> m_start` alone to coordinate, but this is insufficient — the buffer contents themselves are not atomic, so concurrent reads/writes are a data race in C++ and have been observed to cause audio corruption and crashes under sustained load.

This adds a `std::mutex` to protect the input buffer, locked in `AddToBuffer` (audio write path) and around `CopyNewWaveformData` in `UpdateFrameAudioData` (render read path). The lock is released *before* the heavier spectrum/FFT work, so the audio thread is only blocked for the duration of a sample copy (microseconds).

## Changes
- **2 files**: `src/libprojectM/Audio/PCM.{cpp,hpp}` (+13, -5)
- Add `std::mutex m_pcmMutex` to PCM
- Lock in `AddToBuffer` and around `CopyNewWaveformData` reads
- Drop `std::atomic<size_t> m_start` (now protected by the mutex) and remove unused `<atomic>` include

## Design notes

A lock-free SPSC design was considered but rejected for this use case:
- The reader copies the **entire** ring buffer each frame (not a trailing window), so simple release/acquire publication still races on the float values themselves
- Per-sample `std::atomic<float>` would kill SIMD and roughly double memory
- A seqlock would work but is significantly more complex than the bug warrants
- The critical section here is microseconds; audio threads tolerate this fine for a visualizer (vs. pro-audio realtime contexts)

## Test plan
- [x] Clean build on Linux (GCC, RelWithDebInfo)
- [x] Runtime test on NVIDIA RTX 3090, KDE Wayland — sustained PipeWire input, no audio corruption
- [x] No regressions in beat detection / spectrum response