### PR TITLE
Disable vcpkg applocal for static Windows builds

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -65,8 +65,12 @@ jobs:
         run: |
           if("${{ matrix.libs }}" -eq "shared") {
             $shared_libs = "ON"
+            $applocal_deps = "ON"
           } else {
             $shared_libs = "OFF"
+            # Static triplets link everything (incl. CRT) statically, so there are no DLLs to deploy.
+            # Disabling applocal removes a proven file-lock race (MSB3073, exit 32) with zero benefit lost.
+            $applocal_deps = "OFF"
           }
           if("${{ matrix.fslib }}" -eq "boost") {
             $use_boost = "ON"
@@ -100,6 +104,7 @@ jobs:
             -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded$<$<CONFIG:Debug>:Debug>$($runtime)" `
             -DCMAKE_VERBOSE_MAKEFILE=YES `
             -DBUILD_SHARED_LIBS="$($shared_libs)" `
+            -DVCPKG_APPLOCAL_DEPS="$($applocal_deps)" `
             -DENABLE_BOOST_FILESYSTEM="$($use_boost)" `
             -DENABLE_CXX_INTERFACE=YES `
             -DBUILD_TESTING=YES `
@@ -133,9 +138,12 @@ jobs:
           }
           if("${{ matrix.libs }}" -eq "shared") {
             $runtime = "DLL"
+            $applocal_deps = "ON"
           } else {
             $runtime = ""
             $triplet = $triplet + "-static"
+            # Same as above: nothing to deploy for static builds, only file-lock risk.
+            $applocal_deps = "OFF"
           }
           if("${{ matrix.runs-on }}" -eq "windows-2022") {
             $generator = "Visual Studio 17 2022"
@@ -151,6 +159,7 @@ jobs:
             -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded$<$<CONFIG:Debug>:Debug>$($runtime)" `
             -DCMAKE_TOOLCHAIN_FILE="${Env:VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET="$($triplet)" `
+            -DVCPKG_APPLOCAL_DEPS="$($applocal_deps)" `
             -DENABLE_BOOST_FILESYSTEM="$($use_boost)" `
             -DCMAKE_VERBOSE_MAKEFILE=ON
           


### PR DESCRIPTION
Fixes the recurring Windows CI flake where the Release build fails with MSB3073 (exit code 32, sharing violation) in the vcpkg post-build step, e.g. 'vcpkg.exe z-applocal --target-binary=.../projectM-unittest.exe'.

Root cause: that post-build step exists only to deploy dependent DLLs next to executables (VCPKG_APPLOCAL_DEPS in the vcpkg toolchain). The static matrix legs use -static triplets with a static CRT and fully static linking, so there are no DLLs to deploy, the step is a no-op that still opens the freshly linked exe, exposing the build to a file-lock race (Defender scan / concurrent post-build events of the two unittest projects).

Change: pass -DVCPKG_APPLOCAL_DEPS=OFF whenever matrix.libs == static, in both configure blocks (main build and C++ interface test). Shared legs are untouched and keep DLL deployment for ctest. No build-output change: static executables are self-contained, and install/upload steps are unaffected.