### PR TITLE
[v4.1.x] Fix static library linking issue and update projectm-eval to latest commit

### DIFF
--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -34,6 +34,13 @@ generate_export_header(projectM_api
         EXPORT_FILE_NAME "${PROJECTM_EXPORT_HEADER}"
         )
 
+if(NOT BUILD_SHARED_LIBS)
+    target_compile_definitions(projectM_api
+            INTERFACE
+            PROJECTM_STATIC_DEFINE
+            )
+endif()
+
 add_library(libprojectM::API ALIAS projectM_api)
 
 


### PR DESCRIPTION
Just two small fixes for the next patch release:
- Properly propagate static linking flag to export headers when building static libraries. The playlist library tried to import shared symbols (Windows/MinGW32), and thus cause linker errors.
- Updated [projectm-eval](https://github.com/projectM-visualizer/projectm-eval) submodule to the latest upstream commit.