### PR TITLE
Fix: silent exception swallowing in C API factory functions

### DIFF
--- a/src/libprojectM/Logging.cpp
+++ b/src/libprojectM/Logging.cpp
@@ -54,14 +54,19 @@ auto Logging::HasCallback() -> bool
 
 void Logging::Log(const std::string& message, LogLevel severity)
 {
+    Log(message.c_str(), severity);
+}
+
+void Logging::Log(const char* message, LogLevel severity)
+{
     auto callback = GetLoggingCallback();
 
-    if (callback.callbackFunction == nullptr)
+    if (callback.callbackFunction == nullptr || message == nullptr)
     {
         return;
     }
 
-    callback.callbackFunction(message.c_str(), static_cast<int>(severity), callback.userData);
+    callback.callbackFunction(message, static_cast<int>(severity), callback.userData);
 }
 
 auto Logging::GetLoggingCallback() -> UserCallback

--- a/src/libprojectM/Logging.hpp
+++ b/src/libprojectM/Logging.hpp
@@ -92,6 +92,15 @@ public:
     PROJECTM_CXX_EXPORT static void Log(const std::string& message, LogLevel severity);
 
     /**
+     * @brief Passes a log message with the given severity to the active thread or global callback.
+     * This overload avoids implicit string allocations.
+     * If no callbacks are registered, this function does nothing.
+     * @param message Null-terminated C string message
+     * @param severity LogLevel severity
+     */
+    PROJECTM_CXX_EXPORT static void Log(const char* message, LogLevel severity);
+
+    /**
      * The default log level used if no log level is set (LogLevel::Information)
      */
     PROJECTM_CXX_EXPORT static const LogLevel m_defaultLogLevel;

--- a/src/libprojectM/ProjectMCWrapper.cpp
+++ b/src/libprojectM/ProjectMCWrapper.cpp
@@ -12,6 +12,8 @@
 #include <projectM-4/parameters.h>
 #include <projectM-4/render_opengl.h>
 
+#include <exception>
+
 #include <cstring>
 #include <sstream>
 
@@ -76,6 +78,8 @@ projectm_handle projectm_create()
 
 projectm_handle projectm_create_with_opengl_load_proc(void* (*load_proc)(const char*, void*), void* user_data)
 {
+    using libprojectM::Logging;
+
     try
     {
         // Init resolver to discover gl function pointers (guarded internally, valid to call multiple times)
@@ -95,8 +99,15 @@ projectm_handle projectm_create_with_opengl_load_proc(void* (*load_proc)(const c
         auto* projectMInstance = new libprojectM::projectMWrapper();
         return reinterpret_cast<projectm_handle>(projectMInstance);
     }
+    catch (const std::exception& e)
+    {
+        LOG_ERROR("projectm_create_with_opengl_load_proc caught exception:");
+        LOG_ERROR(e.what());
+        return nullptr;
+    }
     catch (...)
     {
+        LOG_ERROR("projectm_create_with_opengl_load_proc caught unknown exception");
         return nullptr;
     }
 }


### PR DESCRIPTION
Currently, the C API factory functions `projectm_create_with_opengl_load_proc` and `projectm_playlist_create` wrap their instance creation logic in a blanket `catch(...)` block. If initialization fails and a standard exception is thrown (e.g. `std::bad_alloc` or any custom exception that derives from `std::exception`), the error is silently swallowed and a null pointer is returned without any log output. This makes diagnosing initialization failures extremely difficult for host applications.

### Changes
* Added a `catch(const std::exception& e)` clause to `projectm_create_with_opengl_load_proc` (in `ProjectMCWrapper.cpp`) to log the error message using `LOG_ERROR` before catching `...`.
* Added the exact same fix to `projectm_playlist_create` (in `PlaylistCWrapper.cpp`), along with the necessary `#include <Logging.hpp>`.

These minimal changes ensure that any standard exceptions thrown during library instantiation are properly recorded by the project's internal logging framework.

I was trying to implement my own frontend but it kept crushing with no useful errors, so i thought i could make this improvement for the future generations