### PR TITLE
GLResolver: fall back to app-managed EGL/GLES when a user resolver is set

### DIFF
--- a/src/libprojectM/Renderer/Platform/GLResolver.cpp
+++ b/src/libprojectM/Renderer/Platform/GLResolver.cpp
@@ -404,9 +404,20 @@ auto GLResolver::Initialize(UserResolver resolver, void* userData) -> bool
         std::string reason;
         if (!HasCurrentContext(currentContext, reason))
         {
-            m_loaded = false;
-            LOG_ERROR(std::string("[GLResolver] No current GL context present: ") + reason);
-            return false;
+            if (state.m_userResolver != nullptr)
+            {
+                currentContext.eglCurrent = true;
+                currentContext.eglAvailable = true;
+                LOG_INFO(std::string("[GLResolver] Current context could not be probed: ") +
+                         reason +
+                         "; assuming app-managed EGL/GLES context because a user resolver was supplied");
+            }
+            else
+            {
+                m_loaded = false;
+                LOG_ERROR(std::string("[GLResolver] No current GL context present: ") + reason);
+                return false;
+            }
         }
     }
 


### PR DESCRIPTION
### Problem

On platforms where the current GL context cannot be probed via the platform's native APIs, `GLResolver::Initialize()` fails hard even when the embedding application has explicitly supplied a resolver via `projectm_create_with_opengl_load_proc()`. Concrete case: ANGLE on tvOS/iOS. The app owns an EGL context backed by Metal, and there is no system EGL/GLX/WGL for the probe to query, so projectM refuses to initialise even though every GL entry point is resolvable through the app's proc loader.

### Change

When the context probe fails AND a user resolver is present, assume an app-managed EGL/GLES context and continue (logged at info level). The app has taken responsibility for providing GL entry points, so an unprobeable context is expected there rather than an error.

Behaviour without a user resolver is unchanged (hard error, as before).

### Notes for reviewers

- ~14 lines, single hunk in `GLResolver.cpp`.
- This is the change that makes libprojectM initialise under ANGLE-on-Metal (tvOS/iOS); it should equally help other embedded/sandboxed environments where the app owns the context.
- Builds clean on macOS (Release), unit tests pass. Running in production in a tvOS app (ANGLE, ES 3.0 on Metal).
