### PR TITLE
[v4.1.x] Fix HLSLParser: Always check preprocessor directive stack

### DIFF
--- a/vendor/hlslparser/src/HLSLParser.cpp
+++ b/vendor/hlslparser/src/HLSLParser.cpp
@@ -3600,7 +3600,7 @@ bool HLSLParser::ApplyPreprocessor(const char* fileName, const char* buffer, siz
     isCodeActive.push(true);
     m_tokenizer = HLSLTokenizer(fileName, buffer, length);
     sourcePreprocessed.clear();
-    while (m_tokenizer.GetToken() != HLSLToken_EndOfStream)
+    while (m_tokenizer.GetToken() != HLSLToken_EndOfStream && !isCodeActive.empty())
     {
         bool addOriginalSource = true;
 


### PR DESCRIPTION
Was previously dereferencing the top element without checking for the stack to be empty (e.g. if there are mismatched preprocessor directives). The loop now aborts if there is at least one more closing directive (e.g. `#endif`) than opening ones.