### PR TITLE
Fix two issues with stb_image and HLSLParser

### DIFF
--- a/vendor/hlslparser/src/HLSLParser.cpp
+++ b/vendor/hlslparser/src/HLSLParser.cpp
@@ -3692,10 +3692,18 @@ HLSLMacro * HLSLParser::ProcessMacroFromIdentifier(std::string & sourcePreproces
             if (m_macros[i]->argument == NULL)
             {
                 // Macro without arguments
-                sourcePreprocessed.append("(");
-                sourcePreprocessed.append(m_macros[i]->value);
-                sourcePreprocessed.append(")");
-                addOriginalSource = false;
+                if (m_macros[i]->name == m_macros[i]->value)
+                {
+                    // Macro name and value are identical (#define xyz xyz)
+                    addOriginalSource = true;
+                }
+                else
+                {
+                    sourcePreprocessed.append("(");
+                    sourcePreprocessed.append(m_macros[i]->value);
+                    sourcePreprocessed.append(")");
+                    addOriginalSource = false;
+                }
             }
             else
             {

--- a/vendor/stb_image/stb_image.h
+++ b/vendor/stb_image/stb_image.h
@@ -6474,7 +6474,7 @@ static stbi_uc *stbi__pic_load_core(stbi__context *s,int width,int height,int *c
       if (packet->size != 8)  return stbi__errpuc("bad format","packet isn't 8bpp");
    } while (chained);
 
-   *comp = (act_comp & 0x10 ? 4 : 3); // has alpha channel?
+   if (comp) *comp = (act_comp & 0x10 ? 4 : 3); // has alpha channel?
 
    for(y=0; y<height; ++y) {
       int packet_idx;
@@ -7399,15 +7399,15 @@ static int stbi__hdr_info(stbi__context *s, int *x, int *y, int *comp)
        return 0;
    }
    token += 3;
-   *y = (int) strtol(token, &token, 10);
+   if (y) *y = (int) strtol(token, &token, 10);
    while (*token == ' ') ++token;
    if (strncmp(token, "+X ", 3)) {
        stbi__rewind( s );
        return 0;
    }
    token += 3;
-   *x = (int) strtol(token, NULL, 10);
-   *comp = 3;
+   if (x) *x = (int) strtol(token, NULL, 10);
+   if (comp) *comp = 3;
    return 1;
 }
 #endif // STBI_NO_HDR
@@ -7457,8 +7457,8 @@ static int stbi__psd_info(stbi__context *s, int *x, int *y, int *comp)
        stbi__rewind( s );
        return 0;
    }
-   *y = stbi__get32be(s);
-   *x = stbi__get32be(s);
+   if (y) *y = stbi__get32be(s);
+   if (x) *x = stbi__get32be(s);
    depth = stbi__get16be(s);
    if (depth != 8 && depth != 16) {
        stbi__rewind( s );
@@ -7468,7 +7468,7 @@ static int stbi__psd_info(stbi__context *s, int *x, int *y, int *comp)
        stbi__rewind( s );
        return 0;
    }
-   *comp = 4;
+   if (comp) *comp = 4;
    return 1;
 }
 

--- a/vendor/stb_image/stbi_DDS_c.h
+++ b/vendor/stb_image/stbi_DDS_c.h
@@ -240,59 +240,62 @@ void stbi_decode_DXT_color_block(
 	//	done
 }
 
-static int stbi__dds_info( stbi__context *s, int *x, int *y, int *comp, int *iscompressed ) {
-	int is_compressed,has_alpha;
-	unsigned int flags;
-	DDS_header header={0};
+static int stbi__dds_info( stbi__context *s, int *x, int *y, int *comp, int *iscompressed )
+{
+    int is_compressed,has_alpha;
+    unsigned int flags;
+    DDS_header header={0};
 
-	if( sizeof( DDS_header ) != 128 )
-	{
-		return 0;
-	}
+    if( sizeof( DDS_header ) != 128 )
+    {
+        return 0;
+    }
 
-	stbi__getn( s, (stbi_uc*)(&header), 128 );
+    stbi__getn( s, (stbi_uc*)(&header), 128 );
 
-	if( header.dwMagic != (('D' << 0) | ('D' << 8) | ('S' << 16) | (' ' << 24)) ) {
-	   stbi__rewind( s );
-	   return 0;
-	}
-	if( header.dwSize != 124 ) {
-	   stbi__rewind( s );
-	   return 0;
-	}
-	flags = DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH | DDSD_PIXELFORMAT;
-	if( (header.dwFlags & flags) != flags ) {
-	   stbi__rewind( s );
-	   return 0;
-	}
-	if( header.sPixelFormat.dwSize != 32 ) {
-	   stbi__rewind( s );
-	   return 0;
-	}
-	flags = DDPF_FOURCC | DDPF_RGB;
-	if( (header.sPixelFormat.dwFlags & flags) == 0 ) {
-	   stbi__rewind( s );
-	   return 0;
-	}
-	if( (header.sCaps.dwCaps1 & DDSCAPS_TEXTURE) == 0 ) {
-	   stbi__rewind( s );
-	   return 0;
-	}
+    if( header.dwMagic != (('D' << 0) | ('D' << 8) | ('S' << 16) | (' ' << 24)) ) {
+        stbi__rewind( s );
+        return 0;
+    }
+    if( header.dwSize != 124 ) {
+        stbi__rewind( s );
+        return 0;
+    }
+    flags = DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH | DDSD_PIXELFORMAT;
+    if( (header.dwFlags & flags) != flags ) {
+        stbi__rewind( s );
+        return 0;
+    }
+    if( header.sPixelFormat.dwSize != 32 ) {
+        stbi__rewind( s );
+        return 0;
+    }
+    flags = DDPF_FOURCC | DDPF_RGB;
+    if( (header.sPixelFormat.dwFlags & flags) == 0 ) {
+        stbi__rewind( s );
+        return 0;
+    }
+    if( (header.sCaps.dwCaps1 & DDSCAPS_TEXTURE) == 0 ) {
+        stbi__rewind( s );
+        return 0;
+    }
 
-	is_compressed = (header.sPixelFormat.dwFlags & DDPF_FOURCC) / DDPF_FOURCC;
-	has_alpha = (header.sPixelFormat.dwFlags & DDPF_ALPHAPIXELS) / DDPF_ALPHAPIXELS;
+    is_compressed = (header.sPixelFormat.dwFlags & DDPF_FOURCC) / DDPF_FOURCC;
+    has_alpha = (header.sPixelFormat.dwFlags & DDPF_ALPHAPIXELS) / DDPF_ALPHAPIXELS;
 
-	*x = header.dwWidth;
-	*y = header.dwHeight;
+    if (x) *x = header.dwWidth;
+    if (y) *y = header.dwHeight;
 
-	if ( !is_compressed ) {
-		*comp = 3;
+    if (comp) {
+        if ( !is_compressed ) {
+            *comp = 3;
 
-		if ( has_alpha )
-			*comp = 4;
-	}
-	else
-		*comp = 4;
+            if ( has_alpha )
+                *comp = 4;
+        }
+        else
+            *comp = 4;
+    }
 
 	if ( iscompressed )
 		*iscompressed = is_compressed;
@@ -349,6 +352,12 @@ static void * stbi__dds_load(stbi__context *s, int *x, int *y, int *comp, int re
 	int block_pitch, num_blocks;
 	DDS_header header={0};
 	int i, sz, cf;
+    int dummy;
+
+    if (!x) x = &dummy;
+    if (!y) y = &dummy;
+    if (!comp) comp = &dummy;
+
 	//	load the header
 	if( sizeof( DDS_header ) != 128 )
 	{

--- a/vendor/stb_image/stbi_pkm_c.h
+++ b/vendor/stb_image/stbi_pkm_c.h
@@ -90,9 +90,9 @@ static int stbi__pkm_info(stbi__context *s, int *x, int *y, int *comp )
 	width = (header.iWidthMSB << 8) | header.iWidthLSB;
 	height = (header.iHeightMSB << 8) | header.iHeightLSB;
 
-	*x = s->img_x = width;
-	*y = s->img_y = height;
-	*comp = s->img_n = 3;
+	if (x) *x = s->img_x = width;
+	if (y) *y = s->img_y = height;
+	if (comp) *comp = s->img_n = 3;
 
 	stbi__rewind(s);
 
@@ -154,9 +154,9 @@ static void * stbi__pkm_load(stbi__context *s, int *x, int *y, int *comp, int re
 	width = (header.iWidthMSB << 8) | header.iWidthLSB;
 	height = (header.iHeightMSB << 8) | header.iHeightLSB;
 
-	*x = s->img_x = width;
-	*y = s->img_y = height;
-	*comp = s->img_n = 4;
+	if (x) *x = s->img_x = width;
+	if (y) *y = s->img_y = height;
+	if (comp) *comp = s->img_n = 4;
 
 	compressed_size = (((width + 3) & ~3) * ((height + 3) & ~3)) >> 1;
 
@@ -174,7 +174,7 @@ static void * stbi__pkm_load(stbi__context *s, int *x, int *y, int *comp, int re
 			//	user has some requirements, meet them
 			if( req_comp != s->img_n ) {
 				pkm_res_data = stbi__convert_format( pkm_res_data, s->img_n, req_comp, s->img_x, s->img_y );
-				*comp = req_comp;
+				if (comp) *comp = req_comp;
 			}
 		}
 

--- a/vendor/stb_image/stbi_pvr_c.h
+++ b/vendor/stb_image/stbi_pvr_c.h
@@ -77,10 +77,9 @@ static int stbi__pvr_info(stbi__context *s, int *x, int *y, int *comp, int * isc
 		stbi__rewind(s);
 		return 0;
 	}
-
-	*x = s->img_x = header.dwWidth;
-	*y = s->img_y = header.dwHeight;
-	*comp = s->img_n = ( header.dwBitCount + 7 ) / 8;
+    if (x) *x = s->img_x = header.dwWidth;
+	if (y) *y = s->img_y = header.dwHeight;
+	if (comp) *comp = s->img_n = ( header.dwBitCount + 7 ) / 8;
 
 	if ( iscompressed )
 		*iscompressed = 0;
@@ -124,7 +123,7 @@ static int stbi__pvr_info(stbi__context *s, int *x, int *y, int *comp, int * isc
 			return 0;
 	}
 
-	*comp = s->img_n;
+	if (comp) *comp = s->img_n;
 
 	return 1;
 }
@@ -896,8 +895,8 @@ static void * stbi__pvr_load(stbi__context *s, int *x, int *y, int *comp, int re
 		return NULL;
 	}
 
-	*x = s->img_x = header.dwWidth;
-	*y = s->img_y = header.dwHeight;
+	if (x) *x = s->img_x = header.dwWidth;
+	if (y) *y = s->img_y = header.dwHeight;
 
 	/* Get if the texture is compressed and the texture mode ( 2bpp or 4bpp ) */
 	switch ( header.dwpfFlags & PVRTEX_PIXELTYPE )
@@ -937,7 +936,7 @@ static void * stbi__pvr_load(stbi__context *s, int *x, int *y, int *comp, int re
 			return NULL;
 	}
 
-	*comp = s->img_n;
+	if (comp) *comp = s->img_n;
 
 	// Load only the first mip map level
 	levelSize = (s->img_x * s->img_y * header.dwBitCount + 7) / 8;
@@ -960,7 +959,7 @@ static void * stbi__pvr_load(stbi__context *s, int *x, int *y, int *comp, int re
 		//	user has some requirements, meet them
 		if( req_comp != s->img_n ) {
 			pvr_res_data = stbi__convert_format( pvr_res_data, s->img_n, req_comp, s->img_x, s->img_y );
-			*comp = req_comp;
+			if (comp) *comp = req_comp;
 		}
 	}
 


### PR DESCRIPTION
While testing, I ran into two issues, one crashing and another freezing projectM. Investigation resulted in this:

### stb_image: Crash due to unchecked pointers
Some image decoders in stb_image - including the DDS loader - didn't check user-provide return variable pointers to be NULL before assignikng values. According to the API docs, these pointers can be NULL if the user isn't interested in the value.

I've added guards around the problematic assignments I've found.

### HLSLParser: Infinite macro replacement loop
Loading some presets, e.g. `martin + Se7enSlasher - pixies party (random texture edit).milk`, resulted in a freeze of the application with quickly increasing memory usage. The reason was a macro in the HLSL code, which just pointed to itself: `#define sampler_rand00 sampler_rand00`. HLSLParser wrapped the value in parentheses and then ran the same code again, adding one set of parentheses per loop execution, indefinitely.

The fix now checks if the macro is simply a copy of itself, and keeps the original code in this case, without the need for another loop. Macros with arguments may still run into an infinite loop, but are harder to create and I haven't found any preset doing such a thing, as it would probably also fail in the original HLSL compiler.